### PR TITLE
Tofu-coredns-install

### DIFF
--- a/k8s/infrastructure/controllers/cert-manager/cloudflare-api-token.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/cloudflare-api-token.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token
+  namespace: cert-manager
+type: Opaque
+stringData:
+  cloudflare_api_token: "token"

--- a/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- cloudflare-api-token.yaml
 - cert-manager.yaml
 - cert-manager-secrets-external.yaml
 - cloudflare-issuer.yaml

--- a/k8s/manual-bootstrap.md
+++ b/k8s/manual-bootstrap.md
@@ -27,6 +27,10 @@ Wait for Cilium to be ready:
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cilium -n kube-system --timeout=90s
 ```
 
+```shell
+kustomize build --enable-helm infrastructure/controllers/cert-manager | kubectl apply -f -
+```
+
 ## ArgoCD Bootstrap
 
 Install ArgoCD:
@@ -49,6 +53,31 @@ Get initial admin password:
 
 ```shell
 kubectl -n argocd get secret argocd-initial-admin-secret -ojson | jq -r '.data.password | @base64d'
+```
+
+```shell
+kustomize build --enable-helm infrastructure/storage/longhorn | kubectl apply -f -
+```
+
+```shell
+kustomize build --enable-helm infrastructure/network/coredns | kubectl apply -f -
+```
+
+```shell
+kustomize build --enable-helm infrastructure/controllers/external-secrets | kubectl apply -f -
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitwarden-access-token
+  namespace: external-secrets
+type: Opaque
+data:
+  token: base64token==
+EOF
 ```
 
 ## GitOps Configuration

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -16,7 +16,9 @@ module "talos" {
     install = file("${path.module}/talos/inline-manifests/cilium-install.yaml")
   }
 
-
+  coredns = {
+    install = file("${path.module}/talos/inline-manifests/coredns-install.yaml")
+  }
 
   cluster = {
     name            = "talos"

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -23,7 +23,7 @@ module "talos" {
     endpoint        = "api.kube.pc-tips.se"
     gateway         = "10.25.150.1"     # Network gateway
     vip             = "10.25.150.10"    # Control plane VIP
-    talos_version   = "v1.9.4"
+    talos_version   = "v1.9.5"
     proxmox_cluster = "kube"
     kubernetes_version = "1.32.3"  # renovate: github-releases=kubernetes/kubernetes
   }

--- a/tofu/talos/config.tf
+++ b/tofu/talos/config.tf
@@ -26,6 +26,7 @@ data "talos_machine_configuration" "this" {
       cluster        = var.cluster
       cilium_values  = var.cilium.values
       cilium_install = var.cilium.install
+      coredns_install = var.coredns.install
     })
     ] : [
     templatefile("${path.module}/machine-config/worker.yaml.tftpl", {

--- a/tofu/talos/kubernetes_manifests.tf
+++ b/tofu/talos/kubernetes_manifests.tf
@@ -1,0 +1,32 @@
+locals {
+  # Transform the inline manifests list into a map for easier dependency resolution
+  inline_manifests_map = { for manifest in var.inline_manifests : manifest.name => manifest }
+
+  # We'll use the raw content strings instead of trying to parse multi-document YAML
+  cilium_content = try(local.inline_manifests_map["cilium-install"].content, "")
+  coredns_content = try(local.inline_manifests_map["coredns-install"].content, "")
+}
+
+# Configure kubernetes provider with the cluster's kubeconfig
+provider "kubernetes" {
+  config_path = "${path.module}/../output/kube-config.yaml"
+}
+
+# The machine configuration is responsible for core bootstrap components
+# Following GitOps principles, we don't directly manage Kubernetes resources here
+# Instead, we include the necessary manifests in the Talos machine configuration
+
+# Output variables for use by other modules
+output "cilium" {
+  description = "Cilium installation details"
+  value = {
+    values = var.cilium.values
+  }
+}
+
+output "core_dns" {
+  description = "CoreDNS installation details"
+  value = {
+    install = var.coredns.install
+  }
+}

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -59,3 +59,6 @@ cluster:
   - name: cilium-bootstrap
     contents: |
       ${indent(6, cilium_install)}
+  - name: coredns-bootstrap
+    contents: |
+      ${indent(6, coredns_install)}

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -38,6 +38,10 @@ variable "nodes" {
     ram_dedicated = number
     update = optional(bool, false)
     igpu = optional(bool, false)
+    disks = optional(map(object({
+      size = string
+      type = string
+    })), {})
   }))
 }
 
@@ -47,6 +51,23 @@ variable "cilium" {
     values  = string
     install = string
   })
+}
+
+variable "coredns" {
+  description = "CoreDNS configuration"
+  type = object({
+    install = string
+  })
+}
+
+variable "inline_manifests" {
+  description = "Inline manifests to apply after bootstrap with dependencies"
+  type = list(object({
+    name = string
+    content = string
+    dependencies = optional(list(string), [])
+  }))
+  default = []
 }
 
 


### PR DESCRIPTION
- Introduced CoreDNS installation configuration in Talos module
- Updated machine configuration to include CoreDNS bootstrap
- Enhanced variable definitions for CoreDNS settings