### PR TITLE
feat(k8s): add Cilium network policies for cert-manager and external-secrets

### DIFF
--- a/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - namespace.yaml
 - cloudflare-issuer.yaml
 - webhook-certificate.yaml
+- networkpolicy.yaml
 #- cert-manager-secrets-external.yaml
 #- cert-manager-email-external.yaml
 

--- a/k8s/infrastructure/controllers/cert-manager/networkpolicy.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/networkpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cert-manager-webhook-ingress
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app: cert-manager-webhook
+  ingress:
+    - fromCIDR:
+        - "0.0.0.0/0"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/k8s/infrastructure/controllers/external-secrets/cilium-network-policy-es-egress.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/cilium-network-policy-es-egress.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-es-egress-to-cert-manager
+  namespace: external-secrets
+spec:
+  # Apply to all pods in external-secrets
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: cert-manager
+            app: cert-manager-webhook
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-es-webhook-ingress
+  namespace: external-secrets
+spec:
+  endpointSelector:
+    matchLabels:
+      app: external-secrets-webhook
+  ingress:
+    - fromCIDR:
+        - "0.0.0.0/0"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/k8s/infrastructure/controllers/external-secrets/kustomization.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - network-policy.yaml
   - webhook-config.yaml
   - webhook-rbac.yaml
+  - cilium-network-policy-es-egress.yaml
 
 helmCharts:
   - name: external-secrets


### PR DESCRIPTION
- Introduced network policies to enhance security for cert-manager and external-secrets
- Updated kustomization files to include new network policy resources