### PR TITLE
feat(k8s): update frigate HTTPRoute and add Authentik Outpost configuration

### DIFF
--- a/k8s/applications/automation/frigate/http-route.yaml
+++ b/k8s/applications/automation/frigate/http-route.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: frigate
+  name: frigate-protected
   namespace: frigate
 spec:
   parentRefs:
@@ -15,5 +15,5 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: frigate
-          port: 5000
+        - name: authentik-outpost
+          port: 9000

--- a/k8s/infrastructure/auth/authentik/README.md
+++ b/k8s/infrastructure/auth/authentik/README.md
@@ -1,0 +1,61 @@
+# Authentik Proxy Outpost for Kubernetes
+
+## Why this setup?
+
+- **Single point of authentication**: One Outpost handles auth for multiple internal apps.
+- **Simplified management**: Add new protected apps without deploying additional components.
+- **Consistent security**: All apps use the same authentication flow and policies.
+
+## What this does
+
+This deploys an Authentik Proxy Outpost as a central authentication proxy for our Kubernetes cluster. It:
+
+1. Runs as a Deployment with an associated Service.
+2. Integrates with our Gateway API setup for routing.
+3. Authenticates users before allowing access to protected apps.
+
+## Adding a new protected app
+
+1. **In Authentik UI**:
+   - Create a new Proxy Provider
+   - Set External Host (e.g., `app.domain.com`)
+   - Set internal Upstream URL (e.g., `http://internal-service:8080`)
+   - Create an Application using this Provider
+
+2. **Add an HTTPRoute**:
+   ```yaml
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: HTTPRoute
+   metadata:
+     name: my-new-app
+     namespace: apps
+   spec:
+     parentRefs:
+       - name: internal
+         namespace: gateway
+     hostnames:
+       - "app.domain.com"
+     rules:
+       - matches:
+           - path:
+               type: PathPrefix
+               value: /
+         backendRefs:
+           - name: authentik-outpost
+             port: 9000
+   ```
+
+3. **Ensure internal app isn't directly exposed**:
+   - Remove any existing Ingress/HTTPRoute for the app
+   - Keep the app's Service internal (ClusterIP)
+
+## Why this works
+
+- All external traffic to `app.domain.com` goes through the Outpost
+- Outpost handles auth, then proxies to the internal service
+- Internal services remain unexposed, adding security
+
+## Maintenance notes
+
+- Update the Outpost image version periodically
+- Token in `authentik-outpost-api` Secret may need rotation (check Authentik docs for best practices)

--- a/k8s/infrastructure/auth/authentik/externalsecret.yaml
+++ b/k8s/infrastructure/auth/authentik/externalsecret.yaml
@@ -69,6 +69,3 @@ spec:
     - secretKey: AUTHENTIK_BOOTSTRAP_EMAIL
       remoteRef:
         key: f00c9b32-da26-4dee-8cbf-b2d500f6fd2b
-
-
-

--- a/k8s/infrastructure/auth/authentik/kustomization.yaml
+++ b/k8s/infrastructure/auth/authentik/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - externalsecret.yaml
   - database.yaml
   - httproute.yaml
+  - outpost.yaml
 
 configMapGenerator:
   - name: authentik-blueprints

