### PR TITLE
feat(k8s): add sm-operator network policy and update RBAC rules

### DIFF
--- a/docs/troubleshooting/2025-02-26-cilium-networking-issues.md
+++ b/docs/troubleshooting/2025-02-26-cilium-networking-issues.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-In Progress
+Solved
 
 ## Impact
 

--- a/docs/troubleshooting/2025-02-26-dns-domain-misconfiguration.md
+++ b/docs/troubleshooting/2025-02-26-dns-domain-misconfiguration.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-In Progress
+Solved
 
 ## Impact
 

--- a/docs/troubleshooting/2025-02-26-kubelet-startup-issues.md
+++ b/docs/troubleshooting/2025-02-26-kubelet-startup-issues.md
@@ -12,7 +12,7 @@
 
 ## Status
 
-In Progress
+Solved
 
 ## Impact
 

--- a/docs/troubleshooting/2025-03-03-sm-operator-bitwarden-api-connectivity.md
+++ b/docs/troubleshooting/2025-03-03-sm-operator-bitwarden-api-connectivity.md
@@ -1,0 +1,84 @@
+# SM Operator Bitwarden API Connectivity
+
+## Date
+
+2025-03-03
+
+## Category
+
+- Authentication
+- Networking
+- Configuration
+
+## Status
+
+In Progress
+
+## Impact
+
+- Unable to sync secrets from Bitwarden
+- Authentication failures to Bitwarden API
+- Applications depending on Bitwarden secrets potentially affected
+- BitwardenSecret resources not reconciling
+
+## Root Cause
+
+1. Circular dependency in auth token configuration:
+
+   - BitwardenSecret CRD attempting to use itself for bootstrapping
+   - Auth token secret being managed by the operator that needs it
+   - Configuration trying to pull auth token using the auth token itself
+
+2. Network connectivity issues:
+   - Unable to reach Bitwarden API endpoints (api.bitwarden.eu)
+   - TLS handshake failures with identity service
+   - DNS resolution problems for Bitwarden domains
+
+## Detection
+
+Error logs from sm-operator showed:
+
+```
+Error pulling Secret Manager secrets from API => API: https://api.bitwarden.eu -- Identity: https://identity.bitwarden.eu
+API error: error sending request for url (https://identity.bitwarden.eu/connect/token)
+```
+
+## Resolution
+
+In Progress:
+
+1. Current approach:
+
+   - Removed circular dependency in auth token configuration
+   - Configured direct CIDR access to Bitwarden API endpoints
+   - Updated network policies to allow external connectivity
+
+2. Remaining issues:
+   - Need to verify proper auth token bootstrapping process
+   - Validate TLS configuration for API endpoints
+   - Ensure proper secret management hierarchy
+
+## Prevention
+
+1. Configuration Management:
+
+   - Create validation checks for circular dependencies
+   - Implement secret hierarchy guidelines
+
+2. Network Access:
+   - Maintain documentation of required API endpoints
+   - Regular connectivity testing
+   - Monitoring of API access patterns
+
+## Related Issues
+
+- Leader election timeout
+- Cilium policy validation
+- Network policy enforcement
+
+## Notes
+
+- Bootstrap process needs careful consideration
+- Avoid circular dependencies in operator configurations
+- Consider implementing API connectivity monitoring
+- Document proper secret management hierarchy

--- a/docs/troubleshooting/2025-03-03-sm-operator-cilium-policy-validation.md
+++ b/docs/troubleshooting/2025-03-03-sm-operator-cilium-policy-validation.md
@@ -1,0 +1,89 @@
+# SM Operator Cilium Policy Validation
+
+## Date
+
+2025-03-03
+
+## Category
+
+- Networking
+- Security
+- Configuration
+
+## Status
+
+Resolved
+
+## Impact
+
+- Network policies not enforcing correctly
+- External connectivity issues for sm-operator
+- Unable to reach Bitwarden API endpoints
+- Potential security implications due to invalid policy state
+
+## Root Cause
+
+1. Cilium network policy was marked as invalid due to:
+
+   - FQDN regex compilation LRU not initialized
+   - Wildcarded FQDN patterns not properly supported
+   - DNS-based policy rules not properly configured
+
+2. Policy validation failures preventing proper enforcement of:
+   - External API access
+   - DNS resolution
+   - TLS connections
+
+## Detection
+
+- Cilium policy status showed VALID: False
+- Error message: "FQDN regex compilation LRU not yet initialized"
+- Network connectivity failures to external endpoints
+
+## Resolution
+
+1. Restructured network policy to use explicit CIDR rules instead of FQDN patterns:
+
+   - Added specific IP ranges for Bitwarden API endpoints (199.232.193.91/32, 199.232.197.91/32)
+   - Configured explicit DNS resolution rules
+   - Defined port-specific access rules
+
+2. Updated policy configuration:
+
+```yaml
+spec:
+  egress:
+    - toCIDRSet:
+        - cidr: '199.232.193.91/32'
+        - cidr: '199.232.197.91/32'
+      toPorts:
+        - ports:
+            - port: '443'
+              protocol: TCP
+```
+
+## Prevention
+
+1. Policy Validation:
+
+   - Implement policy validation in CI/CD pipeline
+   - Create policy templates for common use cases
+   - Document policy requirements for external services
+
+2. DNS Configuration:
+   - Document DNS resolution requirements
+   - Maintain list of required external endpoints
+   - Regular policy audits
+
+## Related Issues
+
+- Leader election timeout
+- External API connectivity
+- DNS resolution problems
+
+## Notes
+
+- FQDN-based policies require careful configuration
+- Consider maintaining IP allowlist for critical external services
+- Regular validation of network policies is essential
+- Document external service dependencies

