### PR TITLE
feat(k8s): change ArgoCD service type to LoadBalancer

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -100,7 +100,9 @@ global:
 
 server:
   service:
-    type: ClusterIP
+    type: LoadBalancer
+    annotations:
+      io.cilium/lb-ipam-ips: "10.25.150.225"  # Assigning a specific IP from the pool
   resources:
     requests:
       cpu: 50m

--- a/k8s/manual-bootstrap.md
+++ b/k8s/manual-bootstrap.md
@@ -32,22 +32,11 @@ kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cilium -n kube-
 Install ArgoCD:
 
 ```shell
-# Apply ArgoCD network policy first to ensure connectivity
-kubectl apply -f infrastructure/controllers/argocd/network-policy.yaml
-
-# Create namespace if it doesn't exist
-kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
 
 # Install ArgoCD components
 kustomize build --enable-helm infrastructure/controllers/argocd | kubectl apply -f -
 
 kubectl apply -k infrastructure/controllers/argo-rollouts
-
-# Check if network policy is correctly applied
-kubectl get ciliumnetworkpolicies -n argocd
-
-# If controller pod is stuck, try restarting it
-kubectl rollout restart statefulset/argocd-application-controller -n argocd
 
 argocd admin redis-initial-password -n argocd
 ```


### PR DESCRIPTION
- Updated ArgoCD service type from ClusterIP to LoadBalancer
- Added specific IP assignment for load balancer
- Removed unnecessary steps from manual bootstrap documentation