### PR TITLE
refactor(k8s): update insecure settings for kubechecks deployment

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -27,14 +27,7 @@ configs:
 
 server:
   extraArgs:
-    - --insecure                         # Allow both HTTP and HTTPS
-  volumes:
-    - name: argocd-server-tls
-      secret:
-        secretName: argocd-server-tls
-  volumeMounts:
-    - name: argocd-server-tls
-      mountPath: /app/config/tls
+    - --insecure
   service:
     servicePortHttps: 443
     servicePortHttp: 80

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -37,13 +37,13 @@ deployment:
           name: kubechecks-combined-secret
           key: argocd_api_token
     - name: KUBECHECKS_ARGOCD_API_INSECURE
-      value: "true"                                    # Skip certificate verification for internal service
+      value: "false"                                    # Skip certificate verification for internal service
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
       value: "argocd-server.argocd.svc:443"          # Use HTTPS port
     - name: KUBECHECKS_ARGOCD_API_PLAINTEXT
       value: "false"                                  # Use HTTPS since we're doing direct service communication
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE
-      value: "true"
+      value: "false"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
   volumes:


### PR DESCRIPTION
- Changed KUBECHECKS_ARGOCD_API_INSECURE and KUBECHECKS_ARGOCD_REPOSITORY_INSECURE to false
- Removed unnecessary volume and volumeMounts for argocd-server-tls