--- a/k8s/infrastructure/auth/authentik/outpost.yaml
+++ b/k8s/infrastructure/auth/authentik/outpost.yaml
@@ -1,0 +1,99 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-outpost-api
+  namespace: auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: authentik-outpost-api
+    creationPolicy: Owner
+  data:
+    - secretKey: authentik_host
+      remoteRef:
+        key: 286314ab-6f56-4371-9e31-b2d800e2bdc1
+    - secretKey: authentik_host_insecure
+      remoteRef:
+        key: 0556c078-be92-494a-94e1-b2d800e2fac8
+    - secretKey: token
+      remoteRef:
+        key: 8d257027-d623-4781-8079-b2d800e3e8d6
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxy-outpost
+    app.kubernetes.io/managed-by: goauthentik.io
+    app.kubernetes.io/name: authentik-proxy
+    app.kubernetes.io/version: 2021.12.3
+  name: authentik-outpost
+spec:
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 9443
+      protocol: TCP
+      targetPort: https
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/managed-by: goauthentik.io
+    app.kubernetes.io/name: authentik-outpost
+    app.kubernetes.io/instance: proxy-outpost
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxy-outpost
+    app.kubernetes.io/managed-by: goauthentik.io
+    app.kubernetes.io/name: authentik-proxy
+    app.kubernetes.io/version: 2021.12.3
+  name: authentik-outpost
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: proxy-outpost
+      app.kubernetes.io/managed-by: goauthentik.io
+      app.kubernetes.io/name: authentik-proxy
+      app.kubernetes.io/version: 2021.12.3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: proxy-outpost
+        app.kubernetes.io/managed-by: goauthentik.io
+        app.kubernetes.io/name: authentik-proxy
+        app.kubernetes.io/version: 2021.12.3
+    spec:
+      containers:
+        - name: proxy
+          image: ghcr.io/goauthentik/proxy
+          ports:
+            - containerPort: 9000
+              name: http
+              protocol: TCP
+            - containerPort: 9443
+              name: https
+              protocol: TCP
+          env:
+            - name: AUTHENTIK_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: authentik_host
+                  name: authentik-outpost-api
+            - name: AUTHENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: token
+                  name: authentik-outpost-api
+            - name: AUTHENTIK_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  key: authentik_host_insecure
+                  name: authentik-outpost-api

--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,12 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    "config:recommended",
     ":enablePreCommit",
     "docker:enableMajor",
     ":automergePatch",
     ":automergeMinor",
     "mergeConfidence:all-badges"
   ],
