### PR TITLE
chore(tofu): update Cilium installation manifest and variables

### DIFF
--- a/docs/storage/longhorn.md
+++ b/docs/storage/longhorn.md
@@ -4,6 +4,62 @@
 
 Longhorn provides distributed block storage with replication, backup, and guaranteed IOPS features.
 
+## Talos Linux Requirements
+
+### System Extensions
+
+The following system extensions are required for Longhorn to function properly on Talos Linux:
+
+- `siderolabs/iscsi-tools`: For iSCSI connectivity between nodes
+- `siderolabs/util-linux-tools`: For various filesystem operations
+
+These extensions are already included in our Talos configuration (see `tofu/talos/image/schematic.yaml`).
+
+### Data Path Configuration
+
+Longhorn requires a special mount configuration on all nodes:
+
+```yaml
+machine:
+  kubelet:
+    extraMounts:
+      - destination: /var/lib/longhorn
+        type: bind
+        source: /var/lib/longhorn
+        options:
+          - bind
+          - rshared
+          - rw
+```
+
+### Pod Security Configuration
+
+Longhorn requires privileged pod security context. Our namespace configuration already includes:
+
+```yaml
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+```
+
+### Upgrade Considerations
+
+**IMPORTANT**: When upgrading Talos Linux, always use the `--preserve` flag to prevent data loss:
+
+```bash
+talosctl upgrade-k8s --to <version> --preserve
+```
+
+This flag ensures that `/var/lib/longhorn` directory contents are preserved during upgrades. Without it, all local
+replicas would be destroyed.
+
+### Limitations
+
+- Only v1 data volumes are supported
+- Talos immutability means certain operations must be handled carefully
+
 ## Configuration
 
 Default configuration optimized for our homelab:
@@ -70,6 +126,30 @@ component:
 - Node metrics
 - Backup status
 - Performance data
+
+## Recovery Procedures
+
+### Recovering From Upgrade Without Preservation
+
+If an upgrade occurred without the `--preserve` flag and data was lost:
+
+1. In Longhorn UI, disable scheduling for all affected nodes
+2. Remove the affected disks from the node
+3. Add the disks back (they should be empty now)
+4. Re-enable scheduling
+5. The volumes will be rebuilt from replicas on other nodes (if replica count >1)
+
+### Recovering From Node Failure
+
+1. If a node becomes unresponsive:
+
+   - Longhorn automatically reschedules volumes to other nodes
+   - Replicas will be rebuilt if capacity allows
+
+2. When restoring the node:
+   - Verify that `/var/lib/longhorn` mount is correctly configured
+   - Check that all system extensions are present
+   - Allow Longhorn to rebalance volumes automatically
 
 ## Best Practices
 

--- a/tofu/talos/inline-manifests/cilium-install.yaml
+++ b/tofu/talos/inline-manifests/cilium-install.yaml
@@ -55,6 +55,7 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
                     operator: Exists
+      serviceAccount: cilium-install
       serviceAccountName: cilium-install
       hostNetwork: true
       containers:
@@ -68,19 +69,23 @@ spec:
               fieldPath: status.podIP
         - name: KUBERNETES_SERVICE_PORT
           value: "6443"
-        volumeMounts:
-          - name: values
-            mountPath: /root/app/values.yaml
-            subPath: values.yaml
         command:
           - cilium
           - install
           - --version=v1.17.2 # renovate: github-releases=cilium/cilium
           - --set
+          - ipam.mode=kubernetes
+          - --set
           - kubeProxyReplacement=true
-          - --values
-          - values.yaml
-      volumes:
-        - name: values
-          configMap:
-            name: cilium-values
+          - --set
+          - securityContext.capabilities.ciliumAgent={CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}
+          - --set
+          - securityContext.capabilities.cleanCiliumState={NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}
+          - --set
+          - cgroup.autoMount.enabled=false
+          - --set
+          - cgroup.hostRoot=/sys/fs/cgroup
+          - --set
+          - k8sServiceHost=localhost
+          - --set
+          - k8sServicePort=7445

--- a/tofu/talos/kubernetes_manifests.tf
+++ b/tofu/talos/kubernetes_manifests.tf
@@ -4,7 +4,7 @@ locals {
 
   # We'll use the raw content strings instead of trying to parse multi-document YAML
   cilium_content = try(local.inline_manifests_map["cilium-install"].content, "")
-  coredns_content = try(local.inline_manifests_map["coredns-install"].content, "")
+  # coredns_content = try(local.inline_manifests_map["coredns-install"].content, "")
 }
 
 # Configure kubernetes provider with the cluster's kubeconfig
@@ -24,9 +24,9 @@ output "cilium" {
   }
 }
 
-output "core_dns" {
-  description = "CoreDNS installation details"
-  value = {
-    install = var.coredns.install
-  }
-}
+# output "core_dns" {
+#   description = "CoreDNS installation details"
+#   value = {
+#     install = var.coredns.install
+#   }
+# }

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -30,7 +30,7 @@ variable "nodes" {
   type = map(object({
     host_node     = string
     machine_type  = string
-    datastore_id = optional(string, "rpool3")
+    datastore_id = optional(string, "velocity")
     ip            = string
     mac_address   = string
     vm_id         = number

--- a/tofu/upgrade-k8s.sh
+++ b/tofu/upgrade-k8s.sh
@@ -1,2 +1,2 @@
 # Usage: sh upgrade-k8s.sh <controlplane node> or sh upgrade-k8s.sh <controlplane node> --dry-run (for a dry run)
-talosctl $2 --nodes $1 upgrade-k8s --to 1.32.3 # renovate: github-releases=kubernetes/kubernetes
+talosctl $2 --nodes $1 upgrade-k8s --to 1.32.3 --preserve # renovate: github-releases=kubernetes/kubernetes

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -46,7 +46,7 @@ variable "proxmox" {
 #    object({
 #      node = string
 #      size = string
-#      storage = optional(string, "rpool3")
+#      storage = optional(string, "velocity")
 #      vmid = optional(number, 9999)
 #      format = optional(string, "raw")
 #    })


### PR DESCRIPTION
- Added service account to Cilium job specification
- Commented out CoreDNS output variable in Terraform
- Changed default datastore ID from "rpool3" to "velocity" in variables