### PR TITLE
refactor(k8s): add namespaces for dev, staging, and prod environments

### DIFF
--- a/k8s/applications/project.yaml
+++ b/k8s/applications/project.yaml
@@ -11,6 +11,12 @@ spec:
       server: '*'
     - namespace: '*-apps'
       server: https://kubernetes.default.svc
+    - namespace: 'dev'
+      server: https://kubernetes.default.svc
+    - namespace: 'staging'
+      server: https://kubernetes.default.svc
+    - namespace: 'prod'
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/k8s/infrastructure/project.yaml
+++ b/k8s/infrastructure/project.yaml
@@ -21,6 +21,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: kube-system
       server: https://kubernetes.default.svc
+    - namespace: longhorn-system
+      server: https://kubernetes.default.svc
 
   clusterResourceWhitelist:
     - group: '*'


### PR DESCRIPTION
Introduce namespaces for development, staging, and production environments to enhance organization and management within the Kubernetes setup. This change allows for better resource segregation and environment-specific configurations.