-  "platform": "github",
-  "onboarding": false,
-  "requireConfig": "optional",
   "dependencyDashboard": true,
   "kustomize": {
     "managerFilePatterns": ["/(^|/)kustomization\\.ya?ml(\\.j2)?$/"]

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -10,13 +10,13 @@ module "talos" {
 
 
   image = {
-    version = "v1.9.5"
+    version        = "v1.9.5"
     update_version = "v1.10.1" # renovate: github-releases=siderolabs/talos
-    schematic = file("${path.module}/talos/image/schematic.yaml")
+    schematic      = file("${path.module}/talos/image/schematic.yaml")
   }
 
   cilium = {
-    values = file("${path.module}/../k8s/infrastructure/network/cilium/values.yaml")
+    values  = file("${path.module}/../k8s/infrastructure/network/cilium/values.yaml")
     install = file("${path.module}/talos/inline-manifests/cilium-install.yaml")
   }
 
@@ -25,102 +25,102 @@ module "talos" {
   }
 
   cluster = {
-    name            = "talos"
-    endpoint        = "api.kube.pc-tips.se"
-    gateway         = "10.25.150.1"     # Network gateway
-    vip             = "10.25.150.10"    # Control plane VIP
-    talos_version   = "v1.9.5"
-    proxmox_cluster = "kube"
-    kubernetes_version = "1.33.0"  # renovate: github-releases=kubernetes/kubernetes
+    name               = "talos"
+    endpoint           = "api.kube.pc-tips.se"
+    gateway            = "10.25.150.1"  # Network gateway
+    vip                = "10.25.150.10" # Control plane VIP
+    talos_version      = "v1.9.5"
+    proxmox_cluster    = "kube"
+    kubernetes_version = "1.33.0" # renovate: github-releases=kubernetes/kubernetes
   }
 
   nodes = {
-  "ctrl-00" = {
-    host_node     = "host3"
-    machine_type  = "controlplane"
-    ip            = "10.25.150.11"
-    mac_address   = "bc:24:11:e6:ba:07"
-    vm_id         = 8101
-    cpu           = 6
-    ram_dedicated = 6144
-    update        = false
-    igpu          = false
-  }
-  "ctrl-01" = {
-    host_node     = "host3"
-    machine_type  = "controlplane"
-    ip            = "10.25.150.12"
-    mac_address   = "bc:24:11:44:94:5c"
-    vm_id         = 8102
-    cpu           = 6
-    ram_dedicated = 6144
-    update        = false
-    igpu          = false
-  }
-  "ctrl-02" = {
-    host_node     = "host3"
-    machine_type  = "controlplane"
-    ip            = "10.25.150.13"
-    mac_address   = "bc:24:11:1e:1d:2f"
-    vm_id         = 8103
-    cpu           = 6
-    ram_dedicated = 6144
-    update        = false
-  }
-  "work-00" = {
-    host_node     = "host3"
-    machine_type  = "worker"
-    ip            = "10.25.150.21"
-    mac_address   = "bc:24:11:64:5b:cb"
-    vm_id         = 8201
-    cpu           = 8
-    ram_dedicated = 10240
-    update        = false
-    disks = {
-      longhorn = {
-        device = "/dev/sdb"
-        size   = "150G"
-        type   = "scsi"
-        mountpoint = "/var/lib/longhorn"
+    "ctrl-00" = {
+      host_node     = "host3"
+      machine_type  = "controlplane"
+      ip            = "10.25.150.11"
+      mac_address   = "bc:24:11:e6:ba:07"
+      vm_id         = 8101
+      cpu           = 6
+      ram_dedicated = 6144
+      update        = false
+      igpu          = false
+    }
+    "ctrl-01" = {
+      host_node     = "host3"
+      machine_type  = "controlplane"
+      ip            = "10.25.150.12"
+      mac_address   = "bc:24:11:44:94:5c"
+      vm_id         = 8102
+      cpu           = 6
+      ram_dedicated = 6144
+      update        = false
+      igpu          = false
+    }
+    "ctrl-02" = {
+      host_node     = "host3"
+      machine_type  = "controlplane"
+      ip            = "10.25.150.13"
+      mac_address   = "bc:24:11:1e:1d:2f"
+      vm_id         = 8103
+      cpu           = 6
+      ram_dedicated = 6144
+      update        = false
+    }
+    "work-00" = {
+      host_node     = "host3"
+      machine_type  = "worker"
+      ip            = "10.25.150.21"
+      mac_address   = "bc:24:11:64:5b:cb"
+      vm_id         = 8201
+      cpu           = 8
+      ram_dedicated = 10240
+      update        = false
+      disks = {
+        longhorn = {
+          device     = "/dev/sdb"
+          size       = "180G"
+          type       = "scsi"
+          mountpoint = "/var/lib/longhorn"
+        }
+      }
+    }
+    "work-01" = {
+      host_node     = "host3"
+      machine_type  = "worker"
+      ip            = "10.25.150.22"
+      mac_address   = "bc:24:11:c9:22:c3"
+      vm_id         = 8202
+      cpu           = 8
+      ram_dedicated = 10240
+      update        = false
+      disks = {
+        longhorn = {
+          device     = "/dev/sdb"
+          size       = "180G"
+          type       = "scsi"
+          mountpoint = "/var/lib/longhorn"
+        }
+      }
+    }
+    "work-02" = {
+      host_node     = "host3"
+      machine_type  = "worker"
+      ip            = "10.25.150.23"
+      mac_address   = "bc:24:11:6f:20:03"
+      vm_id         = 8203
+      cpu           = 8
+      ram_dedicated = 8192
+      update        = false
+      disks = {
+        longhorn = {
+          device     = "/dev/sdb"
+          size       = "180G"
+          type       = "scsi"
+          mountpoint = "/var/lib/longhorn"
+        }
       }
     }
   }
-  "work-01" = {
-    host_node     = "host3"
-    machine_type  = "worker"
-    ip            = "10.25.150.22"
-    mac_address   = "bc:24:11:c9:22:c3"
-    vm_id         = 8202
-    cpu           = 8
-    ram_dedicated = 10240
-    update        = false
-    disks = {
-      longhorn = {
-        device = "/dev/sdb"
-        size   = "150G"
-        type   = "scsi"
-        mountpoint = "/var/lib/longhorn"
-      }
-    }
-  }
-  "work-02" = {
-    host_node     = "host3"
-    machine_type  = "worker"
-    ip            = "10.25.150.23"
-    mac_address   = "bc:24:11:6f:20:03"
-    vm_id         = 8203
-    cpu           = 8
-    ram_dedicated = 8192
-    update        = false
-    disks = {
-      longhorn = {
-        device = "/dev/sdb"
-        size   = "150G"
-        type   = "scsi"
-        mountpoint = "/var/lib/longhorn"
-      }
-    }
-  }
-}
 }
 


### PR DESCRIPTION
- Changed HTTPRoute name to frigate-protected
- Updated backend reference to authentik-outpost on port 9000
- Added README for Authentik Proxy Outpost detailing setup and usage
- Introduced outpost.yaml for Authentik Outpost deployment and service
- Updated kustomization.yaml to include outpost.yaml