--- a/docs/troubleshooting/2025-03-03-sm-operator-leader-election-timeout.md
+++ b/docs/troubleshooting/2025-03-03-sm-operator-leader-election-timeout.md
@@ -1,0 +1,94 @@
+# SM Operator Leader Election Timeout
+
+## Date
+
+2025-03-03
+
+## Category
+
+- Configuration
+- Kubernetes
+- Networking
+
+## Status
+
+Resolved
+
+## Impact
+
+- SM Operator unable to establish leader election
+- Secrets synchronization failing
+- Service disruption for applications depending on Bitwarden secrets
+
+## Root Cause
+
+The sm-operator pod was unable to reach the Kubernetes API server (10.96.0.1:443) due to:
+
+1. Missing Cilium network policy for API server access
+2. Network connectivity issues between the pod and API server
+3. Leader election lease unable to be acquired due to network policy restrictions
+
+## Detection
+
+Error logs from sm-operator showed:
+
+```
+error retrieving resource lock sm-operator-system/479cde60.bitwarden.com: Get "https://10.96.0.1:443/apis/coordination.k8s.io/v1/namespaces/sm-operator-system/leases/479cde60.bitwarden.com": dial tcp 10.96.0.1:443: i/o timeout
+```
+
+## Resolution
+
+1. Created a Cilium Network Policy to allow:
+   - Access to kube-apiserver
+   - DNS resolution via kube-dns
+   - Required ports and protocols
+
+Network policy configuration:
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-sm-operator-api-access
+  namespace: sm-operator-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sm-operator
+      app.kubernetes.io/instance: sm-operator
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: '53'
+              protocol: UDP
+```
+
+## Prevention
+
+1. Network Configuration:
+
+   - Document required network policies for new operators
+   - Implement policy templates for common patterns
+   - Add network policy validation in CI/CD
+
+2. Monitoring:
+   - Add alerts for leader election failures
+   - Monitor API server connectivity
+   - Track network policy enforcement
+
+## Related Issues
+
+- Cilium Network Policy Enforcement
+- API Server Connectivity
+- DNS Resolution
+
+## Notes
+
+- Leader election is critical for operator functionality
+- Network policies should be defined before deploying operators
+- Consider implementing network policy templates

--- a/k8s/infrastructure/base/controllers/sm-operator/base/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/sm-operator/base/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - metrics-service.yaml
   - proxy-rbac.yaml
   - serviceaccount.yaml
+  - sm-operator-policy.yaml

--- a/k8s/infrastructure/base/controllers/sm-operator/base/leader-election-rbac.yaml
+++ b/k8s/infrastructure/base/controllers/sm-operator/base/leader-election-rbac.yaml
@@ -9,43 +9,44 @@ metadata:
     helm.sh/chart: sm-operator-0.1.0-Beta
     app.kubernetes.io/name: sm-operator
     app.kubernetes.io/instance: sm-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: '0.1.0'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/created-by: sm-operator
     app.kubernetes.io/part-of: sm-operator
   namespace: sm-operator-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 # Source: sm-operator/templates/leader-election-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,7 +58,7 @@ metadata:
     helm.sh/chart: sm-operator-0.1.0-Beta
     app.kubernetes.io/name: sm-operator
     app.kubernetes.io/instance: sm-operator
-    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/version: '0.1.0'
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/created-by: sm-operator
     app.kubernetes.io/part-of: sm-operator
@@ -65,8 +66,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: 'sm-operator-leader-election-role'
+  name: sm-operator-leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: 'sm-operator-controller-manager'
-  namespace: sm-operator-system
+  - kind: ServiceAccount
+    name: sm-operator-controller-manager
+    namespace: sm-operator-system

--- a/k8s/infrastructure/base/controllers/sm-operator/base/sm-operator-policy.yaml
+++ b/k8s/infrastructure/base/controllers/sm-operator/base/sm-operator-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-sm-operator-api-access
+  namespace: sm-operator-system
+spec:
+  description: 'Allow sm-operator to access the Kubernetes API server and Bitwarden APIs'
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sm-operator
+      app.kubernetes.io/instance: sm-operator
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: '53'
+              protocol: UDP
+    - toCIDRSet:
+        - cidr: '199.232.193.91/32'
+        - cidr: '199.232.197.91/32'
+      toPorts:
+        - ports:
+            - port: '443'
+              protocol: TCP

--- a/k8s/infrastructure/base/controllers/sm-operator/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/sm-operator/kustomization.yaml
@@ -4,7 +4,6 @@ namespace: sm-operator-system
 
 resources:
   - base
-  - auth-token.yaml
   - bitwarden-secret.yaml
   - infrastructure-secrets.yaml
   - operator-secret.yaml


### PR DESCRIPTION
- Introduced CiliumNetworkPolicy for sm-operator to manage API access
- Updated RBAC rules to include secrets and refined resource definitions
- Removed unused auth-token.yaml from kustomization