### PR TITLE
k8s(apps): verify resource constraints

### DIFF
--- a/k8s/applications/automation/mqtt/deployment.yaml
+++ b/k8s/applications/automation/mqtt/deployment.yaml
@@ -16,6 +16,13 @@ spec:
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: config
               mountPath: /mosquitto/config

--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -23,79 +23,86 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-      - env:
-        - name: DB_DATABASE_NAME
-          value: immich
-        - name: DB_HOSTNAME
-          value: immich-postgresql
-        - name: DB_PASSWORD
-          value: immich
-        - name: DB_SSL
-          value: "true"
-        - name: DB_URL
-          valueFrom:
-            secretKeyRef:
-              key: DB_URL
-              name: immich-db-url
-        - name: DB_USERNAME
-          value: immich
-        - name: IMMICH_CONFIG_FILE
-          value: /config/immich-config.yaml
-        - name: IMMICH_MACHINE_LEARNING_URL
-          value: http://immich-machine-learning:3003
-        - name: REDIS_HOSTNAME
-          value: immich-redis-master
-        - name: TRANSFORMERS_CACHE
-          value: /cache
-        - name: TZ
-          value: Europe/Stockholm
-        image: ghcr.io/immich-app/immich-machine-learning:v1.134.0
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        name: immich-machine-learning
-        ports:
-        - containerPort: 3003
-          name: http
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        startupProbe:
-          failureThreshold: 60
-          httpGet:
-            path: /ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /cache
-          name: cache
-        - mountPath: /config
-          name: config
-          readOnly: true
+        - env:
+            - name: DB_DATABASE_NAME
+              value: immich
+            - name: DB_HOSTNAME
+              value: immich-postgresql
+            - name: DB_PASSWORD
+              value: immich
+            - name: DB_SSL
+              value: 'true'
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  key: DB_URL
+                  name: immich-db-url
+            - name: DB_USERNAME
+              value: immich
+            - name: IMMICH_CONFIG_FILE
+              value: /config/immich-config.yaml
+            - name: IMMICH_MACHINE_LEARNING_URL
+              value: http://immich-machine-learning:3003
+            - name: REDIS_HOSTNAME
+              value: immich-redis-master
+            - name: TRANSFORMERS_CACHE
+              value: /cache
+            - name: TZ
+              value: Europe/Stockholm
+          image: ghcr.io/immich-app/immich-machine-learning:v1.134.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: immich-machine-learning
+          ports:
+            - containerPort: 3003
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /cache
+              name: cache
+            - mountPath: /config
+              name: config
+              readOnly: true
       dnsPolicy: ClusterFirst
       enableServiceLinks: true
       serviceAccountName: default
       volumes:
-      - name: cache
-        emptyDir: {}
-      - name: config
-        projected:
-          sources:
-          - secret:
-              name: immich-config
-          - configMap:
-              name: immich-immich-config
+        - name: cache
+          emptyDir: {}
+        - name: config
+          projected:
+            sources:
+              - secret:
+                  name: immich-config
+              - configMap:
+                  name: immich-immich-config

--- a/k8s/applications/media/immich/immich-server/deployment.yaml
+++ b/k8s/applications/media/immich/immich-server/deployment.yaml
@@ -23,93 +23,100 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-      - env:
-        - name: DB_DATABASE_NAME
-          value: immich
-        - name: DB_HOSTNAME
-          value: immich-postgresql
-        - name: DB_PASSWORD
-          value: immich
-        - name: DB_SSL
-          value: "true"
-        - name: DB_URL
-          valueFrom:
-            secretKeyRef:
-              key: DB_URL
-              name: immich-db-url
-        - name: DB_USERNAME
-          value: immich
-        - name: IMMICH_CONFIG_FILE
-          value: /config/immich-config.yaml
-        - name: IMMICH_MACHINE_LEARNING_URL
-          value: http://immich-machine-learning:3003
-        - name: IMMICH_TELEMETRY_INCLUDE
-          value: all
-        - name: REDIS_HOSTNAME
-          value: immich-redis-master
-        - name: TZ
-          value: Europe/Stockholm
-        image: ghcr.io/immich-app/immich-server:v1.134.0
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /api/server/ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        name: immich-server
-        ports:
-        - containerPort: 2283
-          name: http
-          protocol: TCP
-        - containerPort: 8081
-          name: metrics-api
-          protocol: TCP
-        - containerPort: 8082
-          name: metrics-ms
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /api/server/ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        startupProbe:
-          failureThreshold: 30
-          httpGet:
-            path: /api/server/ping
-            port: http
-          initialDelaySeconds: 0
-          periodSeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /config
-          name: config
-          readOnly: true
-        - mountPath: /usr/src/app/upload
-          name: library
+        - env:
+            - name: DB_DATABASE_NAME
+              value: immich
+            - name: DB_HOSTNAME
+              value: immich-postgresql
+            - name: DB_PASSWORD
+              value: immich
+            - name: DB_SSL
+              value: 'true'
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  key: DB_URL
+                  name: immich-db-url
+            - name: DB_USERNAME
+              value: immich
+            - name: IMMICH_CONFIG_FILE
+              value: /config/immich-config.yaml
+            - name: IMMICH_MACHINE_LEARNING_URL
+              value: http://immich-machine-learning:3003
+            - name: IMMICH_TELEMETRY_INCLUDE
+              value: all
+            - name: REDIS_HOSTNAME
+              value: immich-redis-master
+            - name: TZ
+              value: Europe/Stockholm
+          image: ghcr.io/immich-app/immich-server:v1.134.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/server/ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: immich-server
+          ports:
+            - containerPort: 2283
+              name: http
+              protocol: TCP
+            - containerPort: 8081
+              name: metrics-api
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics-ms
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/server/ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /api/server/ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+            - mountPath: /usr/src/app/upload
+              name: library
       dnsPolicy: ClusterFirst
       enableServiceLinks: true
       serviceAccountName: default
       volumes:
