### PR TITLE
feat(k8s): add HTTPRoute configurations for Argo Rollouts and Longhorn

### DIFF
--- a/k8s/infrastructure/controllers/argo-rollouts/http-route.yaml
+++ b/k8s/infrastructure/controllers/argo-rollouts/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argo-rollouts
+  namespace: argo-rollouts
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "rollouts.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argo-rollouts-dashboard
+          port: 80

--- a/k8s/infrastructure/controllers/argo-rollouts/kustomization.yaml
+++ b/k8s/infrastructure/controllers/argo-rollouts/kustomization.yaml
@@ -6,5 +6,6 @@ namespace: argo-rollouts
 
 resources:
 - namespace.yaml
+- http-route.yaml
 - https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
 - dashboard-service.yaml

--- a/k8s/infrastructure/storage/longhorn/http-route.yaml
+++ b/k8s/infrastructure/storage/longhorn/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "longhorn.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: longhorn-frontend
+          port: 80

--- a/k8s/infrastructure/storage/longhorn/kustomization.yaml
+++ b/k8s/infrastructure/storage/longhorn/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: longhorn-system
 
 resources:
   - namespace.yaml
+  - http-route.yaml
 
 helmCharts:
 - name: longhorn


### PR DESCRIPTION
- Introduced HTTPRoute for Argo Rollouts with hostname "rollouts.pc-tips.se"
- Introduced HTTPRoute for Longhorn with hostname "longhorn.pc-tips.se"
- Updated kustomization files to include new HTTPRoute resources