### PR TITLE
chore(k8s): remove sabnzbd-downloads volume mounts from deployments

### DIFF
--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -44,8 +44,6 @@ spec:
               mountPath: /config
             - name: data
               mountPath: /data
-            - name: sabnzbd-downloads
-              mountPath: /downloads/complete
           resources:
             requests:
               cpu: 50m
@@ -60,6 +58,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: media-share
-        - name: sabnzbd-downloads
-          persistentVolumeClaim:
-            claimName: sabnzbd-downloads

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -49,8 +49,6 @@ spec:
               mountPath: /tmp
             - name: data
               mountPath: /app/data
-            - name: sabnzbd-downloads
-              mountPath: /downloads/complete
           resources:
             requests:
               cpu: 50m
@@ -67,6 +65,3 @@ spec:
             claimName: media-share
         - name: tmp
           emptyDir: { }
-        - name: sabnzbd-downloads
-          persistentVolumeClaim:
-            claimName: sabnzbd-downloads

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -49,8 +49,6 @@ spec:
               mountPath: /tmp
             - name: data
               mountPath: /app/data
-            - name: sabnzbd-downloads
-              mountPath: /downloads/complete
           resources:
             requests:
               cpu: 50m
@@ -67,6 +65,3 @@ spec:
             claimName: media-share
         - name: tmp
           emptyDir: { }
-        - name: sabnzbd-downloads
-          persistentVolumeClaim:
-            claimName: sabnzbd-downloads


### PR DESCRIPTION
Eliminate the sabnzbd-downloads volume mounts from the Kubernetes deployments to streamline configuration and reduce unnecessary complexity.