### PR TITLE
feat(website): enable local search

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,6 +6,10 @@ title: Homelab Kubernetes Configuration Guide
 
 This guide explains our homelab Kubernetes setup, designed to help IT admins understand, run, and maintain the system.
 
+## Searching the docs
+
+The site now includes local search powered by a lightweight plugin. Use the search bar at the top of any page to quickly find topics without relying on an external service.
+
 # Core Design Principles
 
 1. **GitOps as Source of Truth**

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -61,6 +61,14 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
+  plugins: [
+    [
+      '@cmfcmf/docusaurus-search-local',
+      {
+        hashed: true,
+      },
+    ],
+  ],
 
   themeConfig: {
     // Replace with your project's social card

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "typed.js": "^2.1.0"
+    "typed.js": "^2.1.0",
+    "@cmfcmf/docusaurus-search-local": "^1.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.8.1",


### PR DESCRIPTION
## Summary
- add local search dependency
- configure search plugin in Docusaurus
- document search capability in the intro

## Testing
- `npm install --legacy-peer-deps`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6844b3d679888322a9ec57865ccdab36