### PR TITLE
feat(k8s): update Bazarr deployment to use new configMap reference

### DIFF
--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -40,9 +40,8 @@ spec:
               containerPort: 6767
               protocol: TCP
           envFrom:
-            - configMapRef:
-                name: common-env
-                optional: true
+          - configMapRef:
+              name: bazarr-env
           volumeMounts:
             - name: bazarr-config
               mountPath: /config

--- a/k8s/applications/media/arr/bazarr/kustomization.yaml
+++ b/k8s/applications/media/arr/bazarr/kustomization.yaml
@@ -6,3 +6,13 @@ resources:
 - svc.yaml
 - http-route.yaml
 - deployment.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: bazarr-env
+  literals:
+    - PUID=2501
+    - PGID=2501
+    - TZ=Europe/Stockholm

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -13,8 +13,6 @@ spec:
       labels:
         app: sabnzbd
     spec:
-      nodeSelector:
-        fileserv: "true"
       containers:
       - name: sabnzbd
         image: sabnzbd/sabnzbd


### PR DESCRIPTION
- Changed configMap reference from 'common-env' to 'bazarr-env'
- Removed unnecessary nodeSelector from Sabnzbd deployment