### PR TITLE
fix(k8s): correct allowEmpty syntax in ApplicationSet configurations

### DIFF
--- a/k8s/apps/application-set.yaml
+++ b/k8s/apps/application-set.yaml
@@ -57,7 +57,7 @@ spec:
         automated:
           selfHeal: true
           prune: true
-          allowEmpty: '{{allowEmpty}}'
+          allowEmpty: {{allowEmpty}}
         syncOptions:
           - CreateNamespace=true
           - PruneLast=true

--- a/k8s/apps/application-set.yaml
+++ b/k8s/apps/application-set.yaml
@@ -57,7 +57,7 @@ spec:
         automated:
           selfHeal: true
           prune: true
-          allowEmpty: {{allowEmpty}}
+          allowEmpty: true
         syncOptions:
           - CreateNamespace=true
           - PruneLast=true

--- a/k8s/sets/infrastructure.yaml
+++ b/k8s/sets/infrastructure.yaml
@@ -37,7 +37,7 @@ spec:
         automated:
           prune: true
           selfHeal: true
-          allowEmpty: '{{allowEmpty}}'
+          allowEmpty: false
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true


### PR DESCRIPTION
Correct the syntax for the `allowEmpty` field in the ApplicationSet and infrastructure configurations to ensure proper functionality. This change sets `allowEmpty` to a boolean value instead of a template string.