### PR TITLE
refactor(k8s): update HTTPRoute configurations for frigate

### DIFF
--- a/k8s/applications/automation/frigate/http-route.yaml
+++ b/k8s/applications/automation/frigate/http-route.yaml
@@ -1,12 +1,10 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: frigate
+  name: frigate-internal
   namespace: frigate
 spec:
   parentRefs:
-    - name: internal
-      namespace: gateway
     - name: external
       namespace: gateway
   hostnames:
@@ -20,3 +18,25 @@ spec:
         - name: authentik-proxy
           namespace: auth
           port: 9000
+
+---
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frigate-external
+  namespace: frigate
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "frigate.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frigate
+          port: 5000


### PR DESCRIPTION
- Renamed internal HTTPRoute to frigate-internal
- Adjusted parentRefs for frigate-internal
- Ensured frigate-external route remains intact