### PR TITLE
refactor(k8s): change creationPolicy to Merge for argocd-secret

### DIFF
--- a/k8s/infrastructure/controllers/argocd/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/argocd/externalsecret.yaml
@@ -10,7 +10,7 @@ spec:
     name: bitwarden-backend
   target:
     name: argocd-secret
-    creationPolicy: Owner
+    creationPolicy: Merge
   data:
     - secretKey: dex.authentik.clientSecret
       remoteRef:


### PR DESCRIPTION
Change the creation policy of the argocd-secret to Merge to allow for better management of resources. This adjustment improves the handling of secrets within the Kubernetes environment.