### PR TITLE
feat(k8s): update Bitwarden configurations for external secrets

### DIFF
--- a/docs/external-docs/external-secrets/bitwarden.md
+++ b/docs/external-docs/external-secrets/bitwarden.md
@@ -56,7 +56,7 @@ spec:
           credentials:
             key: token
             name: bitwarden-access-token
-      bitwardenServerSDKURL: https://bitwarden-sdk-server.default.svc.kube.pc-tips.se:9998
+      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se:9998
       caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...
       organizationID: 7c0d21ec-10d9-4972-bdf8-ec52df99cc86
       projectID: 9c713cd6-728c-437a-a783-252b0773a0bb

--- a/k8s/infrastructure/controllers/argocd/network-policy.yaml
+++ b/k8s/infrastructure/controllers/argocd/network-policy.yaml
@@ -15,7 +15,6 @@ spec:
             selector:
               matchLabels:
                 component: apiserver
-            namespace: default
       toPorts:
         - ports:
             - port: "443"

--- a/k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml
@@ -20,8 +20,8 @@ spec:
     organizations:
       - external-secrets.io
   dnsNames:
-    - external-secrets-bitwarden-sdk-server.default.svc.kube.pc-tips.se
-    - bitwarden-sdk-server.default.svc.kube.pc-tips.se
+    - external-secrets-bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
+    - bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
     - localhost
   ipAddresses:
     - 127.0.0.1

--- a/k8s/infrastructure/controllers/cert-manager/cert-manager-secrets-external.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/cert-manager-secrets-external.yaml
@@ -13,12 +13,12 @@ spec:
     name: bitwarden-backend  # Uses the ClusterSecretStore
     kind: ClusterSecretStore
   target:
-    name: infrastructure-secrets
+    name: cloudflare-api-token
     creationPolicy: Owner
   data:
   - secretKey: cloudflare_api_token
     remoteRef:
       key: 154f7f9b-a324-47d2-b11e-b287015e66a8
-  # - secretKey: email
-  #   remoteRef:
-  #     key: e0f77c49-54b7-43e1-902e-b29701526934
+  - secretKey: email
+    remoteRef:
+      key: e0f77c49-54b7-43e1-902e-b29701526934

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml
@@ -2,12 +2,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: bitwarden-tls-certs
-  namespace: default
+  namespace: external-secrets
 spec:
   secretName: bitwarden-tls-certs
   dnsNames:
-    - bitwarden-sdk-server.default.svc.kube.pc-tips.se
-    - external-secrets-bitwarden-sdk-server.default.svc.kube.pc-tips.se
+    - bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
+    - external-secrets-bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
     - localhost
   ipAddresses:
     - 127.0.0.1

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml
@@ -12,12 +12,12 @@ spec:
           credentials:
             key: token
             name: bitwarden-access-token
-            namespace: default
-      bitwardenServerSDKURL: https://bitwarden-sdk-server.default.svc.kube.pc-tips.se:9998
+            namespace: external-secrets
+      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se:9998
       caProvider:
         type: Secret
         name: bitwarden-tls-certs
         key: ca.crt
-        namespace: default
+        namespace: external-secrets
       organizationID: 4a014e57-f197-4852-9831-b287013e47b6
       projectID: d22d5a96-5177-43a4-bdc5-b287015de957

--- a/k8s/infrastructure/controllers/kubechecks/argocd-token-external.yaml
+++ b/k8s/infrastructure/controllers/kubechecks/argocd-token-external.yaml
@@ -18,4 +18,4 @@ spec:
   data:
     - secretKey: argocd-api-token
       remoteRef:
-        key: 0d2a2732-db70-49b7-b64a-b29400a92230 # This should be updated to the correct Bitwarden secret UUID
+        key: 0d2a2732-db70-49b7-b64a-b29400a92230


### PR DESCRIPTION
- Changed Bitwarden SDK server URL to use the external-secrets namespace
- Updated DNS names in the Bitwarden issuer configuration
- Modified secret store references to align with new naming conventions
- Adjusted network policies to reflect namespace changes for ArgoCD