### PR TITLE
fix(network): align coredns forwarders

### DIFF
--- a/tofu/talos/inline-manifests/coredns-install.yaml
+++ b/tofu/talos/inline-manifests/coredns-install.yaml
@@ -38,7 +38,9 @@ data:
         }
 
         # Forwarding to external DNS servers for non-cluster queries
-        forward . 1.1.1.1 8.8.8.8
+        forward . 10.25.150.1 1.1.1.1 8.8.8.8 {
+            policy sequential
+        }
 
         cache 30
         loop

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -50,7 +50,7 @@ spec:
 ### 2. DNS (CoreDNS)
 
 - Internal domain: kube.pc-tips.se
-- External forwarding to 1.1.1.1, 8.8.8.8
+- External forwarding to 10.25.150.1, 1.1.1.1, 8.8.8.8
 - Caching enabled
 
 ### 3. Gateway API
@@ -64,6 +64,7 @@ Three gateway types:
 ### 4. Security
 
 - **Cert-Manager:**
+
   - Cloudflare DNS validation
   - Internal CA for cluster services
   - Automatic certificate renewal


### PR DESCRIPTION
## Summary
- update CoreDNS bootstrap manifest to include local resolver
- document new list of external DNS forwarders

## Testing
- `npx prettier -w tofu/talos/inline-manifests/coredns-install.yaml website/docs/k8s/infrastructure/infrastructure-management.md`
- `yamllint tofu/talos/inline-manifests/coredns-install.yaml`
- `npm install && npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6840c7f283708322823beee0299f017c