### PR TITLE
feat(k8s): add automation and MQTT configurations

### DIFF
--- a/k8s/applications/application-set.yaml
+++ b/k8s/applications/application-set.yaml
@@ -20,6 +20,7 @@ spec:
           - path: k8s/applications/external
           - path: k8s/applications/web
           - path: k8s/applications/network
+          - path: k8s/applications/automation
   template:
     metadata:
       name: 'apps-{{ path.basename }}'

--- a/k8s/applications/automation/frigate/externalsecret.yaml
+++ b/k8s/applications/automation/frigate/externalsecret.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: frigate-rstp-credentials
+  namespace: frigate
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: frigate-rstp-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: FRIGATE_RTSP_USERNAME
+      remoteRef:
+        key: 191e2a17-e7fe-4abb-b061-b2d4013c77e8
+    - secretKey: FRIGATE_RTSP_PASSWORD
+      remoteRef:
+        key: 78361026-625e-4166-9352-b2d4013c9b78
+    - secretKey: FRIGATE_RTSP_SUB
+      remoteRef:
+        key: 34890eb6-91fc-49ff-bd76-b2d40138fa28
+    - secretKey: FRIGATE_RTSP_MAIN
+      remoteRef:
+        key: 8b20e489-2fb0-457a-af15-b2d40139d025
+    - secretKey: FRIGATE_ONVIF
+      remoteRef:
+        key: 83a74433-75d5-40d6-9616-b2d4013b3685
+    - secretKey: FRIGATE_MQTT_PASSWORD
+      remoteRef:
+        key: e60a8c39-80ad-4e8c-8869-b2d401149702

--- a/k8s/applications/automation/frigate/http-route.yaml
+++ b/k8s/applications/automation/frigate/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frigate
+  namespace: frigate
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "frigate.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frigate
+          port: 5000

--- a/k8s/applications/automation/frigate/kustomization.yaml
+++ b/k8s/applications/automation/frigate/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: frigate
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - http-route.yaml
+
+configMapGenerator:
+- name: frigate-env
+  literals:
+    - TZ=Europe/Stockholm
+
+helmCharts:
+  - name: frigate
+    repo: https://blakeblackshear.github.io/blakeshome-charts/
+    version: 7.3.0
+    releaseName: frigate
+    namespace: frigate
+    valuesFile: values.yaml
+
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/applications/automation/frigate/namespace.yaml
+++ b/k8s/applications/automation/frigate/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frigate

--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -1,0 +1,279 @@
+# Default values for frigate.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
+image:
+  # -- Docker registry/repository to pull the image from
+  repository: ghcr.io/blakeblackshear/frigate
+  # -- Overrides the default tag (appVersion) used in Chart.yaml ([Docker Hub](https://hub.docker.com/r/blakeblackshear/frigate/tags?page=1))
+  tag: 0.13.1
+  # -- Docker image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Docker image pull policy
+imagePullSecrets: []
+
+# -- additional ENV variables to set. Prefix with FRIGATE_ to target Frigate configuration values
+env:
+  # TZ: UTC
+
+# -- set environment variables from Secret(s)
+envFromSecrets:
+  # secrets are required before `helm install`
+  - frigate-rstp-credentials
+
+coral:
+  # -- enables the use of a Coral device
+  enabled: false
+  # -- path on the host to which to mount the Coral device
+  hostPath: /dev/bus/usb
+
+gpu:
+  nvidia:
+    # -- Enables NVIDIA GPU compatibility. Must also use the "amd64nvidia" tagged image
+    enabled: false
+
+    # -- Overrides the default runtimeClassName
+    runtimeClassName:
+
+# -- declare extra volumes to use for Frigate
+extraVolumes: []
+# -- declare additional volume mounts
+extraVolumeMounts: []
+
+# -- amount of shared memory to use for caching
+shmSize: 1Gi
+
+# -- use memory for tmpfs (mounted to /tmp)
+tmpfs:
+  enabled: true
+  sizeLimit: 1Gi
+
+# nameOverride -- Overrides the name of resources
+nameOverride: ""
+
+# fullnameOverride -- Overrides the Full Name of resources
+fullnameOverride: ""
+
+# -- frigate configuration - see [Docs](https://docs.frigate.video/configuration/index) for more info
+config: |
+  mqtt:
+    host: mosquitto.mqtt.svc.kube.pc-tips.se
+    port: 1883
+    topic_prefix: frigate
+    client_id: frigate
+    user: mqtt_user
+    password: '{FRIGATE_MQTT_PASSWORD}'
+    stats_interval: 60
+
+  detectors:
+    cpu1:
+      type: cpu
+
+  go2rtc:
+    streams:
+      reolink:
+        - "{FRIGATE_RTSP_MAIN}"
+        - "{FRIGATE_RTSP_SUB}"
+        - "{FRIGATE_ONVIF}"
+
+  cameras:
+    sovrum:
+      ffmpeg:
+        inputs:
+          - path: "{FRIGATE_RTSP_MAIN}"
+            roles:
+              - detect
+              - rtmp
+              - record
+            input_args:
+              - -rtsp_transport
+              - tcp
+              - -timeout
+              - '5000000'
+        output_args:
+          record: -f segment -segment_time 60 -reset_timestamps 1 -strftime 1 -c copy
+      detect:
+        enabled: true
+      record:
+        enabled: true
+        retain:
+          days: 3
+        events:
+          retain:
+            default: 20
+      onvif:
+        host: 192.168.16.186
+        port: 8000
+        user: "{FRIGATE_RTSP_USERNAME}"
+        password: "{FRIGATE_RTSP_PASSWORD}"
+
+
+
+
+# Probes configuration
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+  readiness:
+    enabled: true
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+  startup:
+    enabled: false
+    failureThreshold: 30
+    periodSeconds: 10
+
+service:
+  # -- Type of Service to use
+  type: ClusterIP
+  # -- Port the Service should communicate on
+  port: 5000
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  labels: {}
+
+  # -- Set specific IP address for LoadBalancer. `service.type` must be set to `LoadBalancer`
+  loadBalancerIP:
+
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
+  # default IP family to use for the service
+  ipFamilyPolicy: SingleStack
+  # ipFamilies for service
+  ipFamilies: []
+
+ingress:
+  # -- Enables the use of an Ingress Controller to front the Service and can provide HTTPS
+  enabled: false
+
+persistence:
+  data:
+    # Data directory is obsolete. Use config and media instead.
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    skipuninstall: false
+
+  config:
+    # -- Enables persistence for the config directory
+    enabled: true
+    ## frigate data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+
+    # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC
+    accessMode: ReadWriteOnce
+
+    # -- size/capacity of the PVC
+    size: 100Mi
+
+    # -- Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
+    ## Copy configMap config into volume to make writable
+    ## All live changes are lost when pod restarts, but this allows
+    ## an easy way to run migrations and edit config, then scrape
+    ## it from the API or copy out of the pod and update local helm values
+    ephemeralWritableConfigYaml: true
+
+  media:
+    # -- Enables persistence for the media directory
+    enabled: true
+    ## frigate data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+
+    # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to use for the PVC
+    accessMode: ReadWriteOnce
+
+    # -- size/capacity of the PVC
+    size: 10Gi
+
+    # -- Do not delete the pvc upon helm uninstall
+    skipuninstall: false
+
+# -- Set resource limits/requests for the Pod(s)
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #   gpu.intel.com/i915: 1
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #   gpu.intel.com/i915: 1
+
+# -- Set Frigate Container Security Context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # privileged: true
+
+# -- Set Pod level Security Context
+# -- the container level securiy context defined above
+# -- will override it for frigate container
+podSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # fsGroup: 1000
+  # privileged: true
+
+# -- Node Selector configuration
+nodeSelector: {}
+
+# -- Node toleration configuration
+tolerations: []
+
+# -- Set Pod affinity rules
+affinity: {}
+
+# -- Set additonal pod Annotations
+podAnnotations: {}
+
+# -- Define extra init containers
+extraInitContainers: []

