### PR TITLE
docs(website): fix template links

### DIFF
--- a/website/docs/writing-documentation/templates/index.md
+++ b/website/docs/writing-documentation/templates/index.md
@@ -7,36 +7,41 @@ project provides templates for common document types to simplify the contributio
 
 The most common types of documentation you might write for this project are:
 
-- [**Combination (Combo) Topics**](./combo.md): For many topics, especially when explaining a specific component or
+- [**Combination (Combo) Topics**](./combo.tmpl.md): For many topics, especially when explaining a specific component or
   configuration set, it's useful to combine conceptual information (the "what" and "why") with procedural or structural
   information (the "how"). A guideline is: if the actionable steps or structural details are extensive and get buried
   under too much conceptual text, consider splitting into separate Conceptual and Procedural documents.
 
-- [**Procedural Topics**](./procedural.md): These are "how-to" guides. They provide step-by-step instructions for
+- [**Procedural Topics**](./procedural.tmpl.md): These are "how-to" guides. They provide step-by-step instructions for
   accomplishing a specific task, such as running a script, configuring a service, or performing a maintenance operation.
 
-- [**Conceptual Topics**](./conceptual.md): These documents explain the "why" and "what" behind a feature, component,
-  design decision, or technology. They provide background, use cases, benefits, and important considerations.
+- [**Conceptual Topics**](./conceptual.tmpl.md): These documents explain the "why" and "what" behind a feature,
+  component, design decision, or technology. They provide background, use cases, benefits, and important considerations.
 
-- [**Reference Topics**](./reference.md): This type of documentation typically consists of tables, lists, or detailed
-  descriptions of specific items like configuration parameters, script arguments, API endpoints (if applicable), or
-  resource definitions.
+- [**Reference Topics**](./reference.tmpl.md): This type of documentation typically consists of tables, lists, or
+  detailed descriptions of specific items like configuration parameters, script arguments, API endpoints (if
+  applicable), or resource definitions.
 
 ## Using a template
 
-To use a template, you can download it directly into your local clone of the `homelab` repository using `wget` or a similar tool. Navigate to the directory where you want to create your new documentation page (e.g., `website/docs/your-chosen-subdirectory/`) and run the appropriate command:
+To use a template, you can download it directly into your local clone of the `homelab` repository using `wget` or a
+similar tool. Navigate to the directory where you want to create your new documentation page (e.g.,
+`website/docs/your-chosen-subdirectory/`) and run the appropriate command:
 
 - **For the Combo Template:**
+
   ```bash
   wget https://raw.githubusercontent.com/theepicsaxguy/homelab/main/website/docs/writing-documentation/templates/combo.tmpl.md -O my-new-combo-topic.md
   ```
 
 - **For the Conceptual Template:**
+
   ```bash
   wget https://raw.githubusercontent.com/theepicsaxguy/homelab/main/website/docs/writing-documentation/templates/conceptual.tmpl.md -O my-new-conceptual-topic.md
   ```
 
 - **For the Procedural Template:**
+
   ```bash
   wget https://raw.githubusercontent.com/theepicsaxguy/homelab/main/website/docs/writing-documentation/templates/procedural.tmpl.md -O my-new-procedural-topic.md
   ```
@@ -46,4 +51,6 @@ To use a template, you can download it directly into your local clone of the `ho
   wget https://raw.githubusercontent.com/theepicsaxguy/homelab/main/website/docs/writing-documentation/templates/reference.tmpl.md -O my-new-reference-topic.md
   ```
 
-Remember to replace `my-new-...-topic.md` with your desired filename. After downloading, open the file and fill in the content according to the template's structure and the guidance provided in its corresponding `.md` guide file (e.g., [./combo.md](./combo.md) for the combo template).
+Remember to replace `my-new-...-topic.md` with your desired filename. After downloading, open the file and fill in the
+content according to the template's structure and the guidance provided in its corresponding `.md` guide file (e.g.,
+[./combo.tmpl.md](./combo.tmpl.md) for the combo template).


### PR DESCRIPTION
## Summary
- point template links at correct filenames

## Testing
- `npx prettier -w website/docs/writing-documentation/templates/index.md`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6840cb3359bc8322b3c1af91cc1eddbb