### PR TITLE
chore: Update Immich to use VectorChord extension instead of pgvector

### DIFF
--- a/k8s/applications/media/immich/database.yaml
+++ b/k8s/applications/media/immich/database.yaml
@@ -32,7 +32,6 @@ spec:
   preparedDatabases:
     immich:
       extensions:
-        pgvector: public
         vectorchord: public
 
   additionalVolumes:

--- a/k8s/applications/media/immich/values.yaml
+++ b/k8s/applications/media/immich/values.yaml
@@ -1,6 +1,6 @@
 env:
   TZ: Europe/Stockholm
-  DB_VECTOR_EXTENSION: pgvector
+  DB_VECTOR_EXTENSION: vectorchord
   DB_URL:
     valueFrom:
       secretKeyRef:

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -38,7 +38,7 @@ spec:
   preparedDatabases:
     immich:
       extensions:
-        pgvector: public
+        vectorchord: public
 ```
 
 ---
@@ -90,4 +90,31 @@ resources:
   - pvc.yaml
   - zalando-k8s-store.yaml
   - serviceaccount.yaml
+```
+
+---
+
+## 5. Removal of pgvector and Use of VectorChord
+
+**Why it changed:**
+The old `pgvector` extension was replaced with the `VectorChord` extension to enhance the PostgreSQL database setup for the Immich application.
+
+**How we fixed it:**
+In `database.yaml`, remove the `pgvector` extension and ensure `vectorchord` is the only extension listed under `spec.preparedDatabases`:
+
+```yaml
+# k8s/applications/media/immich/database.yaml
+spec:
+  preparedDatabases:
+    immich:
+      extensions:
+        vectorchord: public
+```
+
+In `values.yaml`, update the `DB_VECTOR_EXTENSION` environment variable to reference `vectorchord` instead of `pgvector`:
+
+```yaml
+# k8s/applications/media/immich/values.yaml
+env:
+  DB_VECTOR_EXTENSION: vectorchord
 ```


### PR DESCRIPTION
Remove the old `pgvector` extension and update to use the `VectorChord` extension in the Immich application.

* **Database Configuration:**
  - Remove `pgvector` from the `preparedDatabases` section in `k8s/applications/media/immich/database.yaml`.
  - Ensure `vectorchord` is the only extension listed under `preparedDatabases`.

* **Environment Variables:**
  - Update the `DB_VECTOR_EXTENSION` environment variable to reference `vectorchord` instead of `pgvector` in `k8s/applications/media/immich/values.yaml`.

* **Documentation:**
  - Update `website/docs/k8s/applications/immich-implementation.md` to mention the removal of `pgvector` and the use of `VectorChord`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/701?shareId=b712ba65-af56-43cb-9ad5-42b2fe9db269).