### PR TITLE
feat(auth): add groups and users blueprints

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
@@ -8,6 +8,18 @@ version: 1
 metadata:
   name: Apps - ArgoCD
 entries:
+  - id: argocd-admin-group
+    model: authentik_core.group
+    identifiers:
+      name: ArgoCD Admins
+    attrs:
+      name: ArgoCD Admins
+  - id: argocd-viewer-group
+    model: authentik_core.group
+    identifiers:
+      name: ArgoCD Viewers
+    attrs:
+      name: ArgoCD Viewers
   - id: argocd_provider
     model: authentik_providers_oauth2.oauth2provider
     identifiers:
@@ -69,6 +81,6 @@ entries:
   - model: authentik_policies.policybinding
     identifiers:
       target: !KeyOf argocd_application
-      group: !Find [authentik_core.group, [name, "roots"]]
+      group: !Find [authentik_core.group, [name, "ArgoCD Admins"]]
     attrs:
       order: 1

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
@@ -84,3 +84,9 @@ entries:
       group: !Find [authentik_core.group, [name, "ArgoCD Admins"]]
     attrs:
       order: 1
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf argocd_application
+      group: !Find [authentik_core.group, [name, "ArgoCD Viewers"]]
+    attrs:
+      order: 2

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-grafana.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-grafana.yaml
@@ -7,6 +7,18 @@ version: 1
 metadata:
   name: Apps - Grafana
 entries:
+  - id: grafana-admin-group
+    model: authentik_core.group
+    identifiers:
+      name: Grafana Admins
+    attrs:
+      name: Grafana Admins
+  - id: grafana-user-group
+    model: authentik_core.group
+    identifiers:
+      name: Grafana Users
+    attrs:
+      name: Grafana Users
   - id: grafana_provider
     model: authentik_providers_oauth2.oauth2provider
     identifiers:
@@ -69,12 +81,12 @@ entries:
   - model: authentik_policies.policybinding
     identifiers:
       target: !KeyOf grafana_application
-      group: !Find [authentik_core.group, [name, "users"]]
+      group: !Find [authentik_core.group, [name, "Grafana Users"]]
     attrs:
       order: 1
   - model: authentik_policies.policybinding
     identifiers:
       target: !KeyOf grafana_application
-      group: !Find [authentik_core.group, [name, "roots"]]
+      group: !Find [authentik_core.group, [name, "Grafana Admins"]]
     attrs:
       order: 2

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-openwebui.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-openwebui.yaml
@@ -8,6 +8,12 @@ version: 1
 metadata:
   name: Apps - Open WebUI
 entries:
+  - id: openwebui-user-group
+    model: authentik_core.group
+    identifiers:
+      name: Open WebUI Users
+    attrs:
+      name: Open WebUI Users
   - id: openwebui_provider
     model: authentik_providers_oauth2.oauth2provider
     identifiers:
@@ -70,7 +76,7 @@ entries:
   - model: authentik_policies.policybinding
     identifiers:
       target: !KeyOf openwebui_application