--- a/k8s/applications/automation/kustomization.yaml
+++ b/k8s/applications/automation/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- project.yaml
+- frigate
+- mqtt

--- a/k8s/applications/automation/mqtt/configmap.yaml
+++ b/k8s/applications/automation/mqtt/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosquitto-config
+  namespace: mqtt
+data:
+  mosquitto.conf: |
+    listener 1883
+    allow_anonymous false
+    password_file /mosquitto/config/password.txt

--- a/k8s/applications/automation/mqtt/deployment.yaml
+++ b/k8s/applications/automation/mqtt/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mosquitto
+  namespace: mqtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mosquitto
+  template:
+    metadata:
+      labels:
+        app: mosquitto
+    spec:
+      containers:
+        - name: mosquitto
+          image: eclipse-mosquitto:2.0
+          volumeMounts:
+            - name: config
+              mountPath: /mosquitto/config
+          ports:
+            - containerPort: 1883
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: mosquitto-config
+              - secret:
+                  name: mosquitto-password

--- a/k8s/applications/automation/mqtt/externalsecret.yaml
+++ b/k8s/applications/automation/mqtt/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mosquitto-password
+  namespace: mqtt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: mosquitto-password
+    creationPolicy: Owner
+  data:
+    - secretKey: password.txt
+      remoteRef:
+        key: 186f58c7-f967-4be9-b912-b2d40142d2a7

--- a/k8s/applications/automation/mqtt/kustomization.yaml
+++ b/k8s/applications/automation/mqtt/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mqtt
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/applications/automation/mqtt/namespace.yaml
+++ b/k8s/applications/automation/mqtt/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mqtt

--- a/k8s/applications/automation/mqtt/service.yaml
+++ b/k8s/applications/automation/mqtt/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto
+  namespace: mqtt
+spec:
+  selector:
+    app: mosquitto
+  ports:
+    - protocol: TCP
+      port: 1883
+      targetPort: 1883
+  type: ClusterIP

--- a/k8s/applications/automation/project.yaml
+++ b/k8s/applications/automation/project.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: automation
+  namespace: argocd
+spec:
+  sourceRepos:
+    - 'https://github.com/theepicsaxguy/homelab'
+  destinations:
+    - namespace: 'frigate'
+      server: '*'
+    - namespace: 'mqtt'
+      server: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -54,7 +54,9 @@ deployment:
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
     - name: KUBECHECKS_SCHEMAS_LOCATION
-      value: "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/release-1.0/config/crd/standard,https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.76.0/example/prometheus-operator-crd"
+      value: |
+        - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/release-1.0/config/crd/standard
+        - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.76.0/example/prometheus-operator-crd
   volumes:
     - name: home
       emptyDir: {}

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -53,6 +53,8 @@ deployment:
       value: "true"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
+    - name: KUBECHECKS_SCHEMAS_LOCATION
+      value: "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/release-1.0/config/crd/standard,https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.76.0/example/prometheus-operator-crd"
   volumes:
     - name: home
       emptyDir: {}


### PR DESCRIPTION
Introduce an automation application with external secrets and HTTP routes, along with MQTT configurations including deployment, service, and external secrets. Add schemas location for gateway API and Prometheus CRDs to enhance integration capabilities.