### PR TITLE
Fix(authentik)--update-secret-key-references-in-ExternalSecret-configuration

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -106,9 +106,14 @@ config: |
           record: -f segment -segment_time 60 -reset_timestamps 1 -strftime 1 -c copy
       detect:
         enabled: true
-        width: 640
-        height: 360
-        fps: 5
+        max_disappeared: 25
+      objects:
+        track:
+          - person
+          - dog
+      motion:
+        threshold: 25
+        contour_area: 40
       record:
         enabled: true
         retain:
@@ -116,11 +121,18 @@ config: |
         events:
           retain:
             default: 20
+      snapshots:
+        enabled: true
+        retain:
+          default: 5
       onvif:
         host: 192.168.16.186
         port: 8000
         user: "{FRIGATE_RTSP_USERNAME}"
         password: "{FRIGATE_RTSP_PASSWORD}"
+      rtmp:
+        enabled: true
+      name: sovrum_camera
 
 
 # Probes configuration

--- a/k8s/infrastructure/auth/authentik/externalsecret.yaml
+++ b/k8s/infrastructure/auth/authentik/externalsecret.yaml
@@ -1,4 +1,3 @@
-# 1) ExternalSecret: pull _all_ the keys you need
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -13,21 +12,30 @@ spec:
     name: authentik-combined-secret
     creationPolicy: Owner
   data:
-    - secretKey: secret_key
+    # Authentik configuration env vars
+    - secretKey: SECRET_KEY
       remoteRef:
         key: 49416301-9093-4c1d-b713-b2d500632388
+    - secretKey: BOOTSTRAP_PASSWORD
+      remoteRef:
+        key: a72fef1f-af7f-4c92-889c-b2d500f9a2c1
+    - secretKey: BOOTSTRAP_TOKEN
+      remoteRef:
+        key: 1c460c2a-c0e7-4a93-8a0f-b2d301342555
+    - secretKey: BOOTSTRAP_EMAIL
+      remoteRef:
+        key: f00c9b32-da26-4dee-8cbf-b2d500f6fd2b
+    - secretKey: POSTGRESQL_PASSWORD
+      remoteRef:
+        key: 145b2bd7-fa15-4fee-99a3-b2d5006372d1
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: cb26a5a7-3a42-425d-98cd-b2d500f984e7
+
+    # Bitnami sub-chart keys
     - secretKey: postgresql_password
       remoteRef:
         key: 145b2bd7-fa15-4fee-99a3-b2d5006372d1
     - secretKey: redis_password
       remoteRef:
         key: cb26a5a7-3a42-425d-98cd-b2d500f984e7
-    - secretKey: bootstrap_password
-      remoteRef:
-        key: a72fef1f-af7f-4c92-889c-b2d500f9a2c1
-    - secretKey: bootstrap_token
-      remoteRef:
-        key: 1c460c2a-c0e7-4a93-8a0f-b2d301342555
-    - secretKey: bootstrap_email
-      remoteRef:
-        key: f00c9b32-da26-4dee-8cbf-b2d500f6fd2b

--- a/k8s/infrastructure/auth/authentik/values.yaml
+++ b/k8s/infrastructure/auth/authentik/values.yaml
@@ -1,24 +1,21 @@
-# 0) Inject all six keys into every Pod via envFrom
 global:
   envFrom:
     - secretRef:
         name: authentik-combined-secret
 
-# 1) Authentik’s own config secret
 authentik:
-  # Tell Authentik to read its SECRET_KEY from this env var
-  secret_key: env://AUTHENTIK_SECRET_KEY
-
-  # Tell Authentik’s bootstrap step to read these from env vars
+  secret_key: env://SECRET_KEY
   bootstrap:
-    password: env://AUTHENTIK_BOOTSTRAP_PASSWORD
-    token:   env://AUTHENTIK_BOOTSTRAP_TOKEN
-    email:   env://AUTHENTIK_BOOTSTRAP_EMAIL
-
+    password: env://BOOTSTRAP_PASSWORD
+    token:   env://BOOTSTRAP_TOKEN
+    email:   env://BOOTSTRAP_EMAIL
+  postgresql:
+    password: env://POSTGRESQL_PASSWORD
+  redis:
+    password: env://REDIS_PASSWORD
   error_reporting:
     enabled: true
 
-# 2) Postgres sub‑chart (no mounts at all)
 postgresql:
   enabled: true
   auth:
@@ -26,7 +23,6 @@ postgresql:
     secretKeys:
       adminPasswordKey: postgresql_password
 
-# 3) Redis sub‑chart
 redis:
   enabled: true
   auth:
@@ -34,7 +30,6 @@ redis:
     existingSecretPasswordKey: redis_password
     usePasswordFile: false
 
-# 4) Ensure both server & worker blocks exist
 server:
   enabled: true
   ingress:

--- a/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
@@ -14,7 +14,7 @@ spec:
   data:
     - secretKey: github_token
       remoteRef:
-        key: 2594d160-f36f-4877-95c6-b29000c0ae0f
+        key: 7ecb4650-ab7a-42f7-b9d1-b2d501183924
     - secretKey: argocd_api_token
       remoteRef:
         key: 0d2a2732-db70-49b7-b64a-b29400a92230

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -56,7 +56,7 @@ deployment:
     - name: KUBECHECKS_SCHEMAS_LOCATION
       value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
     - name: KUBECHECKS_GITHUB_APP_ID
-      value: 1243453
+      value: "1243453"
     - name: KUBECHECKS_GITHUB_INSTALLATION_ID
       value: 65970314
     - name: KUBECHECKS_GITHUB_PRIVATE_KEY

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -58,7 +58,7 @@ deployment:
     - name: KUBECHECKS_GITHUB_APP_ID
       value: "1243453"
     - name: KUBECHECKS_GITHUB_INSTALLATION_ID
-      value: 65970314
+      value: "65970314"
     - name: KUBECHECKS_GITHUB_PRIVATE_KEY
       valueFrom:
         secretKeyRef:

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -33,28 +33,37 @@ deployment:
           key: webhook_hmac
     - name: KUBECHECKS_VCS_TYPE
       value: "github"
-    - name: KUBECHECKS_VCS_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: kubechecks-combined-secret
-          key: github_token
+    # - name: KUBECHECKS_VCS_TOKEN
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: kubechecks-combined-secret
+    #       key: github_token
     - name: KUBECHECKS_ARGOCD_API_TOKEN
       valueFrom:
         secretKeyRef:
           name: kubechecks-combined-secret
           key: argocd_api_token
     - name: KUBECHECKS_ARGOCD_API_INSECURE
-      value: "true"                                    # Skip certificate verification for internal service
+      value: "true"
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
       value: "argocd-server.argocd.svc.kube.pc-tips.se"
     - name: KUBECHECKS_ARGOCD_API_PLAINTEXT
-      value: "true"                                  # Use HTTPS since we're doing direct service communication
+      value: "true"
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE
       value: "true"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
     - name: KUBECHECKS_SCHEMAS_LOCATION
       value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+    - name: KUBECHECKS_GITHUB_APP_ID
+      value: 1243453
+    - name: KUBECHECKS_GITHUB_INSTALLATION_ID
+      value: 65970314
+    - name: KUBECHECKS_GITHUB_PRIVATE_KEY
+      valueFrom:
+        secretKeyRef:
+          name: kubechecks-combined-secret
+          key: github_token
   volumes:
     - name: home
       emptyDir: {}


### PR DESCRIPTION
- Moved to using envFrom for injecting secrets into Pods
- Updated Authentik configuration to read secrets from environment variables
- Ensured consistency in secret references across the configuration