### PR TITLE
Fix workspace schema paths

### DIFF
--- a/homelab.code-workspace
+++ b/homelab.code-workspace
@@ -136,13 +136,12 @@
     "git.diagnosticsCommitHook.Enabled": true,
     "git.enableSmartCommit": true,
     "yaml.schemas": {
-      "https://json.schemastore.org/yamllint.json": "file:///root/homelab/k8s/infrastructure/controllers/argocd/charts/argo-cd-7.8.2/argo-cd/templates/aggregate-roles.yaml",
+      "https://json.schemastore.org/yamllint.json": "k8s/infrastructure/controllers/argocd/charts/argo-cd-7.8.2/argo-cd/templates/aggregate-roles.yaml",
       "https://goauthentik.io/blueprints/schema.json": [
         "k8s/infrastructure/auth/authentik/extra/blueprints/*.yaml",
-        "file:///home/benjaminsanden/Documents/Projects/homelab/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml"
+        "k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml"
       ]
     },
-    "github.copilot.chat.codesearch.enabled": true,
     "chat.promptFilesLocations": {
       ".github/prompts/kustomize": true
     }


### PR DESCRIPTION
## Summary
- fix incorrect absolute path for YAML schemas
- remove duplicate Copilot codesearch setting

## Testing
- `grep -n codesearch -n homelab.code-workspace`

------
https://chatgpt.com/codex/tasks/task_e_6840511c2b6c8322ae8034c3acf7ff5c