### PR TITLE
fix(k8s): update jellyseerr and omada configurations for port changes

### DIFF
--- a/k8s/applications/media/jellyseerr/http-route.yaml
+++ b/k8s/applications/media/jellyseerr/http-route.yaml
@@ -10,7 +10,7 @@ spec:
     - name: internal
       namespace: gateway
   hostnames:
-    - "jellyseerr.pc-tips.se"
+    - "ansok.pc-tips.se"
   rules:
     - matches:
         - path:

--- a/k8s/infrastructure/network/omada/deployment.yaml
+++ b/k8s/infrastructure/network/omada/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         image: envoyproxy/envoy:v1.34-latest
         args: ["-c", "/etc/envoy/envoy.yaml"]
         ports:
-        - {containerPort: 8080}
+        - {containerPort: 8088}
         volumeMounts:
         - {name: envoy-config, mountPath: /etc/envoy}
       volumes:
@@ -58,4 +58,3 @@ spec:
       - {name: omada-logs, persistentVolumeClaim: {claimName: omada-logs-pvc}}
       - {name: omada-cert, secret: {secretName: cert-omada}}
       - {name: envoy-config, configMap: {name: envoy-config}}
-      restartPolicy: Always

--- a/k8s/infrastructure/network/omada/envoy-config.yaml
+++ b/k8s/infrastructure/network/omada/envoy-config.yaml
@@ -14,7 +14,7 @@ data:
         - filters:
           - name: envoy.filters.network.http_connection_manager
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: ingress_http
               route_config:
                 name: local_route
@@ -26,6 +26,8 @@ data:
                     route: {cluster: backend_service_https}
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
       - name: backend_service_https
         connect_timeout: 5s
@@ -41,8 +43,7 @@ data:
         transport_socket:
           name: envoy.transport_sockets.tls
           typed_config:
-            "@type": type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
             common_tls_context:
               validation_context:
-                trusted_ca:
-                  filename: /etc/ssl/certs/ca-certificates.crt
+                trust_chain_verification: ACCEPT_UNTRUSTED

--- a/k8s/infrastructure/network/omada/tls-route.yaml
+++ b/k8s/infrastructure/network/omada/tls-route.yaml
@@ -11,4 +11,4 @@ spec:
   rules:
   - backendRefs:
     - name: omada-svc
-      port: 8080
+      port: 8088


### PR DESCRIPTION
- Changed jellyseerr hostname to "ansok.pc-tips.se"
- Updated omada container port from 8080 to 8088
- Adjusted envoy configuration to use the new port 8088
- Modified tls-route to reflect the updated backend port