### PR TITLE
Chore(k8s)--update-bitwarden-sdk-server-to-version-v0.4.0

### DIFF
--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/deployment.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server:v0.4.0
+    helm.sh/chart: bitwarden-sdk-server-v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v0.4.0"
@@ -54,10 +54,10 @@ spec:
         - name: bitwarden-tls-certs
           secret:
             items:
-            - key: "tls.crt"
-              path: "cert.pem"
-            - key: "tls.key"
-              path: "key.pem"
-            - key: "ca.crt"
-              path: "ca.pem"
+            - key: tls.crt
+              path: cert.pem
+            - key: tls.key
+              path: key.pem
+            - key: ca.crt
+              path: ca.pem
             secretName: bitwarden-tls-certs

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/deployment.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server-v0.3.1
+    helm.sh/chart: bitwarden-sdk-server:v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.3.1"
+    app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/service.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/service.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server:v0.4.0
+    helm.sh/chart: bitwarden-sdk-server-v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v0.4.0"

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/service.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server-v0.3.1
+    helm.sh/chart: bitwarden-sdk-server:v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.3.1"
+    app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/serviceaccount.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server:v0.4.0
+    helm.sh/chart: bitwarden-sdk-server-v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/version: "v0.4.0"

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/serviceaccount.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-sdk-server/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: bitwarden-sdk-server
   labels:
-    helm.sh/chart: bitwarden-sdk-server-v0.3.1
+    helm.sh/chart: bitwarden-sdk-server:v0.4.0
     app.kubernetes.io/name: bitwarden-sdk-server
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/version: "v0.3.1"
+    app.kubernetes.io/version: "v0.4.0"
     app.kubernetes.io/managed-by: Helm

--- a/k8s/infrastructure/controllers/external-secrets/templates/rbac.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/templates/rbac.yaml
@@ -19,6 +19,7 @@ rules:
     - "externalsecrets"
     - "clusterexternalsecrets"
     - "pushsecrets"
+    - "clusterpushsecrets"
     verbs:
     - "get"
     - "list"
@@ -41,6 +42,9 @@ rules:
     - "pushsecrets"
     - "pushsecrets/status"
     - "pushsecrets/finalizers"
+    - "clusterpushsecrets"
+    - "clusterpushsecrets/status"
+    - "clusterpushsecrets/finalizers"
     verbs:
     - "get"
     - "update"
@@ -128,6 +132,14 @@ rules:
     - "create"
     - "update"
     - "delete"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "pushsecrets"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
 ---
 # Source: external-secrets/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -151,6 +163,7 @@ rules:
       - "secretstores"
       - "clustersecretstores"
       - "pushsecrets"
+      - "clusterpushsecrets"
     verbs:
       - "get"
       - "watch"
@@ -196,6 +209,7 @@ rules:
       - "secretstores"
       - "clustersecretstores"
       - "pushsecrets"
+      - "clusterpushsecrets"
     verbs:
       - "create"
       - "delete"
@@ -241,6 +255,7 @@ rules:
     - "external-secrets.io"
     resources:
     - "externalsecrets"
+    - "pushsecrets"
     verbs:
     - "get"
     - "list"

--- a/k8s/infrastructure/controllers/external-secrets/templates/webhook-service.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/templates/webhook-service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/version: "v0.15.1"
     app.kubernetes.io/managed-by: Helm
     external-secrets.io/component: webhook
-
+  
 spec:
   type: ClusterIP
   ports:

--- a/k8s/infrastructure/crds/kustomization.yaml
+++ b/k8s/infrastructure/crds/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 resources:
 - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
-- https://raw.githubusercontent.com/external-secrets/external-secrets/v0.15.0/deploy/crds/bundle.yaml
+- https://raw.githubusercontent.com/external-secrets/external-secrets/v0.15.1/deploy/crds/bundle.yaml


### PR DESCRIPTION
- Corrected chart label format in deployment, service, and serviceaccount files
- Added clusterpushsecrets resource to RBAC configuration
- Updated external-secrets CRD bundle version in kustomization.yaml