### PR TITLE
chore(k8s): update mount paths for data volumes in deployments

### DIFF
--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: bazarr-config
               mountPath: /config
             - name: data
-              mountPath: /data
+              mountPath: /app/data
           resources:
             requests:
               cpu: 50m

--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: config
               mountPath: /config
             - name: media
-              mountPath: /mnt/media
+              mountPath: /app/data
             - name: cache
               mountPath: /cache
       volumes:

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: sabnzbd-config
           mountPath: /config
         - name: media-share
-          mountPath: /downloads/complete
+          mountPath: /app/data
         - name: sabnzbd-incomplete
           mountPath: /downloads/incomplete
       volumes:


### PR DESCRIPTION
- Changed mountPath for bazarr from /data to /app/data
- Changed mountPath for jellyfin from /mnt/media to /app/data
- Changed mountPath for sabnzbd from /downloads/complete to /app/data