### PR TITLE
Fix duplicate Bitwarden ID in secrets.yml

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -66,5 +66,5 @@ spec:
   data:
     - secretKey: AUTHENTIK_BLUEPRINTS_NOTIFICATIONS_SLACK_WEBHOOK
       remoteRef:
-        key: "f00c9b32-da26-4dee-8cbf-b2d500f6fd2b" # Replace with actual Bitwarden UUID
+        key: "5bc23bdf-75c4-4e97-a19b-b2ec0130cad4" # Replace with actual Bitwarden UUID
     # Add other blueprint-specific !Env secrets here


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/theepicsaxguy/homelab?shareId=XXXX-XXXX-XXXX-XXXX).