### PR TITLE
docs(website): update editUrl

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -47,7 +47,7 @@ const config: Config = {
           },
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/theepicsaxguy/homelab/tree/main/website/',
+          editUrl: 'https://github.com/theepicsaxguy/homelab/edit/main/website/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -37,8 +37,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/theepicsaxguy/homelab/tree/main/packages/create-docusaurus/templates/shared/',
+          editUrl: 'https://github.com/theepicsaxguy/homelab/tree/main/website/',
         },
         blog: {
           showReadingTime: true,
@@ -48,8 +47,7 @@ const config: Config = {
           },
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/theepicsaxguy/homelab/tree/main/packages/create-docusaurus/templates/shared/',
+          editUrl: 'https://github.com/theepicsaxguy/homelab/tree/main/website/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -37,7 +37,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/theepicsaxguy/homelab/tree/main/website/',
+          editUrl: baseEditUrl,
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
## Summary
- fix the edit URL for docs and blog in the website config

## Testing
- `npx prettier -w website/docusaurus.config.ts`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68415c440dfc83229180ca4475884993