### PR TITLE
fix(k8s): set babybuddy port to 3000

### DIFF
--- a/k8s/applications/web/babybuddy/deployment.yaml
+++ b/k8s/applications/web/babybuddy/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               cpu: '300m'
               memory: '512Mi'
           ports:
-            - containerPort: 8000
+            - containerPort: 3000
               name: http
           env:
             - name: PUID
@@ -50,7 +50,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 8000
+              port: 3000
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -58,7 +58,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 8000
+              port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 5

--- a/k8s/applications/web/babybuddy/http-route.yaml
+++ b/k8s/applications/web/babybuddy/http-route.yaml
@@ -18,4 +18,4 @@ spec:
             value: /
       backendRefs:
         - name: babybuddy
-          port: 8000
+          port: 3000

--- a/k8s/applications/web/babybuddy/service.yaml
+++ b/k8s/applications/web/babybuddy/service.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: babybuddy
   ports:
-    - port: 8000
+    - port: 3000
       targetPort: http
       protocol: TCP
       name: http

--- a/k8s/applications/web/babybuddy/values.yaml
+++ b/k8s/applications/web/babybuddy/values.yaml
@@ -23,7 +23,7 @@ envFrom:
 
 service:
   port:
-    port: 8000
+    port: 3000
 ingress:
   enabled: false
 

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -112,4 +112,9 @@ We use NFS for shared media files:
 OpenWebUI provides a chat interface backed by local AI models. The deployment integrates with Authentik using OIDC. The
 `OLLAMA_BASE_URL` variable is intentionally omitted because the Ollama stack is not managed in this repository.
 
+## BabyBuddy Notes
+
+BabyBuddy runs on port `3000`. Update your service and readiness probes to point
+to this port if you override the default configuration.
+
 Need help? Check the application examples in `/k8s/applications/` for reference implementations.


### PR DESCRIPTION
## Summary
- update BabyBuddy port to 3000
- document BabyBuddy port in application management docs

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/web`

------
https://chatgpt.com/codex/tasks/task_e_684585422c7883228815910474b54533