### PR TITLE
feat(external-secrets): add ClusterRole and ClusterRoleBinding for clusterpushsecret

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -54,7 +54,7 @@ server:
   certificate:
     enabled: true
     domain: argocd.kube.pc-tips.se
-    issuerRef:
+    issuer:
       name: cloudflare-issuer
       kind: ClusterIssuer
 

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml
@@ -14,5 +14,9 @@ spec:
             name: bitwarden-access-token
             namespace: external-secrets
       bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se:9998
+      caProvider:
+        type: Secret
+        name: letsencrypt-ca
+        key: ca.crt
       organizationID: 4a014e57-f197-4852-9831-b287013e47b6
       projectID: d22d5a96-5177-43a4-bdc5-b287015de957

--- a/k8s/infrastructure/controllers/external-secrets/clusterrole-clusterpushsecret.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/clusterrole-clusterpushsecret.yaml
@@ -1,0 +1,9 @@
+# clusterrole-clusterpushsecret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-clusterpushsecret
+rules:
+  - apiGroups: ["external-secrets.io"]
+    resources: ["clusterpushsecrets"]
+    verbs: ["get", "list", "watch"]

--- a/k8s/infrastructure/controllers/external-secrets/clusterrolebinding-clusterpushsecret.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/clusterrolebinding-clusterpushsecret.yaml
@@ -1,0 +1,13 @@
+# clusterrolebinding-clusterpushsecret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-clusterpushsecret-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-clusterpushsecret
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets

--- a/k8s/infrastructure/controllers/external-secrets/kustomization.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - bitwarden-sdk-tls.yaml
 - bitwarden-sdk-server
 - namespace.yaml
+- clusterrole-clusterpushsecret.yaml
+- clusterrolebinding-clusterpushsecret.yaml
 - templates
 
 # helm template external-secrets \
@@ -18,3 +20,8 @@ resources:
 
 # mv /root/homelab/k8s/infrastructure/controllers/external-secrets/external-secrets/charts/bitwarden-sdk-server/templates/* /root/homelab/k8s/infrastructure/controllers/external-secrets/external-secrets/bitwarden-sdk-server/
 # rm -rf /root/homelab/k8s/infrastructure/controllers/external-secrets/external-secrets/charts/bitwarden-sdk-server/templates/
+
+# To get the CA certificate root@vscode:~/homelab/k8s# curl -sSL https://letsencrypt.org/certs/isrgrootx1.pem -o isrgrootx1.pem
+# root@vscode:~/homelab/k8s# kubectl create secret generic letsencrypt-ca \
+#   -n external-secrets \
+#   --from-file=ca.crt=isrgrootx1.pem


### PR DESCRIPTION
- Introduced ClusterRole for managing clusterpushsecrets
- Added ClusterRoleBinding to associate the ClusterRole with the external-secrets ServiceAccount
- Updated kustomization.yaml to include new resources