### PR TITLE
docs: fix configuration inconsistencies

### DIFF
--- a/website/docs/applications/media-stack.md
+++ b/website/docs/applications/media-stack.md
@@ -73,9 +73,9 @@ Storage Classes:
 | Application | CPU Request | CPU Limit | Memory Request | Memory Limit | Storage     |
 | ----------- | ----------- | --------- | -------------- | ------------ | ----------- |
 | Jellyfin    | 2           | 4         | 2Gi            | 5Gi          | 2Ti (media) |
-| Sonarr      | 500m        | 1         | 512Mi          | 1Gi          | 10Gi        |
-| Radarr      | 500m        | 1         | 512Mi          | 1Gi          | 10Gi        |
-| Prowlarr    | 250m        | 500m      | 256Mi          | 512Mi        | 5Gi         |
+| Sonarr      | 50m         | 1         | 384Mi          | 1Gi          | 10Gi        |
+| Radarr      | 50m         | 1         | 128Mi          | 1Gi          | 10Gi        |
+| Prowlarr    | 50m         | 500m      | 192Mi          | 512Mi        | 5Gi         |
 
 ### Network Configuration
 

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -75,7 +75,7 @@ High-Availability Profile:
 
 | Controller       | CPU Request | Memory Request | CPU Limit | Memory Limit |
 | ---------------- | ----------- | -------------- | --------- | ------------ |
-| ArgoCD Server    | 500m        | 512Mi          | 2000m     | 1Gi          |
+| ArgoCD Server    | 50m         | 64Mi           | 2000m     | 1Gi          |
 | cert-manager     | 75m         | 96Mi           | 75m       | 96Mi         |
 | External Secrets | 80m         | 100Mi          | 80m       | 100Mi        |
 | Longhorn Manager | 250m        | 256Mi          | 250m      | 256Mi        |

--- a/website/docs/infrastructure/overview.md
+++ b/website/docs/infrastructure/overview.md
@@ -80,13 +80,8 @@ infrastructure/
 
 ```yaml
 Deployment Flow:
-1. CRDs (Wave -1)
-2. Core Infrastructure (Wave 0)
-3. Controllers (Wave 1)
-4. Storage (Wave 2)
-5. Networking (Wave 3)
-6. Authentication (Wave 4)
-7. Applications (Wave 5+)
+1. Infrastructure (Wave -10)
+2. Applications (Wave 0)
 ```
 
 ### Version Control

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -17,7 +17,7 @@ This document highlights the four critical issues that blocked a smooth Immich d
 
 ## Overview of Issues & Resolutions
 
-1. **PostgreSQL Extensions Missing** → Operator CRD misconfigured (pgvector & vectorchord)
+1. **PostgreSQL Extension Missing** → Operator CRD lacked the `vchord` extension
 2. **DB\_URL Secret Fragmentation** → Immich requires a single URI
 3. **ExternalSecret Authentication Failures** → Missing CA & RBAC
 4. **Resource Organization** → Inconsistent manifests
@@ -27,7 +27,7 @@ This document highlights the four critical issues that blocked a smooth Immich d
 ## 1. PostgreSQL: Vector Extensions Not Loaded
 
 **Why it failed:**
-By default, the Zalando operator won't install `pgvector` and `vectorchord` unless they're explicitly declared in the CRD's `preparedDatabases` block.
+By default, the Zalando operator won't install the `vchord` extension unless it's explicitly declared in the CRD's `preparedDatabases` block.
 
 **How we fixed it:**
 In `database.yaml`, specify each extension under `spec.preparedDatabases` so the operator creates them at startup:
@@ -38,8 +38,7 @@ spec:
   preparedDatabases:
     immich:
       extensions:
-        pgvector: public
-        vectorchord: public
+        vchord: public
 ```
 
 ---

--- a/website/docs/k8s/cloudflare-dns-records.md
+++ b/website/docs/k8s/cloudflare-dns-records.md
@@ -37,7 +37,7 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
 1. **Deploy Crossplane**: Install the Crossplane Helm chart into `crossplane-system`.
 2. **Fetch Cloudflare token**: Create an `ExternalSecret` to sync the API token into a Secret.
 3. **Install Cloudflare provider**: Apply the `Provider` and `ProviderConfig` manifests.
-4. **Declare DNS records**: Add `dns-record.yaml` and update `kustomization.yaml` in each service repo.
+4. **Declare DNS records**: Edit `dns-records.yaml` under `k8s/infrastructure/controllers/crossplane/` to add new `Record` entries.
 5. **Apply and verify**: Deploy manifests and confirm records in Crossplane and Cloudflare.
 
 ## Deploy Crossplane and configure the Cloudflare provider
@@ -53,16 +53,7 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
 
 ## Apply DNS records for each service
 
-Each application repository should include:
-
-1. A `dns-record.yaml` manifest declaring a `Record` (type `CNAME`) with:
-   - `metadata.name` and `metadata.namespace` matching the service.
-   - `spec.forProvider.name` as the hostname (e.g., `frigate`).
-   - `spec.forProvider.value` as the Cloudflare Tunnel target.
-
-2. An update to `kustomization.yaml` adding `dns-record.yaml` to the resources list.
-
-Repeat for Immich, Jellyfin, Jellyseerr, Baby Buddy, IT Tools, Authentik, etc., adjusting names and namespaces per service.
+DNS records are defined centrally. Update `k8s/infrastructure/controllers/crossplane/dns-records.yaml` with a new `Record` block for each service. ArgoCD reconciles the file and provisions the records in Cloudflare.
 
 ## Verify the configuration
 

--- a/website/docs/k8s/infrastructure/dex-configuration.md
+++ b/website/docs/k8s/infrastructure/dex-configuration.md
@@ -64,13 +64,9 @@ configs:
 
 4. Correct the variable reference for `clientID` to `$dex.authentik.clientId`.
 
-## Deleting `values-oidc.yaml`
+## Legacy `values-oidc.yaml`
 
-The `values-oidc.yaml` file is no longer needed with the DEX configuration. Delete the file located in `k8s/infrastructure/controllers/argocd/`.
-
-## Updating `kustomization.yaml`
-
-Remove the reference to `values-oidc.yaml` in `k8s/infrastructure/controllers/argocd/kustomization.yaml` if it exists.
+Earlier revisions included a separate `values-oidc.yaml` file. That file has since been removed from the repository, so no cleanup is required.
 
 ## Adding Secret Entry for `dex.authentik.clientId`
 
@@ -90,4 +86,4 @@ Replace `<appropriate-remote-key>` with the actual remote key for `dex.authentik
 
 ## Summary
 
