### PR TITLE
fix(k8s): update jellyfin hostname and timezone configuration

### DIFF
--- a/k8s/applications/media/jellyfin/http-route.yaml
+++ b/k8s/applications/media/jellyfin/http-route.yaml
@@ -10,7 +10,7 @@ spec:
     - name: internal
       namespace: gateway
   hostnames:
-    - 'jellyfin.pc-tips.se'
+    - 'film.pc-tips.se'
   rules:
     - matches:
         - path:

--- a/k8s/applications/media/jellyfin/kustomization.yaml
+++ b/k8s/applications/media/jellyfin/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 configMapGenerator:
 - literals:
-  - TZ="Europe/Oslo"
+  - TZ="Europe/Stockholm"
   name: jellyfin-env
 
 namespace: media


### PR DESCRIPTION
- Changed hostname from 'jellyfin.pc-tips.se' to 'film.pc-tips.se'
- Updated timezone from 'Europe/Oslo' to 'Europe/Stockholm'