### PR TITLE
feat(k8s): add probes and backups

### DIFF
--- a/k8s/applications/ai/karakeep/kustomization.yaml
+++ b/k8s/applications/ai/karakeep/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - meilisearch-deployment.yaml
 - meilisearch-service.yaml
 - meilisearch-pvc.yaml
+- meilisearch-backup-cronjob.yaml
 - data-pvc.yaml
 - http-route.yaml
 - karakeep-secrets-external.yaml

--- a/k8s/applications/ai/karakeep/meilisearch-backup-cronjob.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-backup-cronjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: meilisearch-backup
+  namespace: karakeep
+spec:
+  schedule: "30 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: meili-backup
+              image: getmeili/meilisearch:v1.14.0
+              command: ["/bin/sh","-c"]
+              args:
+                - meilisearch --dump-dir /backup --dump
+              volumeMounts:
+                - mountPath: /backup
+                  name: backup
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: meilisearch-pvc

--- a/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
@@ -48,6 +48,22 @@ spec:
                 name: karakeep-secrets
             - configMapRef:
                 name: karakeep-configuration
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 7700
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 7700
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: meilisearch
           persistentVolumeClaim:

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -51,3 +51,19 @@ spec:
                 name: karakeep-secrets
             - configMapRef:
                 name: karakeep-configuration
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/applications/ai/openwebui/webui-deployment.yaml
+++ b/k8s/applications/ai/openwebui/webui-deployment.yaml
@@ -80,3 +80,19 @@ spec:
               mountPath: /app/backend/data
             - name: tmp
               mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -50,6 +50,22 @@ spec:
             limits:
               cpu: 1000m
               memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6767
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 6767
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: bazarr-config
           persistentVolumeClaim:

--- a/k8s/applications/media/arr/prowlarr/deployment.yaml
+++ b/k8s/applications/media/arr/prowlarr/deployment.yaml
@@ -36,6 +36,22 @@ spec:
             limits:
               cpu: 1000m
               memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9696
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9696
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: prowlarr-config
           persistentVolumeClaim:

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -36,6 +36,22 @@ spec:
             limits:
               cpu: 1000m
               memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 7878
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 7878
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: radarr-config
           persistentVolumeClaim:

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -36,6 +36,22 @@ spec:
             limits:
               cpu: 1000m
               memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8989
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8989
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: sonarr-config
           persistentVolumeClaim:

--- a/k8s/applications/media/immich/immich-redis/values.yaml
+++ b/k8s/applications/media/immich/immich-redis/values.yaml
@@ -6,6 +6,9 @@ auth:
 fullnameOverride: immich-redis
 
 primary:
+  persistence:
+    enabled: true
+    size: 1Gi
   resources:
     requests:
       cpu: 80m

--- a/k8s/applications/media/immich/immich-server/database.yaml
+++ b/k8s/applications/media/immich/immich-server/database.yaml
@@ -15,7 +15,7 @@ spec:
       - createdb
   databases:
     immich: immich
-  enableLogicalBackup: false
+  enableLogicalBackup: true
   preparedDatabases:
     immich:
       extensions:

--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -51,6 +51,22 @@ spec:
               mountPath: /app/data
             - name: cache
               mountPath: /cache
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8096
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8096
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -47,6 +47,22 @@ spec:
               mountPath: /app/data
             - name: sabnzbd-incomplete
               mountPath: /downloads/incomplete
+          livenessProbe:
+            httpGet:
+              path: /api?mode=version
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api?mode=version
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: sabnzbd-config
           persistentVolumeClaim:

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -34,3 +34,19 @@ spec:
           envFrom:
             - secretRef:
                 name: jellyseerr-jellyfin
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/applications/network/omada/deployment.yaml
+++ b/k8s/applications/network/omada/deployment.yaml
@@ -105,6 +105,20 @@ spec:
               value: Etc/UTC
             - name: SKIP_USERMOD
               value: 'true'
+          livenessProbe:
+            tcpSocket:
+              port: 8088
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8088
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: omada-data
               mountPath: /opt/tplink/EAPController/data

--- a/k8s/applications/tools/it-tools/deployment.yaml
+++ b/k8s/applications/tools/it-tools/deployment.yaml
@@ -54,3 +54,19 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /run
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/applications/tools/whoami/deployment.yaml
+++ b/k8s/applications/tools/whoami/deployment.yaml
@@ -42,3 +42,19 @@ spec:
             limits:
               cpu: '100m'
               memory: '48Mi'
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/applications/web/babybuddy/deployment.yaml
+++ b/k8s/applications/web/babybuddy/deployment.yaml
@@ -47,6 +47,22 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/k8s/applications/web/pedrobot/deployment.yaml
+++ b/k8s/applications/web/pedrobot/deployment.yaml
@@ -39,6 +39,22 @@ spec:
               mountPath: /app/logs
             - name: data
               mountPath: /app/data
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: logs
           hostPath:

--- a/k8s/applications/web/pedrobot/kustomization.yaml
+++ b/k8s/applications/web/pedrobot/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - service.yaml
 - http-route.yaml
 - mongodb-statefulset.yaml
+- mongodb-backup-cronjob.yaml

