### PR TITLE
refactor(k8s): remove trust-manager labels from namespaces

### DIFF
--- a/k8s/infrastructure/controllers/argocd/namespace.yaml
+++ b/k8s/infrastructure/controllers/argocd/namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: argocd
-  labels:
-    trust-manager.cert-manager.io/inject-trust: "true"
+

--- a/k8s/infrastructure/controllers/cert-manager/namespace.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
-  labels:
-    trust-manager.cert-manager.io/inject-trust: "true"
+

--- a/k8s/infrastructure/controllers/external-secrets/namespace.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: external-secrets
-  labels:
-    trust-manager.cert-manager.io/inject-trust: "true"
+

--- a/k8s/infrastructure/controllers/kustomization.yaml
+++ b/k8s/infrastructure/controllers/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
 - argocd
 - cert-manager
 - external-secrets
-- trust-manager

--- a/k8s/infrastructure/monitoring/prometheus-stack/namespace.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/namespace.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
-  labels:
-    trust-manager.cert-manager.io/inject-trust: "true"
+


### PR DESCRIPTION
- Eliminated trust-manager.cert-manager.io/inject-trust labels from argocd, cert-manager, external-secrets, and monitoring namespaces.
- Updated kustomization to remove trust-manager resource.