### PR TITLE
Update values.yaml

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -132,7 +132,6 @@ config: |
         password: "{FRIGATE_RTSP_PASSWORD}"
       rtmp:
         enabled: true
-      name: sovrum_camera
 
 
 # Probes configuration


### PR DESCRIPTION
This pull request includes a minor change in the `k8s/applications/automation/frigate/values.yaml` file. The change removes the `name` field (`sovrum_camera`) under the `rtmp` configuration, possibly because it was unnecessary or redundant.