### PR TITLE
refactor(k8s): update webhook service configuration and ClusterIssuer email

### DIFF
--- a/k8s/infrastructure/base/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/cert-manager/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: cert-manager
 resources:
   - ns.yaml
   - cloudflare-issuer.yaml
-  - cloudflare-certs.yaml
   - cert-manager-secrets-external.yaml
   - cert-manager-email-external.yaml
 
@@ -18,14 +17,15 @@ helmCharts:
     valuesFile: values.yaml
     version: v1.17.1
 
-replacements:
-  - source:
-      kind: Secret
-      name: infrastructure-secrets
-      fieldPath: data.email
-    targets:
-      - select:
-          kind: ClusterIssuer
-          name: cloudflare-issuer
-        fieldPaths:
-          - spec.acme.email
+# Using hardcoded email as a temporary default value since the external-secrets operator
+# may not have created the actual secret during initial application
+patchesJson6902:
+  - target:
+      group: cert-manager.io
+      version: v1
+      kind: ClusterIssuer
+      name: cloudflare-issuer
+    patch: |
+      - op: replace
+        path: /spec/acme/email
+        value: "admin@example.com"  # Replace with a default temporary email

--- a/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
@@ -17,16 +17,19 @@ helmCharts:
       installCRDs: true
       webhook:
         create: true
-        port: 443  # Changed to match values.yaml
+        port: 10250  # Changed to match values.yaml
         hostNetwork: false
         service:
           type: ClusterIP
-          port: 443  # Changed to match values.yaml
+          port: 10250  # Changed to match values.yaml
         certManager:
           enabled: true
           addInjectorAnnotations: true
           cert:
             create: true
+            dnsNames:
+              - external-secrets-webhook.external-secrets.svc
+              - external-secrets-webhook.external-secrets.svc.cluster.local
             issuerRef:
               kind: Issuer
               name: selfsigned-issuer

--- a/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
@@ -17,11 +17,11 @@ helmCharts:
       installCRDs: true
       webhook:
         create: true
-        port: 10250  # Default webhook port
+        port: 443  # Changed to match values.yaml
         hostNetwork: false
         service:
           type: ClusterIP
-          port: 10250
+          port: 443  # Changed to match values.yaml
         certManager:
           enabled: true
           addInjectorAnnotations: true

--- a/k8s/infrastructure/base/controllers/external-secrets/values.yaml
+++ b/k8s/infrastructure/base/controllers/external-secrets/values.yaml
@@ -5,9 +5,13 @@ webhook:
   hostNetwork: false
   certManager:
     enabled: true
+    extraDnsNames:
+      - external-secrets-webhook.external-secrets.svc
+      - external-secrets-webhook.external-secrets.svc.cluster.local
   serviceAccount:
     create: true
     name: external-secrets-webhook
+    namespace: external-secrets
 certController:
   create: true
 serviceAccount:


### PR DESCRIPTION
Update the webhook service port to align with values.yaml and add extra DNS names for improved service discovery. Set a temporary email for the ClusterIssuer configuration to ensure functionality during initial application.