### PR TITLE
fix(infrastructure): pin Argo Rollouts install YAML to specific version

### DIFF
--- a/k8s/infrastructure/controllers/argo-rollouts/kustomization.yaml
+++ b/k8s/infrastructure/controllers/argo-rollouts/kustomization.yaml
@@ -7,5 +7,5 @@ namespace: argo-rollouts
 resources:
 - namespace.yaml
 - http-route.yaml
-- https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+- https://github.com/argoproj/argo-rollouts/releases/download/v1.8.2/install.yaml
 - dashboard-service.yaml


### PR DESCRIPTION
What: Updated the Argo Rollouts install YAML URL to a specific version (v1.8.2).

Why: Using 'latest' can lead to unexpected changes in deployments; pinning to a specific version ensures stability.

Fixes #353