### PR TITLE
Ensure that the network policy for kubechecks is a cilium

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
@@ -18,3 +18,5 @@ labels:
     app.kubernetes.io/managed-by: argocd
     app.kubernetes.io/part-of: infrastructure
     dev.pc-tips: deployment
+patchesStrategicMerge:
+- network-policy.yaml

--- a/k8s/infrastructure/deployment/kubechecks/network-policy.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/network-policy.yaml
@@ -1,49 +1,43 @@
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
 metadata:
   name: allow-to-argocd
   namespace: kubechecks
 spec:
-  podSelector:
+  endpointSelector:
     matchLabels:
       app.kubernetes.io/name: kubechecks
-  policyTypes:
-    - Egress
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kubechecks
   egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              app.kubernetes.io/part-of: infrastructure   # or match on namespace “argocd”
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: argocd-server
-      ports:
-        - protocol: TCP
-          port: 443
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: argocd
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: argocd-repo-server
-      ports:
-        - protocol: TCP
-          port: 8081
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: default
-          podSelector:
-            matchLabels:
-              kubernetes.io/name: kubernetes
-      ports:
-        - protocol: TCP
-          port: 443
-    - to:
-        - namespaceSelector: {}
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: argocd-server
+      toPorts:
+        - ports:
+            - port: 443
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: argocd-repo-server
+      toPorts:
+        - ports:
+            - port: 8081
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            kubernetes.io/name: kubernetes
+      toPorts:
+        - ports:
+            - port: 443
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels: {}
+      toPorts:
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/397?shareId=73027f5e-79ba-4491-938b-4f1aec5e672f).