-      - name: config
-        projected:
-          defaultMode: 0440
-          sources:
-            - configMap:
-                name: immich-immich-config
-                items:
-                  - key: immich-config.yaml
-                    path: immich-config.yaml
-            - secret:
-                name: immich-config
-                items:
-                  - key: immich.json
-                    path: immich.json
-      - name: library
-        persistentVolumeClaim:
-          claimName: immich-library
+        - name: config
+          projected:
+            defaultMode: 0440
+            sources:
+              - configMap:
+                  name: immich-immich-config
+                  items:
+                    - key: immich-config.yaml
+                      path: immich-config.yaml
+              - secret:
+                  name: immich-config
+                  items:
+                    - key: immich.json
+                      path: immich.json
+        - name: library
+          persistentVolumeClaim:
+            claimName: immich-library

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -14,33 +14,40 @@ spec:
         app: sabnzbd
     spec:
       containers:
-      - name: sabnzbd
-        image: ghcr.io/linuxserver/sabnzbd:4.5.1
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        env:
-        - name: PUID
-          value: "2501"
-        - name: PGID
-          value: "2501"
-        - name: TZ
-          value: "Europe/Stockholm"
-        - name: HOST_WHITELIST_ENTRIES
-          value: "sabnzbd,sabnzbd.media,sabnzbd.media.svc,sabnzbd.media.svc.cluster.local,sabnzbd.pc-tips.se"
-        volumeMounts:
-        - name: sabnzbd-config
-          mountPath: /config
-        - name: media-share
-          mountPath: /app/data
-        - name: sabnzbd-incomplete
-          mountPath: /downloads/incomplete
+        - name: sabnzbd
+          image: ghcr.io/linuxserver/sabnzbd:4.5.1
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PUID
+              value: '2501'
+            - name: PGID
+              value: '2501'
+            - name: TZ
+              value: 'Europe/Stockholm'
+            - name: HOST_WHITELIST_ENTRIES
+              value: 'sabnzbd,sabnzbd.media,sabnzbd.media.svc,sabnzbd.media.svc.cluster.local,sabnzbd.pc-tips.se'
+          volumeMounts:
+            - name: sabnzbd-config
+              mountPath: /config
+            - name: media-share
+              mountPath: /app/data
+            - name: sabnzbd-incomplete
+              mountPath: /downloads/incomplete
       volumes:
-      - name: sabnzbd-config
-        persistentVolumeClaim:
-          claimName: sabnzbd-config
-      - name: media-share
-        persistentVolumeClaim:
-          claimName: media-share
-      - name: sabnzbd-incomplete
-        emptyDir: {}
+        - name: sabnzbd-config
+          persistentVolumeClaim:
+            claimName: sabnzbd-config
+        - name: media-share
+          persistentVolumeClaim:
+            claimName: media-share
+        - name: sabnzbd-incomplete
+          emptyDir: {}

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -17,10 +17,17 @@ spec:
         - name: whisperasr
           image: onerahmet/openai-whisper-asr-webservice:v1.8.2
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 9000
           env:
             - name: ASR_MODEL
-              value: "small"
+              value: 'small'
             - name: ASR_ENGINE
-              value: "faster_whisper"
+              value: 'faster_whisper'

--- a/k8s/applications/web/babybuddy/deployment.yaml
+++ b/k8s/applications/web/babybuddy/deployment.yaml
@@ -17,21 +17,28 @@ spec:
         app: babybuddy
     spec:
       securityContext:
-        fsGroup: 1000            # ensure PVC files are owned by PUID/PGID
+        fsGroup: 1000
       containers:
         - name: babybuddy
           image: ghcr.io/linuxserver/babybuddy:2.7.1
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 8000
               name: http
           env:
             - name: PUID
-              value: "1000"
+              value: '1000'
             - name: PGID
-              value: "1000"
+              value: '1000'
             - name: TZ
-              value: "Europe/Stockholm"
+              value: 'Europe/Stockholm'
           envFrom:
             - secretRef:
                 name: es-babybuddy-secret-key


### PR DESCRIPTION
## Summary
- ensure all deployments have CPU and memory requests/limits
- remove stray comment in BabyBuddy spec

## Testing
- `npx prettier -w k8s/applications/automation/mqtt/deployment.yaml k8s/applications/web/babybuddy/deployment.yaml k8s/applications/media/immich/immich-server/deployment.yaml k8s/applications/media/immich/immich-ml/deployment.yaml k8s/applications/media/sabnzbd/deployment.yaml k8s/applications/media/whisperasr/deployment.yaml`
- `yamllint -c .yamllint.yml k8s/applications/automation/mqtt/deployment.yaml k8s/applications/web/babybuddy/deployment.yaml k8s/applications/media/immich/immich-server/deployment.yaml k8s/applications/media/immich/immich-ml/deployment.yaml k8s/applications/media/sabnzbd/deployment.yaml k8s/applications/media/whisperasr/deployment.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6840c8825dac83228ab8e4b0b5f391cc