### PR TITLE
Feat(k8s)  add external secret for min io longhorn backup

### DIFF
--- a/k8s/applications/external/application-set.yaml
+++ b/k8s/applications/external/application-set.yaml
@@ -4,7 +4,7 @@ metadata:
   name: external
   namespace: argocd
   labels:
-    dev.stonegarden: external
+    dev.pctips: external
 spec:
   generators:
     - git:
@@ -16,7 +16,7 @@ spec:
     metadata:
       name: '{{ path.basename }}'
       labels:
-        dev.stonegarden: application
+        dev.pctips: application
       finalizers:
         - resources-finalizer.argocd.argoproj.io
     spec:

--- a/k8s/infrastructure/network/coredns/configmap.yaml
+++ b/k8s/infrastructure/network/coredns/configmap.yaml
@@ -24,7 +24,7 @@ data:
         }
 
         # Forwarding to external DNS servers for non-cluster queries
-        forward . 1.1.1.1 8.8.8.8
+        forward . 10.25.150.1 1.1.1.1 8.8.8.8
 
         cache 30
         loop

--- a/k8s/infrastructure/network/coredns/configmap.yaml
+++ b/k8s/infrastructure/network/coredns/configmap.yaml
@@ -24,7 +24,9 @@ data:
         }
 
         # Forwarding to external DNS servers for non-cluster queries
-        forward . 10.25.150.1 1.1.1.1 8.8.8.8
+        forward . 10.25.150.1 1.1.1.1 8.8.8.8 {
+            policy sequential
+        }
 
         cache 30
         loop

--- a/k8s/infrastructure/storage/longhorn/backup.yaml
+++ b/k8s/infrastructure/storage/longhorn/backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: longhorn-system
+data:
+  default-resource.yaml: |
+    "backup-target": "s3://longhorn@us-west-1/"
+    "backup-target-credential-secret": "longhorn-minio-credentials"
+    "backupstore-poll-interval": "180"

--- a/k8s/infrastructure/storage/longhorn/externalsecret.yaml
+++ b/k8s/infrastructure/storage/longhorn/externalsecret.yaml
@@ -9,15 +9,15 @@ spec:
     name: bitwarden-backend
     kind: ClusterSecretStore
   target:
-    name: minio-longhorn-backup-secret
+    name: longhorn-minio-credentials
     creationPolicy: Owner
   data:
     - secretKey: AWS_ACCESS_KEY_ID
       remoteRef:
-        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
+        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
     - secretKey: AWS_SECRET_ACCESS_KEY
       remoteRef:
-        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
+        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: da1cf25e-0219-401f-9063-b2e400c1e12a

--- a/k8s/infrastructure/storage/longhorn/externalsecret.yaml
+++ b/k8s/infrastructure/storage/longhorn/externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: longhorn-system
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: minio-longhorn-backup-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: da1cf25e-0219-401f-9063-b2e400c1e12a

--- a/k8s/infrastructure/storage/longhorn/kustomization.yaml
+++ b/k8s/infrastructure/storage/longhorn/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: longhorn-system
 resources:
 - namespace.yaml
 - http-route.yaml
+- externalsecret.yaml
 
 helmCharts:
 - name: longhorn

--- a/k8s/infrastructure/storage/longhorn/kustomization.yaml
+++ b/k8s/infrastructure/storage/longhorn/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: longhorn-system
 
 resources:
 - namespace.yaml
+- recurringjob.yaml
+- backup.yaml
 - http-route.yaml
 - externalsecret.yaml
 

--- a/k8s/infrastructure/storage/longhorn/recurringjob.yaml
+++ b/k8s/infrastructure/storage/longhorn/recurringjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: backup-daily
+  namespace: longhorn-system
+spec:
+  cron: "0 1 * * *"  # Daily at 1 AM
+  task: "backup"
+  groups:
+  - default
+  - group1
+  retain: 7  # Keep a week of backups
+  concurrency: 2
+  labels:
+    type: scheduled
+---
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: snapshot-hourly
+  namespace: longhorn-system
+spec:
+  cron: "0 * * * *"  # Every hour
+  task: "snapshot"
+  groups:
+  - default
+  - group1
+  retain: 24  # Keep a day of hourly snapshots
+  concurrency: 2
+  labels:
+    type: scheduled
+---
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: snapshot-cleanup
+  namespace: longhorn-system
+spec:
+  cron: "15 2 * * *"  # Daily at 2:15 AM (after backup)
+  task: "snapshot-cleanup"
+  groups:
+  - default
+  - group1
+  concurrency: 2
+  labels:
+    type: maintenance

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -44,10 +44,6 @@ csi:
       limits:
         cpu: 200m
         memory: 256Mi
-defaultBackupStore:
-  backupTarget: "s3://longhorn@us-east-1/"
-  backupTargetCredentialSecret: "minio-longhorn-backup-secret"
-  pollInterval: 300
 
 defaultSettings:
   createDefaultDiskLabeledNodes: true

--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -44,6 +44,10 @@ csi:
       limits:
         cpu: 200m
         memory: 256Mi
+defaultBackupStore:
+  backupTarget: "s3://longhorn@us-east-1/"
+  backupTargetCredentialSecret: "minio-longhorn-backup-secret"
+  pollInterval: 300
 
 defaultSettings:
   createDefaultDiskLabeledNodes: true


### PR DESCRIPTION
This pull request introduces updates to the CoreDNS configuration and significant enhancements to the Longhorn storage infrastructure by adding new configurations for backups, recurring jobs, and external secrets management. These changes aim to improve DNS resolution, automate backup and snapshot processes, and securely manage credentials.

### CoreDNS Configuration Update:
* Updated the `forward` directive in `k8s/infrastructure/network/coredns/configmap.yaml` to include an additional internal DNS server (`10.25.150.1`) for non-cluster queries.

### Longhorn Storage Enhancements:
* **Backup Configuration**:
  * Added a new ConfigMap in `k8s/infrastructure/storage/longhorn/backup.yaml` to set up default backup targets, credentials, and poll intervals for Longhorn backups.
* **Recurring Jobs**:
  * Added recurring job configurations in `k8s/infrastructure/storage/longhorn/recurringjob.yaml` for daily backups, hourly snapshots, and daily snapshot cleanup tasks. These jobs automate key maintenance tasks for Longhorn volumes.
* **External Secrets Management**:
  * Introduced an `ExternalSecret` in `k8s/infrastructure/storage/longhorn/externalsecret.yaml` to securely fetch and manage AWS credentials for Longhorn backups using an external secret store.
* **Kustomization Updates**:
  * Updated `k8s/infrastructure/storage/longhorn/kustomization.yaml` to include the new resources (`backup.yaml`, `recurringjob.yaml`, and `externalsecret.yaml`) in the Longhorn system.