### PR TITLE
feat(k8s): add deployment, service, and external secret for pedro-bot

### DIFF
--- a/k8s/applications/web/pedrobot/deployment.yaml
+++ b/k8s/applications/web/pedrobot/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pedro-bot
+  namespace: pedro-bot
+  labels:
+    app: pedro-bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pedro-bot
+  template:
+    metadata:
+      labels:
+        app: pedro-bot
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: pedro-bot
+          image: your-registry/pedro-bot:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: es-pedro-bot-secrets
+          env:
+            - name: MONGO_URI
+              value: mongodb://mongodb:27017/pedro-bot
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: logs
+              mountPath: /app/logs
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: logs
+          hostPath:
+            path: /var/log/pedro-bot
+        - name: data
+          hostPath:
+            path: /etc/pedro-bot

--- a/k8s/applications/web/pedrobot/http-route.yaml
+++ b/k8s/applications/web/pedrobot/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pedro-bot
+  namespace: pedro-bot
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+    - name: external
+      namespace: gateway
+  hostnames:
+    - "pedro.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: pedro-bot
+          port: 3000

--- a/k8s/applications/web/pedrobot/kustomization.yaml
+++ b/k8s/applications/web/pedrobot/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - pedro-bot-external-secret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - http-route.yaml

--- a/k8s/applications/web/pedrobot/namespace.yaml
+++ b/k8s/applications/web/pedrobot/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pedro-bot

--- a/k8s/applications/web/pedrobot/pedro-bot-external-secret.yaml
+++ b/k8s/applications/web/pedrobot/pedro-bot-external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-pedro-bot-secrets
+  namespace: pedro-bot
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: es-pedro-bot-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DISCORD_TOKEN
+      remoteRef:
+        key: e799eef9-162b-4fbf-be96-b2cc00bcd612
+    - secretKey: CLIENT_ID
+      remoteRef:
+        key: 25373172-fca5-40fd-85df-b2cc00bcb73a
+    - secretKey: GUILD_ID
+      remoteRef:
+        key: 1f3fcdd4-5ae3-4001-be27-b2cc00bceb14

--- a/k8s/applications/web/pedrobot/pvc.yaml
+++ b/k8s/applications/web/pedrobot/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-data
+  namespace: pedro-bot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/k8s/applications/web/pedrobot/service.yaml
+++ b/k8s/applications/web/pedrobot/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: pedro-bot
+  labels:
+    app: mongodb
+spec:
+  type: ClusterIP
+  selector:
+    app: mongodb
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+      name: mongo

--- a/k8s/applications/web/pedrobot/values.yaml
+++ b/k8s/applications/web/pedrobot/values.yaml
@@ -1,0 +1,19 @@
+image:
+  repository: your-registry/pedro-bot
+  pullPolicy: IfNotPresent
+  tag: latest
+
+envFrom:
+  - secretRef:
+      name: es-pedro-bot-secrets
+
+service:
+  port:
+    port: 3000
+
+persistence:
+  mongo-data:
+    enabled: true
+    size: 5Gi
+    storageClass: longhorn
+    mountPath: /data/db

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -42,7 +42,7 @@ module "talos" {
     mac_address   = "bc:24:11:e6:ba:07"
     vm_id         = 8101
     cpu           = 6
-    ram_dedicated = 6150
+    ram_dedicated = 6144
     update        = false
     igpu          = false
   }
@@ -53,7 +53,7 @@ module "talos" {
     mac_address   = "bc:24:11:44:94:5c"
     vm_id         = 8102
     cpu           = 6
-    ram_dedicated = 6150
+    ram_dedicated = 6144
     update        = false
     igpu          = false
   }
@@ -64,7 +64,7 @@ module "talos" {
     mac_address   = "bc:24:11:1e:1d:2f"
     vm_id         = 8103
     cpu           = 6
-    ram_dedicated = 6150
+    ram_dedicated = 6144
     update        = false
   }
   "work-00" = {
@@ -74,7 +74,7 @@ module "talos" {
     mac_address   = "bc:24:11:64:5b:cb"
     vm_id         = 8201
     cpu           = 8
-    ram_dedicated = 6120
+    ram_dedicated = 7168
     update        = false
     disks = {
       longhorn = {
@@ -92,7 +92,7 @@ module "talos" {
     mac_address   = "bc:24:11:c9:22:c3"
     vm_id         = 8202
     cpu           = 8
-    ram_dedicated = 6120
+    ram_dedicated = 7168
     update        = false
     disks = {
       longhorn = {
@@ -110,7 +110,7 @@ module "talos" {
     mac_address   = "bc:24:11:6f:20:03"
     vm_id         = 8203
     cpu           = 8
-    ram_dedicated = 5120
+    ram_dedicated = 7168
     update        = false
     disks = {
       longhorn = {


### PR DESCRIPTION
- Introduced deployment configuration for pedro-bot with resource requests and limits
- Added service definition for MongoDB with appropriate ports
- Created external secret to manage sensitive data securely
- Defined HTTP route for traffic management
- Included persistent volume claim for MongoDB data storage
- Established namespace for pedro-bot application