### PR TITLE
chore(k8s): update container images for bazarr, prowlarr, radarr, sonarr, and jellyfin

### DIFF
--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         topology.kubernetes.io/zone: host3
       containers:
         - name: bazarr
-          image: ghcr.io/hotio/bazarr:latest
+          image: ghcr.io/hotio/bazarr:release-1.5.1
           ports:
             - name: http
               containerPort: 6767

--- a/k8s/applications/media/arr/prowlarr/deployment.yaml
+++ b/k8s/applications/media/arr/prowlarr/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: prowlarr
-          image: ghcr.io/onedr0p/prowlarr:1.32.2 # renovate: docker=ghcr.io/onedr0p/prowlarr
+          image: ghcr.io/onedr0p/prowlarr:1.32.2
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: radarr
-          image: ghcr.io/onedr0p/radarr:5.19.3 # renovate: docker=ghcr.io/onedr0p/radarr
+          image: ghcr.io/onedr0p/radarr:5.19.3
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sonarr
-          image: ghcr.io/onedr0p/sonarr:4.0.13 # renovate: docker=ghcr.io/onedr0p/sonarr
+          image: ghcr.io/onedr0p/sonarr:4.0.13
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: jellyfin
-          image: ghcr.io/jellyfin/jellyfin:10.10.7 # renovate: docker=ghcr.io/jellyfin/jellyfin
+          image: ghcr.io/jellyfin/jellyfin:10.10.7
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
- Updated bazarr image to release-1.5.1
- Updated prowlarr image to 1.32.2
- Updated radarr image to 5.19.3
- Updated sonarr image to 4.0.13
- Updated jellyfin image to 10.10.7