### PR TITLE
fix(website): replace local search plugin

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -8,7 +8,7 @@ This guide explains our homelab Kubernetes setup, designed to help IT admins und
 
 ## Searching the docs
 
-The site now includes local search powered by a lightweight plugin. Use the search bar at the top of any page to quickly find topics without relying on an external service.
+Local search runs entirely in the browser thanks to the `@easyops-cn/docusaurus-search-local` plugin. Use the search bar at the top of any page to quickly find topics, and your search terms will be highlighted on the destination page.
 
 # Core Design Principles
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -61,11 +61,13 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
-  plugins: [
+  themes: [
     [
-      '@cmfcmf/docusaurus-search-local',
+      require.resolve('@easyops-cn/docusaurus-search-local'),
       {
         hashed: true,
+        docsRouteBasePath: '/',
+        highlightSearchTermsOnTargetPage: true,
       },
     ],
   ],

--- a/website/package.json
+++ b/website/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "typed.js": "^2.1.0",
-    "@cmfcmf/docusaurus-search-local": "^1.2.0"
+    "@easyops-cn/docusaurus-search-local": "^0.50.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.8.1",


### PR DESCRIPTION
## Summary
- use `@easyops-cn/docusaurus-search-local` instead of the v2-only plugin
- configure new search plugin in `docusaurus.config.ts`
- update intro docs about local search

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6844bd45599883229355856e75962b01