### PR TITLE
refactor(k8s): update server configuration for TLS support

### DIFF
--- a/k8s/infrastructure/controllers/argocd/http-route.yaml
+++ b/k8s/infrastructure/controllers/argocd/http-route.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: argocd
 spec:
   parentRefs:
-    - name: internal
+    - name: internal        # your Gateway with a TLS listener on 443
       namespace: gateway
   hostnames:
-    - "argocd.pc-tips.se"
+    - "argocd.pc-tips.se"   # the public hostname clients hit
   rules:
     - matches:
         - path:
@@ -16,4 +16,4 @@ spec:
             value: /
       backendRefs:
         - name: argocd-server
-          port: 80
+          port: 80           # HTTPRoute → Service:80 (plaintext)

--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -23,8 +23,8 @@ configs:
 
   params:
     controller.diff.server.side: true
-    server.insecure: false               # Disable “insecure” mode to enable TLS
-    server.tls.certificate.secretName: argocd-server-tls
+    server.insecure: "false"
+    server.tls.certificate.secretName: "argocd-server-tls"
 
 server:
   extraArgs: []                         # No --insecure flag, so HTTPS listener will start

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -39,7 +39,7 @@ deployment:
     - name: KUBECHECKS_ARGOCD_API_INSECURE
       value: "false"                                    # Skip certificate verification for internal service
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
-      value: "argocd-server.argocd.svc:443"          # Use HTTPS port
+      value: "argocd-server.argocd.svc.kube.pc‑tips.se:443"
     - name: KUBECHECKS_ARGOCD_API_PLAINTEXT
       value: "false"                                  # Use HTTPS since we're doing direct service communication
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE


### PR DESCRIPTION
- Ensure server.insecure is set to "false" for TLS compatibility
- Maintain consistency in secretName formatting for TLS certificate