### PR TITLE
refactor(k8s): remove unused persistent volume claims from deployments

### DIFF
--- a/k8s/applications/application-set.yaml
+++ b/k8s/applications/application-set.yaml
@@ -17,6 +17,8 @@ spec:
           - path: k8s/applications/media
           - path: k8s/applications/tools
           - path: k8s/applications/ai
+          - path: k8s/applications/external
+          - path: k8s/applications/web
   template:
     metadata:
       name: 'apps-{{ path.basename }}'

--- a/k8s/applications/media/arr/lidarr/deployment.yaml
+++ b/k8s/applications/media/arr/lidarr/deployment.yaml
@@ -65,6 +65,3 @@ spec:
             claimName: media-share
         - name: tmp
           emptyDir: { }
-        - name: data
-          persistentVolumeClaim:
-            claimName: lidarr-data

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -65,6 +65,3 @@ spec:
             claimName: media-share
         - name: tmp
           emptyDir: { }
-        - name: data
-          persistentVolumeClaim:
-            claimName: radarr-data

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -65,6 +65,3 @@ spec:
             claimName: media-share
         - name: tmp
           emptyDir: { }
-        - name: data
-          persistentVolumeClaim:
-            claimName: sonarr-data

--- a/k8s/applications/media/arr/torrent/deployment.yaml
+++ b/k8s/applications/media/arr/torrent/deployment.yaml
@@ -102,6 +102,3 @@ spec:
           emptyDir: { }
         - name: themes
           emptyDir: { }
-        - name: data
-          persistentVolumeClaim:
-            claimName: torrent-data


### PR DESCRIPTION
- Removed 'data' persistent volume claims from lidarr, radarr, sonarr, and torrent deployments.