### PR TITLE
fix(k8s): update argocd token generator image

### DIFF
--- a/k8s/infrastructure/controllers/argocd/token-generator-job.yaml
+++ b/k8s/infrastructure/controllers/argocd/token-generator-job.yaml
@@ -12,7 +12,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: token-generator
-          image: argoproj/argocd:v2.12.3
+          image: quay.io/argoproj/argocd:v2.12.3
           command:
             - /bin/bash
             - -c

--- a/k8s/infrastructure/controllers/argocd/token-rotator-cronjob.yaml
+++ b/k8s/infrastructure/controllers/argocd/token-rotator-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: token-rotator
-              image: argoproj/argocd:v2.12.3
+              image: quay.io/argoproj/argocd:v2.12.3
               command:
                 - /bin/bash
                 - -c

--- a/website/docs/infrastructure/controllers/kubechecks-token.md
+++ b/website/docs/infrastructure/controllers/kubechecks-token.md
@@ -32,6 +32,8 @@ metadata:
   namespace: argocd
 ```
 
+The job uses `quay.io/argoproj/argocd:v2.12.3` for the ArgoCD CLI to avoid DockerHub pull issues.
+
 The `PushSecret` uploads the token to Bitwarden under the key `argocd-kubechecks-api-token`.
 
 ## Consuming the token


### PR DESCRIPTION
## Summary
- switch token generator Job and CronJob to use `quay.io/argoproj/argocd:v2.12.3`
- document the new image used for kubechecks token generation

## Testing
- `npx prettier -w k8s/infrastructure/controllers/argocd/token-generator-job.yaml k8s/infrastructure/controllers/argocd/token-rotator-cronjob.yaml website/docs/infrastructure/controllers/kubechecks-token.md`
- `yamllint k8s/infrastructure/controllers/argocd/token-generator-job.yaml k8s/infrastructure/controllers/argocd/token-rotator-cronjob.yaml`
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd` *(failed: Error: looks like "https://argoproj.github.io/argo-helm" is not a valid chart repository or cannot be reached)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6843825b40cc8322b36995edd41471df