### PR TITLE
feat(k8s): add network policy and update service configuration

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -59,6 +59,10 @@ redis:
       memory: 1Gi
 
 server:
+  service:
+      httpsPort: 443
+      httpsTargetPort: 8443
+
   resources:
     requests:
       cpu: 50m

--- a/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - kubechecks-secret-external.yaml
   - http-route.yaml
+  - networkpolicy.yaml
 
 helmCharts:
   - name: kubechecks

--- a/k8s/infrastructure/deployment/kubechecks/networkpolicy.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-all-traffic-argocd
+  namespace: argocd
+spec:
+  # matches every pod in argocd
+  endpointSelector: {}
+
+  # allow all incoming traffic
+  ingress:
+  - fromEntities:
+    - cluster
+    - host
+    - world
+
+  # allow all outgoing traffic
+  egress:
+  - toEntities:
+    - cluster
+    - host
+    - world

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -39,13 +39,12 @@ deployment:
     - name: KUBECHECKS_ARGOCD_API_INSECURE
       value: "true"
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
-      value: argocd-server.argocd.svc.kube.pc-tips.se
+      value: argocd-server.argocd.svc.kube.pc-tips.se:80
 
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE
       value: "true"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
-
   volumes:
     - name: home
       emptyDir: {}


### PR DESCRIPTION
- Introduced a new Cilium network policy to allow all traffic for argocd
- Updated service configuration to specify HTTPS ports