-      group: !Find [authentik_core.group, [name, "users"]] # Or your desired user group
+      group: !Find [authentik_core.group, [name, "Open WebUI Users"]]
     attrs:
       order: 1
   - model: authentik_policies.policybinding

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable-file
+# prettier-ignore-start
+# eslint-disable
+---
+version: 1
+metadata:
+  name: Groups - Applications
+entries:
+  - id: argocd-admins
+    model: authentik_core.group
+    identifiers:
+      name: ArgoCD Admins
+    attrs:
+      name: ArgoCD Admins
+  - id: argocd-viewers
+    model: authentik_core.group
+    identifiers:
+      name: ArgoCD Viewers
+    attrs:
+      name: ArgoCD Viewers
+  - id: grafana-admins
+    model: authentik_core.group
+    identifiers:
+      name: Grafana Admins
+    attrs:
+      name: Grafana Admins
+  - id: grafana-users
+    model: authentik_core.group
+    identifiers:
+      name: Grafana Users
+    attrs:
+      name: Grafana Users
+  - id: frigate-users
+    model: authentik_core.group
+    identifiers:
+      name: Frigate Users
+    attrs:
+      name: Frigate Users
+  - id: home-assistant-users
+    model: authentik_core.group
+    identifiers:
+      name: Home Assistant Users
+    attrs:
+      name: Home Assistant Users
+  - id: immich-users
+    model: authentik_core.group
+    identifiers:
+      name: Immich Users
+    attrs:
+      name: Immich Users
+  - id: jellyfin-users
+    model: authentik_core.group
+    identifiers:
+      name: Jellyfin Users
+    attrs:
+      name: Jellyfin Users
+  - id: media-users
+    model: authentik_core.group
+    identifiers:
+      name: Media Users
+    attrs:
+      name: Media Users
+  - id: openwebui-users
+    model: authentik_core.group
+    identifiers:
+      name: Open WebUI Users
+    attrs:
+      name: Open WebUI Users

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/users.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/users.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable-file
+# prettier-ignore-start
+# eslint-disable
+---
+version: 1
+metadata:
+  name: Users
+entries:
+  - id: user-argocd-admin
+    model: authentik_core.user
+    identifiers:
+      username: argocd-admin
+    attrs:
+      username: argocd-admin
+      name: ArgoCD Admin
+      email: !Env ARGOCD_ADMIN_EMAIL
+      password: !Env ARGOCD_ADMIN_PASSWORD
+      groups:
+        - !Find [authentik_core.group, [name, "ArgoCD Admins"]]
+  - id: user-grafana-viewer
+    model: authentik_core.user
+    identifiers:
+      username: grafana-viewer
+    attrs:
+      username: grafana-viewer
+      name: Grafana Viewer
+      email: !Env GRAFANA_VIEWER_EMAIL
+      password: !Env GRAFANA_VIEWER_PASSWORD
+      groups:
+        - !Find [authentik_core.group, [name, "Grafana Users"]]

--- a/k8s/infrastructure/auth/authentik/extra/kustomization.yml
+++ b/k8s/infrastructure/auth/authentik/extra/kustomization.yml
@@ -18,6 +18,8 @@ configMapGenerator:
       - ./blueprints/apps-jellyfin.yaml
       - ./blueprints/apps-media.yaml
       - ./blueprints/apps-openwebui.yaml
+      - ./blueprints/groups.yaml
+      - ./blueprints/users.yaml
       - ./blueprints/brands.yaml
       - ./blueprints/flows-default-provider-authorization-one-time-consent.yaml
       - ./blueprints/notifications.yaml

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -18,26 +18,26 @@ spec:
     # Changed from 'secret-key' to 'AUTHENTIK_SECRET_KEY' for env var usage
     - secretKey: AUTHENTIK_SECRET_KEY
       remoteRef:
-        key: "49416301-9093-4c1d-b713-b2d500632388"
+        key: '49416301-9093-4c1d-b713-b2d500632388'
 
     # --- Redis Password ---
     - secretKey: redis-password
       remoteRef:
-        key: "cb26a5a7-3a42-425d-98cd-b2d500f984e7"
+        key: 'cb26a5a7-3a42-425d-98cd-b2d500f984e7'
 
     - secretKey: AUTHENTIK_REDIS__PASSWORD
       remoteRef:
-        key: "cb26a5a7-3a42-425d-98cd-b2d500f984e7"
+        key: 'cb26a5a7-3a42-425d-98cd-b2d500f984e7'
     # --- Bootstrap Credentials ---
     - secretKey: AUTHENTIK_BOOTSTRAP_TOKEN
       remoteRef:
-        key: "1c460c2a-c0e7-4a93-8a0f-b2d301342555"
+        key: '1c460c2a-c0e7-4a93-8a0f-b2d301342555'
     - secretKey: AUTHENTIK_BOOTSTRAP_PASSWORD
       remoteRef:
-        key: "a72fef1f-af7f-4c92-889c-b2d500f9a2c1"
+        key: 'a72fef1f-af7f-4c92-889c-b2d500f9a2c1'
     - secretKey: AUTHENTIK_BOOTSTRAP_EMAIL
       remoteRef:
-        key: "f00c9b32-da26-4dee-8cbf-b2d500f6fd2b"
+        key: 'f00c9b32-da26-4dee-8cbf-b2d500f6fd2b'
 
 ---
 apiVersion: external-secrets.io/v1
@@ -56,115 +56,129 @@ spec:
   data:
     - secretKey: AUTHENTIK_BLUEPRINTS_NOTIFICATIONS_SLACK_WEBHOOK
       remoteRef:
-        key: "5bc23bdf-75c4-4e97-a19b-b2ec0130cad4"
+        key: '5bc23bdf-75c4-4e97-a19b-b2ec0130cad4'
     # --- ArgoCD ---
     - secretKey: ARGOCd_CLIENT_ID
       remoteRef:
-        key: "<argocd-client-id-uuid>"
+        key: '<argocd-client-id-uuid>'
     - secretKey: ARGOCD_CLIENT_SECRET
       remoteRef:
-        key: "<argocd-client-secret-uuid>"
+        key: '<argocd-client-secret-uuid>'
 
     # --- Grafana ---
     - secretKey: GRAFANA_CLIENT_ID
       remoteRef:
-        key: "<grafana-client-id-uuid>"
+        key: '<grafana-client-id-uuid>'
     - secretKey: GRAFANA_CLIENT_SECRET
       remoteRef:
-        key: "<grafana-client-secret-uuid>"
+        key: '<grafana-client-secret-uuid>'
 
     # --- Zigbee2MQTT ---
     - secretKey: ZIGBEE2MQTT_CLIENT_ID
       remoteRef:
-        key: "<zigbee2mqtt-client-id-uuid>"
+        key: '<zigbee2mqtt-client-id-uuid>'
     - secretKey: ZIGBEE2MQTT_CLIENT_SECRET
       remoteRef:
-        key: "<zigbee2mqtt-client-secret-uuid>"
+        key: '<zigbee2mqtt-client-secret-uuid>'
 
     # --- Immich ---
     - secretKey: IMMICH_CLIENT_ID
       remoteRef:
-        key: "<immich-client-id-uuid>"
+        key: '<immich-client-id-uuid>'
     - secretKey: IMMICH_CLIENT_SECRET
       remoteRef:
-        key: "<immich-client-secret-uuid>"
+        key: '<immich-client-secret-uuid>'
 
     # --- Jellyfin ---
     - secretKey: JELLYFIN_CLIENT_ID
       remoteRef:
-        key: "<jellyfin-client-id-uuid>"
+        key: '<jellyfin-client-id-uuid>'
     - secretKey: JELLYFIN_CLIENT_SECRET
       remoteRef:
-        key: "<jellyfin-client-secret-uuid>"
+        key: '<jellyfin-client-secret-uuid>'
 
     # --- Bazarr ---
     - secretKey: BAZARR_CLIENT_ID
       remoteRef:
-        key: "<bazarr-client-id-uuid>"
+        key: '<bazarr-client-id-uuid>'
     - secretKey: BAZARR_CLIENT_SECRET
       remoteRef:
-        key: "<bazarr-client-secret-uuid>"
+        key: '<bazarr-client-secret-uuid>'
 
     # --- Lidarr ---
     - secretKey: LIDARR_CLIENT_ID
       remoteRef:
-        key: "<lidarr-client-id-uuid>"
+        key: '<lidarr-client-id-uuid>'
     - secretKey: LIDARR_CLIENT_SECRET
       remoteRef:
-        key: "<lidarr-client-secret-uuid>"
+        key: '<lidarr-client-secret-uuid>'
 
     # --- Prowlarr ---
     - secretKey: PROWLARR_CLIENT_ID
       remoteRef:
-        key: "<prowlarr-client-id-uuid>"
+        key: '<prowlarr-client-id-uuid>'
     - secretKey: PROWLARR_CLIENT_SECRET
       remoteRef:
-        key: "<prowlarr-client-secret-uuid>"
+        key: '<prowlarr-client-secret-uuid>'
 
     # --- Radarr ---
     - secretKey: RADARR_CLIENT_ID
       remoteRef:
