### PR TITLE
Enable Prometheus integration for Longhorn

### DIFF
--- a/k8s/infrastructure/storage/longhorn/http-route.yaml
+++ b/k8s/infrastructure/storage/longhorn/http-route.yaml
@@ -9,6 +9,7 @@ spec:
       namespace: gateway
   hostnames:
     - "longhorn.pc-tips.se"
+    - "longhorn-metrics.pc-tips.se"
   rules:
     - matches:
         - path:
@@ -17,3 +18,10 @@ spec:
       backendRefs:
         - name: longhorn-frontend
           port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /metrics
+      backendRefs:
+        - name: longhorn-metrics
+          port: 8080

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -52,7 +52,7 @@ metrics:
     enabled: true
     additionalLabels: {}
     annotations: {}
-    interval: ""
+    interval: "30s" # Default scrape interval. Override if needed.
     scrapeTimeout: ""
     relabelings: []
     metricRelabelings: []

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -46,3 +46,13 @@ longhornDriver:
 
 preUpgradeChecker:
   jobEnabled: false
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+    annotations: {}
+    interval: ""
+    scrapeTimeout: ""
+    relabelings: []
+    metricRelabelings: []

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -53,6 +53,6 @@ metrics:
     additionalLabels: {}
     annotations: {}
     interval: "30s" # Default scrape interval. Override if needed.
-    scrapeTimeout: ""
+    scrapeTimeout: "10s" # Default scrape timeout for Prometheus metrics
     relabelings: []
     metricRelabelings: []


### PR DESCRIPTION
Enable Prometheus ServiceMonitor and configure metrics settings for Longhorn.

* Set `metrics.serviceMonitor.enabled` to `true` in `k8s/infrastructure/storage/longhorn/values.yaml`
* Add `additionalLabels` and `annotations` under `metrics.serviceMonitor` in `k8s/infrastructure/storage/longhorn/values.yaml`
* Define `interval` and `scrapeTimeout` under `metrics.serviceMonitor` in `k8s/infrastructure/storage/longhorn/values.yaml`
* Add `relabelings` and `metricRelabelings` under `metrics.serviceMonitor` in `k8s/infrastructure/storage/longhorn/values.yaml`
* Add HTTPRoute for Prometheus exposure in `k8s/infrastructure/storage/longhorn/http-route.yaml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/485?shareId=e77427c0-9394-4a68-8ed5-a255dc1014c3).