### PR TITLE
Add Jellyseerr overlay to media applications

### DIFF
--- a/k8s/applications/media/jellyseerr/http-route.yaml
+++ b/k8s/applications/media/jellyseerr/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyseerr
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "jellyseerr.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jellyseerr
+          port: 80

--- a/k8s/applications/media/jellyseerr/jellyseerr-config-pvc.yaml
+++ b/k8s/applications/media/jellyseerr/jellyseerr-config-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyseerr-config
+  namespace: media
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/applications/media/jellyseerr/kustomization.yaml
+++ b/k8s/applications/media/jellyseerr/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: media
+
+helmCharts:
+  - name: jellyseerr
+    repo: oci://ghcr.io/fallenbagel/jellyseerr/jellyseerr-chart
+    version: 2.3.3
+    releaseName: jellyseerr
+    namespace: media
+    valuesFile: values.yaml

--- a/k8s/applications/media/jellyseerr/values.yaml
+++ b/k8s/applications/media/jellyseerr/values.yaml
@@ -1,0 +1,29 @@
+replicaCount: 1
+
+image:
+  pullPolicy: IfNotPresent
+  registry: ghcr.io
+  repository: fallenbagel/jellyseerr
+
+service:
+  type: ClusterIP
+  port: 80
+
+config:
+  persistence:
+    name: jellyseerr-config
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+    annotations: {}
+
+extraEnv: []
+extraEnvFrom: []
+
+ingress:
+  enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+resources: {}

--- a/k8s/applications/media/kustomization.yaml
+++ b/k8s/applications/media/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - arr
 - media-share-pvc.yaml
 - nfs-pv.yaml
+- jellyseerr


### PR DESCRIPTION
Add new `media/jellyseerr/` overlay to the repository.

* **kustomization.yaml**: Define `Kustomization` with `namespace: media` and add `helmCharts` section for `jellyseerr`.
* **values.yaml**: Configure deployment settings, image, service, config persistence, and other standard pod settings.
* **jellyseerr-config-pvc.yaml**: Define `PersistentVolumeClaim` for `jellyseerr-config` with storage class `longhorn`.
* **http-route.yaml**: Define `HTTPRoute` for `jellyseerr` with parent references, hostnames, and rules.
* **kustomization.yaml**: Add `- jellyseerr` to `resources` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/419?shareId=98eae2d3-7615-4b2a-ba8c-47050cec4410).