### PR TITLE
perf(k8s): increase resource limits for omada-controller deployment

### DIFF
--- a/k8s/infrastructure/network/omada/deployment.yaml
+++ b/k8s/infrastructure/network/omada/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - ALL
         resources:
           requests: {cpu: 100m, memory: 512Mi}
-          limits:   {cpu: 500m, memory: 1Gi}
+          limits:   {cpu: 750m, memory: 2Gi}
         env:
         - name: ROOTLESS
           value: "true"


### PR DESCRIPTION
- Updated CPU limit from 500m to 750m
- Updated memory limit from 1Gi to 2Gi