### PR TITLE
perf(k8s): increase resource requests and limits for jellyfin deployment

### DIFF
--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -33,10 +33,10 @@ spec:
               drop: [ "ALL" ]
           resources:
             requests:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: 2000m
+              memory: 2Gi
             limits:
-              cpu: 3000m
+              cpu: 4000m
               memory: 5Gi
           envFrom:
             - configMapRef:


### PR DESCRIPTION
- Updated CPU requests from 1000m to 2000m
- Updated memory requests from 1Gi to 2Gi
- Updated CPU limits from 3000m to 4000m