### PR TITLE
fix(k8s): use Recreate strategy for PVC deployments

### DIFF
--- a/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: meilisearch
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: meilisearch

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: web
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: karakeep-web

--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app.kubernetes.io/instance: immich
       app.kubernetes.io/name: machine-learning
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/k8s/applications/media/immich/immich-server/deployment.yaml
+++ b/k8s/applications/media/immich/immich-server/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app.kubernetes.io/instance: immich
       app.kubernetes.io/name: server
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sabnzbd

--- a/k8s/applications/web/babybuddy/deployment.yaml
+++ b/k8s/applications/web/babybuddy/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app: babybuddy
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: babybuddy

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -104,6 +104,7 @@ We use NFS for shared media files:
 3. Set resource limits
 4. Configure security contexts
 5. Use automated sync with ArgoCD
+6. Use the `Recreate` strategy for any Deployment that mounts a PVC
 
 ## OpenWebUI Notes
 

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -104,7 +104,8 @@ We use NFS for shared media files:
 3. Set resource limits
 4. Configure security contexts
 5. Use automated sync with ArgoCD
-6. Use the `Recreate` strategy for any Deployment that mounts a PVC
+6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
+7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.
 
 ## OpenWebUI Notes
 


### PR DESCRIPTION
## Summary
- prevent multi-attach errors by switching PVC-based Deployments to `Recreate`
- document the new requirement for apps using PersistentVolumeClaims

## Testing
- `npx prettier -w` *(files unchanged)*
- `yamllint k8s/applications/...` *(warnings only)*
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `kustomize build --enable-helm k8s/applications/web/babybuddy`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-ml`
- `kustomize build --enable-helm k8s/applications/media/immich` *(fails: cannot reach bitnami helm repo)*

------
https://chatgpt.com/codex/tasks/task_e_6843816ce558832282152dfa5f2856eb