### PR TITLE
Add transformer to kustomization files

### DIFF
--- a/k8s/applications/kustomization.yaml
+++ b/k8s/applications/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - web
 - network
 
+configurations:
+  - https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform-kustomize-v5.yaml
+
 # configurations:
 # - common/varreference.yaml
 

--- a/k8s/infrastructure/kustomization.yaml
+++ b/k8s/infrastructure/kustomization.yaml
@@ -10,5 +10,8 @@ resources:
 - auth
 - database
 
+configurations:
+  - https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform-kustomize-v5.yaml
+
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Add transformer configuration to kustomization files for applications and infrastructure folders.

* Modify `k8s/applications/kustomization.yaml`
  - Add `configurations` section with the transformer URL `https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform-kustomize-v5.yaml`

* Modify `k8s/infrastructure/kustomization.yaml`
  - Add `configurations` section with the transformer URL `https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform-kustomize-v5.yaml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/655?shareId=39f07624-c85c-410c-850d-babfb6f0097e).