### PR TITLE
refactor(k8s): update application set destination and ignore differences

### DIFF
--- a/k8s/applications/application-set.yaml
+++ b/k8s/applications/application-set.yaml
@@ -33,7 +33,7 @@ spec:
         targetRevision: main
         path: k8s/applications/overlays/{{environment}}
       destination:
-        name: in-cluster
+        name: in-cluster  # If multi-cluster, change this to 'server: {{server}}'
         namespace: '{{namespace}}'
       syncPolicy:
         automated:
@@ -43,3 +43,8 @@ spec:
           - CreateNamespace=true
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
+      ignoreDifferences:
+        - group: argoproj.io
+          kind: Rollout
+          jsonPointers:
+            - /status

--- a/k8s/infrastructure/applicationsets/application-set.yaml
+++ b/k8s/infrastructure/applicationsets/application-set.yaml
@@ -35,7 +35,7 @@ spec:
         targetRevision: main
         path: k8s/infrastructure/overlays/{{environment}}
       destination:
-        name: in-cluster
+        name: in-cluster  # Ensure this is correct, change to 'server: <cluster-api>' if multi-cluster
         namespace: '{{namespace}}'
       syncPolicy:
         automated:
@@ -55,11 +55,11 @@ spec:
             factor: 2
             maxDuration: '10m'
       ignoreDifferences:
-        - group: ''
+        - group: v1
           kind: Secret
           jsonPointers:
             - /data
-        - group: ''
+        - group: v1
           kind: ConfigMap
           jsonPointers:
             - /data


### PR DESCRIPTION
- Clarified destination name for multi-cluster setups
- Added ignore differences for Rollout status in application sets