### PR TITLE
refactor(k8s): update resource requests and limits for PostgreSQL instances

### DIFF
--- a/k8s/applications/media/immich/database.yaml
+++ b/k8s/applications/media/immich/database.yaml
@@ -23,8 +23,8 @@ spec:
   enableConnectionPooler: false
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
+      cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi

--- a/k8s/infrastructure/auth/authentik/database.yaml
+++ b/k8s/infrastructure/auth/authentik/database.yaml
@@ -19,8 +19,8 @@ spec:
   enableConnectionPooler: false
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
+      cpu: 200m
       memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -42,8 +42,8 @@ module "talos" {
       mac_address   = "bc:24:11:e6:ba:07"
       vm_id         = 8101
       cpu           = 6
-      ram_dedicated = 6144
-      update        = false
+      ram_dedicated = 7168
+      update        = true
       igpu          = false
     }
     "ctrl-01" = {
@@ -110,7 +110,7 @@ module "talos" {
       mac_address   = "bc:24:11:6f:20:03"
       vm_id         = 8203
       cpu           = 8
-      ram_dedicated = 8192
+      ram_dedicated = 10240
       update        = false
       disks = {
         longhorn = {


### PR DESCRIPTION
- Increased CPU and memory requests for immich and authentik databases
- Adjusted dedicated RAM for Talos nodes