### PR TITLE
Prioritize critical pods without wasting cluster resources

### DIFF
--- a/k8s/infrastructure/common/kustomization.yaml
+++ b/k8s/infrastructure/common/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - base-network-policy.yaml
 - limit-range.yaml
 - control-plane-limit-range.yaml
+- ../scheduling/priorityclass.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/infrastructure/kustomization.yaml
+++ b/k8s/infrastructure/kustomization.yaml
@@ -20,3 +20,4 @@ components:
 - common/components/immutable-resources
 - common/components/container-images
 - common/components/configmap-validation
+- common/kustomization.yaml

--- a/k8s/infrastructure/network/cilium/values.yaml
+++ b/k8s/infrastructure/network/cilium/values.yaml
@@ -42,11 +42,12 @@ operator:
 rollOutCiliumPods: true
 resources:
   limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 100m
+    cpu: 200m
     memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  priorityClassName: system-critical
 
 #debug:
 #  enabled: true

--- a/k8s/infrastructure/network/coredns/deployment.yaml
+++ b/k8s/infrastructure/network/coredns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
                   - kube-dns
               topologyKey: kubernetes.io/hostname
       serviceAccountName: coredns
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-critical
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -49,8 +49,8 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              cpu: 200m
-              memory: 170Mi
+              cpu: 100m
+              memory: 70Mi
             requests:
               cpu: 100m
               memory: 70Mi

--- a/k8s/infrastructure/scheduling/priorityclass.yaml
+++ b/k8s/infrastructure/scheduling/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: system-critical
+value: 1000000
+globalDefault: false
+description: "Priority for Cilium, CoreDNS, Longhorn and essential networking/storage components"

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -7,42 +7,42 @@ csi:
   plugin:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 250m
+        memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 256Mi
   provisioner:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 250m
+        memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 256Mi
   attacher:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 250m
+        memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 256Mi
   resizer:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 250m
+        memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 256Mi
   snapshotter:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 250m
+        memory: 256Mi
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 256Mi
 
 defaultSettings:
@@ -69,23 +69,21 @@ persistence:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 200m
+    cpu: 250m
     memory: 256Mi
-
-
+  limits:
+    cpu: 250m
+    memory: 256Mi
 
 service:
   ui:
     type: ClusterIP
 
 longhornManager:
-  priorityClass: system-cluster-critical
+  priorityClass: system-critical
 
 longhornDriver:
-  priorityClass: system-cluster-critical
+  priorityClass: system-critical
 
 preUpgradeChecker:
   jobEnabled: false


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/524?shareId=dcf598aa-5236-4aa6-9988-76039198872d).