### PR TITLE
fix: Add Cloudflare resources for zone and account

### DIFF
--- a/k8s/infrastructure/controllers/crossplane/account.yaml
+++ b/k8s/infrastructure/controllers/crossplane/account.yaml
@@ -1,0 +1,10 @@
+apiVersion: account.cloudflare.upbound.io/v1beta1
+kind: Account
+metadata:
+  name: cloudflare-account
+spec:
+  forProvider:
+    accountId: "<your-account-id>"  # Replace with actual ID
+  providerConfigRef:
+    name: cloudflare-provider
+  managementPolicy: ObserveOnly

--- a/k8s/infrastructure/controllers/crossplane/kustomization.yaml
+++ b/k8s/infrastructure/controllers/crossplane/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - external-secret-cloudflare-token.yaml
   - provider-cloudflare.yaml
   - provider-config.yaml
+  - account.yaml
+  - zone.yaml
 
 helmCharts:
   - name: crossplane

--- a/k8s/infrastructure/controllers/crossplane/zone.yaml
+++ b/k8s/infrastructure/controllers/crossplane/zone.yaml
@@ -1,0 +1,10 @@
+apiVersion: zone.cloudflare.upbound.io/v1beta1
+kind: Zone
+metadata:
+  name: pc-tips-se
+spec:
+  forProvider:
+    zone: pc-tips.se
+  providerConfigRef:
+    name: cloudflare-provider
+  managementPolicy: ObserveOnly

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -56,7 +56,7 @@ deployment:
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
     - name: KUBECHECKS_SCHEMAS_LOCATION
-      value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+      value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/config/schema.json"
     - name: KUBECHECKS_GITHUB_APP_ID
       value: "1243453"
     - name: KUBECHECKS_GITHUB_INSTALLATION_ID


### PR DESCRIPTION
Add `account.yaml` and `zone.yaml` files and reference them in `kustomization.yaml` to resolve `zoneIdRef` and `accountIdRef` references.

* **Add `account.yaml` file:**
  - Define `apiVersion`, `kind`, `metadata`, and `spec` for the Cloudflare account.
  - Include `accountId`, `providerConfigRef`, and `managementPolicy`.

* **Add `zone.yaml` file:**
  - Define `apiVersion`, `kind`, `metadata`, and `spec` for the Cloudflare zone.
  - Include `zone`, `providerConfigRef`, and `managementPolicy`.

* **Modify `kustomization.yaml`:**
  - Add `account.yaml` and `zone.yaml` to the `resources` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab/pull/736?shareId=e36713e7-bd04-4872-980e-8df8722ff705).