### PR TITLE
fix(k8s): correct HTTPRoute name and backend reference for frigate

### DIFF
--- a/k8s/applications/automation/frigate/http-route.yaml
+++ b/k8s/applications/automation/frigate/http-route.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: frigate-protected
+  name: frigate
   namespace: frigate
 spec:
   parentRefs:
@@ -15,5 +15,5 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: authentik-outpost
-          port: 9000
+        - name: frigate
+          port: 5000


### PR DESCRIPTION
- Changed HTTPRoute name from 'frigate-protected' to 'frigate'
- Updated backend reference from 'authentik-outpost' on port 9000 to 'frigate' on port 5000