### PR TITLE
fix(k8s): set grafana oauth secret ids

### DIFF
--- a/k8s/infrastructure/monitoring/prometheus-stack/grafana-oauth-secret.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/grafana-oauth-secret.yaml
@@ -19,9 +19,9 @@ spec:
   data:
     - secretKey: clientId
       remoteRef:
-        key: "REPLACE_WITH_GRAFANA_OAUTH_CLIENT_ID_BITWARDEN_UUID"  # Replace with actual Bitwarden UUID
+        key: e0653cbf-e89e-4c7f-bf15-b2f4014daf64
         property: value
     - secretKey: clientSecret
       remoteRef:
-        key: "REPLACE_WITH_GRAFANA_OAUTH_CLIENT_SECRET_BITWARDEN_UUID"  # Replace with actual Bitwarden UUID
+        key: 56041409-832c-4d56-8688-b2f4014dc3cc
         property: value

--- a/website/docs/infrastructure/monitoring.md
+++ b/website/docs/infrastructure/monitoring.md
@@ -16,3 +16,23 @@ To avoid sync errors in Argo CD:
 3. The Application uses `ServerSideApply` so Argo CD no longer adds the `last-applied-configuration` annotation.
 
 This approach keeps the deployment idempotent and avoids manual patching of CRDs.
+
+## Grafana OAuth Credentials
+
+Grafana relies on OIDC with Authentik for authentication. The OAuth client ID and
+secret are managed through an ExternalSecret in `k8s/infrastructure/monitoring/prometheus-stack`.
+Ensure the secret keys reference the correct Bitwarden entries before deploying:
+
+```yaml
+data:
+  - secretKey: clientId
+    remoteRef:
+      key: e0653cbf-e89e-4c7f-bf15-b2f4014daf64
+      property: value
+  - secretKey: clientSecret
+    remoteRef:
+      key: 56041409-832c-4d56-8688-b2f4014dc3cc
+      property: value
+```
+
+If these values are missing, the Grafana pod will fail to authenticate.


### PR DESCRIPTION
## Summary
- set Grafana OAuth secret IDs
- document Grafana OAuth configuration

## Testing
- `kustomize build --enable-helm k8s/infrastructure/monitoring/prometheus-stack` *(fails: looks like `https://prometheus-community.github.io/helm-charts` is not reachable)*
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6844899feed48322981951c65ffed053