-By following these steps, you will enable DEX in ArgoCD, update the `values.yaml` file, delete the unnecessary `values-oidc.yaml` file, update the `kustomization.yaml` file, and add the secret entry for `dex.authentik.clientId`.
+By following these steps, you will enable DEX in ArgoCD, update the `values.yaml` file, and add the secret entry for `dex.authentik.clientId`.

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -91,25 +91,26 @@ Define nodes in `/tofu/main.tf` with:
 
 ```hcl
 module "talos" {
+  talos_image = {
+    version        = "<see https://github.com/siderolabs/talos/releases>"
+    schematic_path = "${path.root}/tofu/talos/image/schematic.yaml.tftpl"
+    # update_version and update_schematic_path can be set as needed
+  }
+
   nodes = {
     "node1" = {
-      host_node    = "proxmox1"
-      machine_type = "controlplane"
-      ip           = "10.0.0.1" # Example IP
-      cpu          = 4
+      host_node     = "proxmox1"
+      machine_type  = "controlplane"
+      ip            = "10.0.0.1" # Example IP
+      cpu           = 4
       ram_dedicated = 8192
       disks = {
-        # Example: a primary disk for the OS (often handled by the image cloning)
-        # and an additional disk for Longhorn.
-        # The exact structure depends on your module's variables.tf.
-        # This example assumes a structure like the one found in the repository:
-        longhorn = { # Key for the disk, e.g., 'longhorn' or 'data'
-          device     = "/dev/sdb" # Or another available device
+        longhorn = {
+          device     = "/dev/sdb"
           size       = "180G"
-          type       = "scsi"     # Or 'virtio', 'sata'
-          mountpoint = "/var/lib/longhorn" # If applicable for Talos config
+          type       = "scsi"
+          mountpoint = "/var/lib/longhorn"
         }
-        # os_disk = { ... } # If explicitly defining the OS disk
       }
     }
   }
@@ -167,19 +168,20 @@ We embed essential services in the Talos config:
    Example snippet from `main.tf` (actual structure may vary based on module inputs):
 
    ```hcl
-   module "talos" {
-     # ...
-     image = {
-       version = "<see https://github.com/siderolabs/talos/releases>" # Target Talos version for OS images
-       # ...
-     }
-     cluster = {
-       talos_version      = "<see https://github.com/siderolabs/talos/releases>" # Target Talos version for machine configs
-       kubernetes_version = "<see https://github.com/kubernetes/kubernetes/releases>"  # Target Kubernetes version
-       # ...
-     }
-     # ...
-   }
+  module "talos" {
+    # ...
+    talos_image = {
+      version        = "<see https://github.com/siderolabs/talos/releases>" # Target Talos version for OS images
+      schematic_path = "${path.root}/tofu/talos/image/schematic.yaml.tftpl"
+      # update_version and update_schematic_path when performing upgrades
+    }
+    cluster = {
+      talos_version      = "<see https://github.com/siderolabs/talos/releases>" # Target Talos version for machine configs
+      kubernetes_version = "<see https://github.com/kubernetes/kubernetes/releases>"  # Target Kubernetes version
+      # ...
+    }
+    # ...
+  }
    ```
 
 2. Set `update = true` for affected nodes if your OpenTofu module supports this flag for triggering upgrades. Otherwise,


### PR DESCRIPTION
## Summary
- correct resource values for ArgoCD, Sonarr, Radarr and Prowlarr
- align tofu examples with current variables and paths
- update disaster recovery guide to reinforce GitOps workflow
- fix Immich extension notes
- remove outdated dex configuration cleanup
- update centralized DNS instructions
- simplify sync-wave explanation

## Testing
- `npm install`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca4b7a8c83228b60b76acdda6213