### PR TITLE
Downgrade external-secrets helm chart version to 0.14.2

### DIFF
--- a/k8s/infra/controllers/bitwarden/kustomization.yaml
+++ b/k8s/infra/controllers/bitwarden/kustomization.yaml
@@ -19,4 +19,4 @@ helmCharts:
     releaseName: external-secrets
     repo: https://charts.external-secrets.io
     valuesFile: external-secrets-values.yaml
-    version: 0.21.0 # renovate: registryUrl=https://charts.external-secrets.io
+    version: 0.14.2 # renovate: registryUrl=https://charts.external-secrets.io


### PR DESCRIPTION
Change the helm chart version for external-secrets to ensure compatibility with existing configurations.