### PR TITLE
refactor(k8s): update secret store references to use ClusterSecretStore

### DIFF
--- a/k8s/argocd/kustomization.yaml
+++ b/k8s/argocd/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - http-route.yaml
   - redis-secret-external.yaml
   - bitwarden-access-token.yaml
-  - bitwarden-sdk-ca-copy-job.yaml
   - bitwarden-store.yaml
   - applicationsets/applications.yaml
   - projects/preview-project.yaml

--- a/k8s/argocd/redis-secret-external.yaml
+++ b/k8s/argocd/redis-secret-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: argocd-redis
     creationPolicy: Owner

--- a/k8s/infrastructure/base/auth/authelia/authelia-secrets-external.yaml
+++ b/k8s/infrastructure/base/auth/authelia/authelia-secrets-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: authelia-secrets
     creationPolicy: Owner

--- a/k8s/infrastructure/base/controllers/cert-manager/cert-manager-email-external.yaml
+++ b/k8s/infrastructure/base/controllers/cert-manager/cert-manager-email-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: cert-manager-email
     creationPolicy: Owner

--- a/k8s/infrastructure/base/controllers/cert-manager/cert-manager-secrets-external.yaml
+++ b/k8s/infrastructure/base/controllers/cert-manager/cert-manager-secrets-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: infrastructure-secrets
     creationPolicy: Owner

--- a/k8s/infrastructure/base/controllers/external-secrets/bitwarden-access-token.yaml
+++ b/k8s/infrastructure/base/controllers/external-secrets/bitwarden-access-token.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitwarden-access-token
+  namespace: external-secrets  # This should match the ClusterSecretStore's namespace
+type: Opaque
+stringData:
+  token: "your-bitwarden-machine-account-token"

--- a/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
+++ b/k8s/infrastructure/base/controllers/external-secrets/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - bitwarden-store.yaml
 - bitwarden-cert.yaml
 - internal-issuer.yaml
+- ClusterSecretStore.yaml
 
 helmCharts:
   - name: external-secrets

--- a/k8s/infrastructure/base/kubechecks/kubechecks-secret-external.yaml
+++ b/k8s/infrastructure/base/kubechecks/kubechecks-secret-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: kubechecks-token
     creationPolicy: Owner

--- a/k8s/infrastructure/base/network/dns/adguard/secret-external.yaml
+++ b/k8s/infrastructure/base/network/dns/adguard/secret-external.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: bitwarden-backend
-    kind: SecretStore
+    name: bitwarden-backend  # Uses the ClusterSecretStore
+    kind: ClusterSecretStore
   target:
     name: adguard-users
     creationPolicy: Owner


### PR DESCRIPTION
Change references from SecretStore to ClusterSecretStore across multiple files to improve consistency and management of secrets. Removed unused configuration and added a new resource for Bitwarden token management.