-        key: "<radarr-client-id-uuid>"
+        key: '<radarr-client-id-uuid>'
     - secretKey: RADARR_CLIENT_SECRET
       remoteRef:
-        key: "<radarr-client-secret-uuid>"
+        key: '<radarr-client-secret-uuid>'
 
     # --- Readarr ---
     - secretKey: READARR_CLIENT_ID
       remoteRef:
-        key: "<readarr-client-id-uuid>"
+        key: '<readarr-client-id-uuid>'
     - secretKey: READARR_CLIENT_SECRET
       remoteRef:
-        key: "<readarr-client-secret-uuid>"
+        key: '<readarr-client-secret-uuid>'
 
     # --- Sonarr ---
     - secretKey: SONARR_CLIENT_ID
       remoteRef:
-        key: "<sonarr-client-id-uuid>"
+        key: '<sonarr-client-id-uuid>'
     - secretKey: SONARR_CLIENT_SECRET
       remoteRef:
-        key: "<sonarr-client-secret-uuid>"
+        key: '<sonarr-client-secret-uuid>'
 
     # --- qBittorrent ---
     - secretKey: QBITTORRENT_CLIENT_ID
       remoteRef:
-        key: "<qbittorrent-client-id-uuid>"
+        key: '<qbittorrent-client-id-uuid>'
     - secretKey: QBITTORRENT_CLIENT_SECRET
       remoteRef:
-        key: "<qbittorrent-client-secret-uuid>"
+        key: '<qbittorrent-client-secret-uuid>'
 
     # --- SABnzbd ---
     - secretKey: SABNZBD_CLIENT_ID
       remoteRef:
-        key: "<sabnzbd-client-id-uuid>"
+        key: '<sabnzbd-client-id-uuid>'
     - secretKey: SABNZBD_CLIENT_SECRET
       remoteRef:
-        key: "<sabnzbd-client-secret-uuid>"
+        key: '<sabnzbd-client-secret-uuid>'
 
     # --- Open WebUI ---
     - secretKey: OPENWEBUI_CLIENT_ID
       remoteRef:
-        key: "<openwebui-client-id-uuid>"
+        key: '<openwebui-client-id-uuid>'
     - secretKey: OPENWEBUI_CLIENT_SECRET
       remoteRef:
-        key: "<openwebui-client-secret-uuid>"
+        key: '<openwebui-client-secret-uuid>'
+
+    # --- User credentials ---
+    - secretKey: ARGOCD_ADMIN_EMAIL
+      remoteRef:
+        key: '<argocd-admin-email-uuid>'
+    - secretKey: ARGOCD_ADMIN_PASSWORD
+      remoteRef:
+        key: '<argocd-admin-password-uuid>'
+    - secretKey: GRAFANA_VIEWER_EMAIL
+      remoteRef:
+        key: '<grafana-viewer-email-uuid>'
+    - secretKey: GRAFANA_VIEWER_PASSWORD
+      remoteRef:
+        key: '<grafana-viewer-password-uuid>'


### PR DESCRIPTION
## Summary
- introduce new Authentik groups blueprint
- create a users blueprint referencing external secrets
- declare new groups inside ArgoCD, Grafana and Open WebUI app blueprints
- update policy bindings to use these groups
- wire new blueprints via kustomization and external secrets

## Testing
- `yamllint -s k8s/infrastructure/auth/authentik/extra/kustomization.yml k8s/infrastructure/auth/authentik/extra/secrets.yml`
- `npx prettier -w k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml k8s/infrastructure/auth/authentik/extra/blueprints/apps-grafana.yaml k8s/infrastructure/auth/authentik/extra/blueprints/apps-openwebui.yaml k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml k8s/infrastructure/auth/authentik/extra/blueprints/users.yaml k8s/infrastructure/auth/authentik/extra/kustomization.yml k8s/infrastructure/auth/authentik/extra/secrets.yml`
- `scripts/fix_kustomize.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840c7d8e09483228da8d6907a36dc2d