### PR TITLE
Refactor(k8s)--streamline-Gateway-listener-configuration

### DIFF
--- a/k8s/infrastructure/controllers/argocd/argocd-tls.yaml
+++ b/k8s/infrastructure/controllers/argocd/argocd-tls.yaml
@@ -1,0 +1,77 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-server-tls
+  namespace: argocd
+spec:
+  secretName: argocd-server-tls
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  subject:
+    organizations:
+      - homelab-internal
+  commonName: argocd-server
+  dnsNames:
+    - argocd-server
+    - argocd-server.argocd
+    - argocd-server.argocd.svc
+    - argocd-server.argocd.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: internal-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-repo-server-tls
+  namespace: argocd
+spec:
+  secretName: argocd-repo-server-tls
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  subject:
+    organizations:
+      - homelab-internal
+  commonName: argocd-repo-server
+  dnsNames:
+    - argocd-repo-server
+    - argocd-repo-server.argocd
+    - argocd-repo-server.argocd.svc
+    - argocd-repo-server.argocd.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: internal-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-application-controller-tls
+  namespace: argocd
+spec:
+  secretName: argocd-application-controller-tls
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  subject:
+    organizations:
+      - homelab-internal
+  commonName: argocd-application-controller
+  dnsNames:
+    - argocd-application-controller
+    - argocd-application-controller.argocd
+    - argocd-application-controller.argocd.svc
+    - argocd-application-controller.argocd.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: internal-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/k8s/infrastructure/controllers/argocd/kustomization.yaml
+++ b/k8s/infrastructure/controllers/argocd/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - http-route.yaml
+  - argocd-tls.yaml
 
 helmCharts:
   - name: argo-cd

--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -31,6 +31,17 @@ server:
   tls:
     certificate:
       secretName: argocd-server-tls
+  volumes:
+    - name: internal-ca-bundle
+      configMap:
+        name: internal-ca-bundle
+        items:
+          - key: ca.crt
+            path: internal-ca.crt
+  volumeMounts:
+    - name: internal-ca-bundle
+      mountPath: /etc/ssl/certs/internal-ca.crt
+      subPath: internal-ca.crt
   service:
     servicePortHttps: 443
     servicePortHttp: 80
@@ -46,12 +57,26 @@ server:
 repoServer:
   containerSecurityContext:
     readOnlyRootFilesystem: true
+  tls:
+    enabled: true
+    certificate:
+      secretName: argocd-repo-server-tls
   volumes:
     - name: cmp-kustomize-build-with-helm
       configMap:
         name: argocd-cmp-cm
     - name: cmp-tmp
       emptyDir: {}
+    - name: internal-ca-bundle
+      configMap:
+        name: internal-ca-bundle
+        items:
+          - key: ca.crt
+            path: internal-ca.crt
+  volumeMounts:
+    - name: internal-ca-bundle
+      mountPath: /etc/ssl/certs/internal-ca.crt
+      subPath: internal-ca.crt
   resources:
     requests:
       cpu: 100m
@@ -80,6 +105,23 @@ repoServer:
           subPath: kustomize-build-with-helm.yaml
         - name: cmp-tmp
           mountPath: /tmp
+
+controller:
+  tls:
+    enabled: true
+    certificate:
+      secretName: argocd-application-controller-tls
+  volumes:
+    - name: internal-ca-bundle
+      configMap:
+        name: internal-ca-bundle
+        items:
+          - key: ca.crt
+            path: internal-ca.crt
+  volumeMounts:
+    - name: internal-ca-bundle
+      mountPath: /etc/ssl/certs/internal-ca.crt
+      subPath: internal-ca.crt
 
 applicationSet:
   resources:

--- a/k8s/infrastructure/controllers/cert-manager/internal-ca-configmap.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/internal-ca-configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-ca-configmap
+  namespace: cert-manager
+spec:
+  # Additional certificate for creating a ConfigMap
+  secretName: internal-ca-for-configmap
+  commonName: internal-ca-configmap
+  dnsNames:
+    - internal-ca.cert-manager.svc
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: internal-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# Create a Job to distribute the CA certificate as a ConfigMap
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-cert-distribution-job
+  namespace: cert-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: ca-cert-distribution
+    spec:
+      serviceAccountName: cert-manager
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kubectl
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          # Using emptyDir volume mounted at /workdir instead of /tmp
+          # Extract CA cert from the secret directly to kubectl commands
+          CA_DATA=$(kubectl get secret internal-ca-tls -n cert-manager -o jsonpath='{.data.ca\.crt}')
+
+          # Create ConfigMap in cert-manager namespace
+          kubectl create configmap internal-ca-bundle -n cert-manager --from-literal=ca.crt="$(echo $CA_DATA | base64 -d)" --dry-run=client -o yaml | kubectl apply -f -
+
+          # Get list of all namespaces and create ConfigMap in each
+          for ns in $(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}'); do
+            # Skip cert-manager namespace (already created)
+            if [ "$ns" != "cert-manager" ]; then
+              kubectl create configmap internal-ca-bundle -n $ns --from-literal=ca.crt="$(echo $CA_DATA | base64 -d)" --dry-run=client -o yaml | kubectl apply -f -
+              echo "Created ConfigMap in namespace: $ns"
+            fi
+          done
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: workdir
+          mountPath: /workdir
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      restartPolicy: OnFailure

--- a/k8s/infrastructure/controllers/cert-manager/internal-ca-issuer.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/internal-ca-issuer.yaml
@@ -1,0 +1,38 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: internal-ca-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-ca-certificate
+  namespace: cert-manager
+spec:
+  commonName: internal-ca
+  isCA: true
+  secretName: internal-ca-tls
+  subject:
+    organizations:
+      - homelab-internal-ca
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  issuerRef:
+    name: internal-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: internal-issuer
+spec:
+  ca:
+    secretName: internal-ca-tls

--- a/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - cert-manager-secrets-external.yaml
 - cloudflare-issuer.yaml
 - bitwarden-issuer.yaml
+- internal-ca-issuer.yaml
+- internal-ca-configmap.yaml

--- a/k8s/infrastructure/network/gateway/gw-internal.yaml
+++ b/k8s/infrastructure/network/gateway/gw-internal.yaml
@@ -9,13 +9,21 @@ spec:
     annotations:
       io.cilium/lb-ipam-ips: 10.25.150.220
   listeners:
-    - name: https
-      protocol: HTTPS
+    - protocol: HTTPS
       port: 443
-      # both apex and subdomains
-      hostnames:
-        - "pc-tips.se"
-        - "*.pc-tips.se"
+      name: https-gateway
+      hostname: "*.pc-tips.se"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cert-pc-tips
+      allowedRoutes:
+        namespaces:
+          from: All
+    - protocol: HTTPS
+      port: 443
+      name: https-domain-gateway
+      hostname: pc-tips.se
       tls:
         certificateRefs:
           - kind: Secret


### PR DESCRIPTION
- Introduced internal CA issuer for managing certificates
- Added certificates for argocd server, repo server, and application controller
- Configured volume mounts for internal CA bundle in argocd server and repo server
- Created a job to distribute the CA certificate as a ConfigMap