### PR TITLE
fix(k8s): correct docker image and extension names in database configuration

### DIFF
--- a/k8s/applications/media/immich/immich-server/database.yaml
+++ b/k8s/applications/media/immich/immich-server/database.yaml
@@ -24,14 +24,7 @@ spec:
     version: "17"
     parameters:
       # Include both vector and vchord for migration phase
-      shared_preload_libraries:
-        - bg_mon
-        - pg_stat_statements
-        - pgextwlist
-        - pg_auth_mon
-        - set_user
-        - vector
-        - vchord
+      shared_preload_libraries: "bg_mon,pg_stat_statements,pgextwlist,pg_auth_mon,set_user,vector,vchord"
   enableConnectionPooler: false
   resources:
     requests:


### PR DESCRIPTION
- updated docker image to use the correct version
- fixed extension name from 'vectorchord' to 'vchord'
- clarified shared_preload_libraries comment for migration phase