### PR TITLE
feat(k8s): implement ArgoCD network policy and update configurations

### DIFF
--- a/k8s/infrastructure/controllers/argocd/network-policy.yaml
+++ b/k8s/infrastructure/controllers/argocd/network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-argocd-apiserver
+  namespace: argocd
+spec:
+  description: "Allow ArgoCD components to communicate with Kubernetes API server and DNS"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: argocd
+  egress:
+    # Allow all egress traffic
+    - {}
+  ingress:
+    # Allow all ingress traffic
+    - {}

--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -5,6 +5,7 @@ configs:
     application.resourceTrackingMethod: annotation+label
     admin.enabled: true
     url: https://argocd.kube.pc-tips.se
+    # https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#sensitive-data-and-sso-client-secrets
     # oidc.config: |
     #   name: 'Authelia'
     #   issuer: 'https://authelia.kube.pc-tips.se'
@@ -73,7 +74,9 @@ redis:
     limits:
       memory: 1Gi
   auth:
-    enabled: true
+    enabled: false
+    existingSecret: argocd-redis
+    existingSecretPasswordKey: auth
   config:
     save: '""' # Disable persistence
   containerSecurityContext:
@@ -90,6 +93,10 @@ redis:
 global:
   image:
     tag: 'v2.9.3'
+  redis:
+    password:
+      existingSecret: argocd-redis
+      key: auth
 
 server:
   service:
@@ -122,13 +129,24 @@ repoServer:
       memory: 256Mi
     limits:
       memory: 2Gi
-  # Removed extraEnv to avoid duplicate REDIS_PASSWORD and REDISCLI_AUTH
-
+  extraEnv:
+    - name: REDIS_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: argocd-redis
+          key: auth
+    - name: REDISCLI_AUTH
+      valueFrom:
+        secretKeyRef:
+          name: argocd-redis
+          key: auth
   extraContainers:
     - name: kustomize-build-with-helm
       command:
         - argocd-cmp-server
-      image: '{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}'
+      image:
+        '{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include
+        "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}'
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -154,7 +172,17 @@ applicationSet:
       memory: 64Mi
     limits:
       memory: 1Gi
-  # Removed env to avoid duplicate REDIS_PASSWORD and REDISCLI_AUTH
+  env:
+    - name: REDIS_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: argocd-redis
+          key: auth
+    - name: REDISCLI_AUTH
+      valueFrom:
+        secretKeyRef:
+          name: argocd-redis
+          key: auth
 
 notifications:
   enabled: false


### PR DESCRIPTION
- Added Cilium network policy to allow ArgoCD components to communicate with the Kubernetes API server and DNS
- Updated ArgoCD configuration to use existing secrets for Redis authentication
- Enhanced manual bootstrap documentation with network policy application steps