### PR TITLE
fix(k8s): specify cloudflare account name

### DIFF
--- a/k8s/infrastructure/controllers/crossplane/account.yaml
+++ b/k8s/infrastructure/controllers/crossplane/account.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cloudflare-account
 spec:
   forProvider:
+    name: pc-tips
     accountId:
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
## Summary
- specify account name for Cloudflare Account resource

## Testing
- `npx prettier -w k8s/infrastructure/controllers/crossplane/account.yaml`
- `yamllint k8s/infrastructure/controllers/crossplane/account.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6840d425d68883229b1ef6e1c82ed16f