### PR TITLE
chore(k8s): update application set configurations

### DIFF
--- a/k8s/applications/application-set.yaml
+++ b/k8s/applications/application-set.yaml
@@ -38,6 +38,12 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ApplyOutOfSyncOnly=true

--- a/k8s/infrastructure/application-set.yaml
+++ b/k8s/infrastructure/application-set.yaml
@@ -39,6 +39,12 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ApplyOutOfSyncOnly=true

--- a/k8s/infrastructure/controllers/cert-manager/cloudflare-issuer.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/cloudflare-issuer.yaml
@@ -8,7 +8,7 @@ spec:
     server: https://acme-v02.api.letsencrypt.org/directory
     email: admin@pc-tips.se  # Kustomize will replace this
     privateKeySecretRef:
-      name: cloudflare-api-token
+      name: cloudflare-issuer-account-key  # Changed: Use a dedicated secret for ACME account
     solvers:
       - dns01:
           cloudflare:

--- a/k8s/infrastructure/controllers/cert-manager/values.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/values.yaml
@@ -3,7 +3,11 @@ crds:
   keep: true
 
 extraArgs:
-  - "--enable-gateway-api"
+  - --v=2
+  - --cluster-resource-namespace=$(POD_NAMESPACE)
+  - --leader-election-namespace=kube-system
+  - --dns01-recursive-nameservers=10.96.0.10:53
+  - --dns01-recursive-nameservers-only=true
 
 resources:
   limits:

--- a/k8s/infrastructure/network/cilium/kustomization.yaml
+++ b/k8s/infrastructure/network/cilium/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - announce.yaml
 - ip-pool.yaml
 - bgp.yaml
-- argocd-lb-advertisement.yaml
 
 helmCharts:
 - includeCRDs: true


### PR DESCRIPTION
- Added retry settings with a limit and backoff strategy
- Updated Cloudflare issuer to use a dedicated secret for ACME account
- Refined extra arguments in cert-manager values
- Removed unused resource from Cilium kustomization