### PR TITLE
fix(k8s): update secret key references in kubechecks configuration

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
@@ -18,6 +18,6 @@ spec:
     - secretKey: argocd_api_token
       remoteRef:
         key: 0d2a2732-db70-49b7-b64a-b29400a92230
-    - secretKey: kubechecks-webhook-secret
+    - secretKey: webhook_hmac
       remoteRef:
         key: aa211860-aeb4-44fc-98b7-b2c600feb358

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -17,20 +17,20 @@ deployment:
     - name: KUBECHECKS_WEBHOOK_SECRET
       valueFrom:
         secretKeyRef:
-          name: kubechecks-webhook-secret
-          key: hmac
+          name: kubechecks-combined-secret
+          key: webhook_hmac
     - name: KUBECHECKS_VCS_TYPE
       value: "github"
     - name: KUBECHECKS_VCS_TOKEN
       valueFrom:
         secretKeyRef:
-          name: github-token
+          name: kubechecks-combined-secret
           key: github_token
     - name: KUBECHECKS_ARGOCD_API_TOKEN
       valueFrom:
         secretKeyRef:
-          name: argocd-token
-          key: argocd-api-token
+          name: kubechecks-combined-secret
+          key: argocd_api_token
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
       value: "argocd-server.argocd.svc.kube.pc-tips.se"
     - name: KUBECHECKS_ARGOCD_API_INSECURE


### PR DESCRIPTION
- Changed webhook secret key reference to use 'webhook_hmac'
- Updated references for GitHub and ArgoCD tokens to use 'kubechecks-combined-secret'