### PR TITLE
refactor(k8s): remove unnecessary filters from HTTPRoute configuration

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/http-route.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/http-route.yaml
@@ -14,12 +14,6 @@ spec:
         - path:
             type: PathPrefix
             value: /
-      filters:
-        - type: RequestHeaderModifier
-          requestHeaderModifier:
-            add:
-              - name: X-Forwarded-Proto
-                value: https
       backendRefs:
         - name: kubechecks
           port: 8080

--- a/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - namespace.yaml
   - kubechecks-secret-external.yaml
   - http-route.yaml
-  - network-policy.yaml
 
 helmCharts:
   - name: kubechecks

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -1,4 +1,5 @@
-# Labels to apply to all resources created by this Helm chart
+# values.yaml for kubechecks v0.5.4
+
 argocd:
   namespace: argocd
 
@@ -14,8 +15,6 @@ deployment:
       value: /home/kubechecks
     - name: KUBECHECKS_MONITOR_ALL_APPLICATIONS
       value: "true"
-    - name: KUBECHECKS_VCS_EMAIL
-      value: "kubechecks.pc-tips.se"
     - name: KUBECHECKS_WEBHOOK_URL_BASE
       value: "https://kubechecks.pc-tips.se"
     - name: KUBECHECKS_ENSURE_WEBHOOKS
@@ -37,9 +36,9 @@ deployment:
         secretKeyRef:
           name: kubechecks-combined-secret
           key: argocd_api_token
-    - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
-      value: "argocd-server.argocd.svc.kube.pc-tips.se"
     - name: KUBECHECKS_ARGOCD_API_INSECURE
+      value: "true"
+    - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE
       value: "true"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
@@ -55,26 +54,32 @@ deployment:
   annotations: {}
   podAnnotations: {}
   args: []
+
   resources:
     limits:
       memory: 512Mi
     requests:
       memory: 256Mi
       cpu: 200m
+
   revisionHistoryLimit: 10
   replicaCount: 1
+
   image:
     pullPolicy: Always
     name: "ghcr.io/zapier/kubechecks"
     tag: "latest"
+
   imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 32123
     fsGroup: 32123
+
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false
@@ -82,17 +87,21 @@ deployment:
       drop:
         - ALL
     readOnlyRootFilesystem: false
+
   envFrom: []
+
   startupProbe:
     initialDelaySeconds: 30
     failureThreshold: 30
     periodSeconds: 10
+
   livenessProbe:
     failureThreshold: 30
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 5
+
   readinessProbe:
     failureThreshold: 30
     initialDelaySeconds: 5


### PR DESCRIPTION
- Eliminated RequestHeaderModifier filter for X-Forwarded-Proto
- Cleaned up kustomization.yaml by removing unused network-policy.yaml reference
- Updated values.yaml to remove deprecated KUBECHECKS_VCS_EMAIL variable