--- a/k8s/applications/web/pedrobot/mongodb-backup-cronjob.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-backup-cronjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mongodb-backup
+  namespace: pedro-bot
+spec:
+  schedule: "0 4 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mongo-backup
+              image: mongo:8.0
+              command: ["/bin/sh","-c"]
+              args:
+                - mongodump --uri=mongodb://mongodb:27017/pedro-bot --archive=/backup/mongodb-$(date +%F).gz --gzip
+              volumeMounts:
+                - mountPath: /backup
+                  name: backup
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: mongo-data

--- a/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
@@ -30,6 +30,20 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
   volumeClaimTemplates:
     - metadata:
         name: mongo-data

--- a/k8s/infrastructure/auth/authentik/database.yaml
+++ b/k8s/infrastructure/auth/authentik/database.yaml
@@ -14,6 +14,7 @@ spec:
       - createdb
   databases:
     authentik: authentik_user
+  enableLogicalBackup: true
   postgresql:
     version: "17"
   enableConnectionPooler: false

--- a/k8s/infrastructure/auth/authentik/values.yaml
+++ b/k8s/infrastructure/auth/authentik/values.yaml
@@ -230,6 +230,10 @@ redis:
     enabled: true
     existingSecret: authentik-core-secrets
     existingSecretPasswordKey: redis-password
+  master:
+    persistence:
+      enabled: true
+      size: 1Gi
 
 prometheus:
   rules:

--- a/k8s/infrastructure/database/postgresql/values.yaml
+++ b/k8s/infrastructure/database/postgresql/values.yaml
@@ -126,7 +126,7 @@ configKubernetes:
   # use finalizers to ensure all managed resources are deleted prior to the postgresql CR
   # this avoids stale resources in case the operator misses a delete event or is not running
   # during deletion
-  enable_finalizers: false
+  enable_finalizers: true
   # enables initContainers to run actions before Spilo is started
   enable_init_containers: true
   # toggles if child resources should have an owner reference to the postgresql CR
@@ -138,7 +138,7 @@ configKubernetes:
   # toggles PDB to set to MinAvailabe 0 or 1
   enable_pod_disruption_budget: true
   # toogles readiness probe for database pods
-  enable_readiness_probe: false
+  enable_readiness_probe: true
   # toggles if operator should delete secrets on cluster deletion
   enable_secrets_deletion: true
   # enables sidecar containers to run alongside Spilo in the same pod
@@ -375,11 +375,11 @@ configLogicalBackup:
   # S3 Access Key ID
   logical_backup_s3_access_key_id: ""
   # S3 bucket to store backup results
-  logical_backup_s3_bucket: "my-bucket-url"
+  logical_backup_s3_bucket: "homelab-postgres-backups"
   # S3 bucket prefix to use
   logical_backup_s3_bucket_prefix: "spilo"
   # S3 region of bucket
-  logical_backup_s3_region: ""
+  logical_backup_s3_region: "us-east-1"
   # S3 endpoint url when not using AWS
   logical_backup_s3_endpoint: ""
   # S3 Secret Access Key
@@ -389,7 +389,7 @@ configLogicalBackup:
   # S3 retention time for stored backups for example "2 week" or "7 days"
   logical_backup_s3_retention_time: ""
   # backup schedule in the cron format
-  logical_backup_schedule: "30 00 * * *"
+  logical_backup_schedule: "0 3 * * *"
   # secret to be used as reference for env variables in cronjob
   logical_backup_cronjob_environment_secret: ""
 

--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -123,6 +123,8 @@ readinessProbe:
   periodSeconds: 10
 ```
 
+All other deployments now include similar probes to keep services responsive.
+
 ### Resource Monitoring
 
 - CPU and memory utilization

--- a/website/docs/disaster/disaster-recovery.md
+++ b/website/docs/disaster/disaster-recovery.md
@@ -233,6 +233,7 @@ After successful recovery:
 
 1. **Update Monitoring**: Ensure all monitoring and alerting is functional
 2. **Test Backups**: Verify new backup jobs are running correctly
+   - Automated CronJobs handle MongoDB and Meilisearch snapshots. Confirm recent successful runs with `kubectl get jobs -n <namespace>`.
 3. **Document Changes**: Record any configuration changes made during recovery
 4. **Schedule DR Test**: Plan the next disaster recovery test
 


### PR DESCRIPTION
## Summary
- add liveness and readiness checks for most deployments
- enable Postgres logical backups and finalizers
- add backup CronJobs for Meilisearch and MongoDB
- enable Redis persistence
- document new backup jobs

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `kustomize build --enable-helm k8s/applications/media/arr/bazarr`
- `kustomize build --enable-helm k8s/applications/media/arr/prowlarr`
- `kustomize build --enable-helm k8s/applications/media/arr/radarr`
- `kustomize build --enable-helm k8s/applications/media/arr/sonarr`
- `kustomize build --enable-helm k8s/applications/media/immich` *(failed: Forbidden)*
- `kustomize build --enable-helm k8s/applications/media/jellyfin`
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `kustomize build --enable-helm k8s/applications/media/whisperasr`
- `kustomize build --enable-helm k8s/applications/network/omada`
- `kustomize build --enable-helm k8s/applications/tools/it-tools`
- `kustomize build --enable-helm k8s/applications/tools/whoami`
- `kustomize build --enable-helm k8s/applications/web/babybuddy`
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik` *(failed: Forbidden)*
- `kustomize build --enable-helm k8s/infrastructure/database/postgresql` *(failed: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68456a448a608322b2af84491efd6016