### PR TITLE
feat(k8s): update AdGuardHome configuration and add new HTTP routes

### DIFF
--- a/k8s/infra/base/network/dns/adguard/config/AdGuardHome.yaml
+++ b/k8s/infra/base/network/dns/adguard/config/AdGuardHome.yaml
@@ -146,45 +146,25 @@ filtering:
     - domain: api.kube.pc-tips.se
       answer: 10.25.150.10 # API Server VIP
     - domain: '*.kube.pc-tips.se'
-      answer: 10.25.150.100 # Main ingress controller IP
+      answer: 10.25.150.220 # Internal gateway IP
     - domain: kube.pc-tips.se
-      answer: 10.25.150.100 # Main ingress controller IP
+      answer: 10.25.150.220 # Internal gateway IP
 
-    # Core Platform Services
-    - domain: argocd.kube.pc-tips.se
-      answer: 10.25.150.220 # ArgoCD dedicated IP
-    - domain: traefik.kube.pc-tips.se
-      answer: 10.25.150.100
-    - domain: cert-manager.kube.pc-tips.se
-      answer: 10.25.150.100
-    - domain: metallb.kube.pc-tips.se
-      answer: 10.25.150.100
-
-    # Monitoring Stack
-    - domain: grafana.kube.pc-tips.se
-      answer: 10.25.150.100
-    - domain: prometheus.kube.pc-tips.se
-      answer: 10.25.150.100
-    - domain: alertmanager.kube.pc-tips.se
-      answer: 10.25.150.100
-
-    # Authentication
-    - domain: authelia.kube.pc-tips.se
-      answer: 10.25.150.100
-
-    # Storage Management
-    - domain: longhorn.kube.pc-tips.se
-      answer: 10.25.150.100
-
-    # External Services
-    - domain: coturn.kube.pc-tips.se
-      answer: 10.25.150.226 # Dedicated TURN server IP
-
-    # Infrastructure Management
+    # TLS Passthrough Services (External)
     - domain: proxmox.pc-tips.se
-      answer: 10.25.150.221
+      answer: 10.25.150.221 # TLS passthrough gateway IP
     - domain: truenas.pc-tips.se
-      answer: 10.25.150.221
+      answer: 10.25.150.221 # TLS passthrough gateway IP
+
+    # External Domain Services
+    - domain: '*.external.pc-tips.se'
+      answer: 10.25.150.222 # External gateway IP
+    - domain: external.pc-tips.se
+      answer: 10.25.150.222 # External gateway IP
+
+    # Special Load Balanced Services
+    - domain: hubble-ui.kube.pc-tips.se
+      answer: 10.25.150.224 # Dedicated Hubble UI IP
 
   safebrowsing_cache_size: 1048576
   safesearch_cache_size: 1048576

--- a/k8s/infra/base/network/gateway/cert-internal.yaml
+++ b/k8s/infra/base/network/gateway/cert-internal.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: gateway
 spec:
   dnsNames:
-    - '*.kube.pc-tips.se'
-    - 'kube.pc-tips.se'
+    - "*.kube.pc-tips.se"
+    - "kube.pc-tips.se"
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/k8s/infra/base/network/gateway/cert-internal.yaml
+++ b/k8s/infra/base/network/gateway/cert-internal.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-internal
+  namespace: gateway
+spec:
+  dnsNames:
+    - '*.kube.pc-tips.se'
+    - 'kube.pc-tips.se'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: cloudflare-issuer
+  secretName: cert-internal
+  usages:
+    - digital signature
+    - key encipherment

--- a/k8s/infra/base/network/gateway/gw-internal.yaml
+++ b/k8s/infra/base/network/gateway/gw-internal.yaml
@@ -12,22 +12,22 @@ spec:
     - protocol: HTTPS
       port: 443
       name: https-gateway
-      hostname: "*.pc-tips.se"
+      hostname: "*.kube.pc-tips.se"
       tls:
         certificateRefs:
           - kind: Secret
-            name: cert-stonegarden
+            name: cert-internal
       allowedRoutes:
         namespaces:
           from: All
     - protocol: HTTPS
       port: 443
       name: https-domain-gateway
-      hostname: pc-tips.se
+      hostname: kube.pc-tips.se
       tls:
         certificateRefs:
           - kind: Secret
-            name: cert-stonegarden
+            name: cert-internal
       allowedRoutes:
         namespaces:
           from: All

--- a/k8s/infra/base/network/gateway/kustomization.yaml
+++ b/k8s/infra/base/network/gateway/kustomization.yaml
@@ -2,9 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-stonegarden.yaml
-- gateway-class.yaml
-- ns.yaml
-- gw-external.yaml
-- gw-internal.yaml
-- gw-tls-passthrough.yaml
+  # Gateways
+  - gw-internal.yaml
+  - gw-external.yaml
+  - gw-tls-passthrough.yaml
+
+  # Certificates
+  - cert-internal.yaml
+  - cert-stonegarden.yaml
+
+  # Internal Routes
+  - route-argocd.yaml
+  - route-authelia.yaml
+  - route-grafana.yaml
+  - route-prometheus.yaml
+  - route-jellyfin.yaml
+  - route-arr.yaml
+  - route-home-assistant.yaml

--- a/k8s/infra/base/network/gateway/route-arr.yaml
+++ b/k8s/infra/base/network/gateway/route-arr.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lidarr
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'lidarr.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: lidarr
+          port: 8686
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'prowlarr.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: prowlarr
+          port: 9696
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'radarr.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: radarr
+          port: 7878
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'sonarr.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: sonarr
+          port: 8989

--- a/k8s/infra/base/network/gateway/route-home-assistant.yaml
+++ b/k8s/infra/base/network/gateway/route-home-assistant.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: home-assistant
+  namespace: home
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'haos.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: home-assistant
+          port: 8123

--- a/k8s/infra/base/network/gateway/route-jellyfin.yaml
+++ b/k8s/infra/base/network/gateway/route-jellyfin.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - 'jellyfin.kube.pc-tips.se'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jellyfin
+          port: 8096


### PR DESCRIPTION
Update AdGuardHome configuration with new internal gateway IPs and introduce certificate management. Add HTTP routes for Lidarr, Prowlarr, Radarr, Sonarr, Jellyfin, and Home Assistant to enhance service accessibility.