### PR TITLE
refactor(k8s): clean up pod security context in values.yaml

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/namespace.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/namespace.yaml
@@ -8,3 +8,5 @@ metadata:
     dev.pc-tips: deployment
     kubernetes.io/metadata.name: kubechecks
     network-policy: enabled
+    # enforce baseline policy (allows root, disallows privileged/host namespaces/hostPath, etc)
+    pod-security.kubernetes.io/enforce: baseline

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -56,16 +56,15 @@ deployment:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  podSecurityContext:
-    runAsNonRoot: true
+  podSecurityContext: {}
   securityContext:
-    runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
         - ALL
     seccompProfile:
       type: RuntimeDefault
+
   envFrom: []
   startupProbe:
     failureThreshold: 30


### PR DESCRIPTION
- Removed redundant runAsNonRoot setting from podSecurityContext
- Simplified podSecurityContext structure for clarity