### PR TITLE
fix(k8s): relax probe intervals

### DIFF
--- a/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
@@ -52,17 +52,17 @@ spec:
             httpGet:
               path: /health
               port: 7700
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 7700
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: meilisearch

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -56,14 +56,14 @@ spec:
               path: /
               port: 3000
             initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/applications/ai/openwebui/webui-deployment.yaml
+++ b/k8s/applications/ai/openwebui/webui-deployment.yaml
@@ -84,15 +84,15 @@ spec:
             httpGet:
               path: /
               port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -54,17 +54,17 @@ spec:
             httpGet:
               path: /
               port: 6767
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 6767
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: bazarr-config

--- a/k8s/applications/media/arr/prowlarr/deployment.yaml
+++ b/k8s/applications/media/arr/prowlarr/deployment.yaml
@@ -40,17 +40,17 @@ spec:
             httpGet:
               path: /
               port: 9696
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 9696
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: prowlarr-config

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -40,17 +40,17 @@ spec:
             httpGet:
               path: /
               port: 7878
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 7878
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: radarr-config

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -40,17 +40,17 @@ spec:
             httpGet:
               path: /
               port: 8989
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 8989
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: sonarr-config

--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -63,9 +63,9 @@ spec:
             httpGet:
               path: /ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
           name: immich-machine-learning
           ports:
             - containerPort: 3003
@@ -76,17 +76,17 @@ spec:
             httpGet:
               path: /ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
           startupProbe:
             failureThreshold: 60
             httpGet:
               path: /ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
           volumeMounts:
             - mountPath: /cache
               name: cache

--- a/k8s/applications/media/immich/immich-server/deployment.yaml
+++ b/k8s/applications/media/immich/immich-server/deployment.yaml
@@ -63,9 +63,9 @@ spec:
             httpGet:
               path: /api/server/ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
           name: immich-server
           ports:
             - containerPort: 2283
@@ -82,17 +82,17 @@ spec:
             httpGet:
               path: /api/server/ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
           startupProbe:
             failureThreshold: 30
             httpGet:
               path: /api/server/ping
               port: http
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
           volumeMounts:
             - mountPath: /config
               name: config

--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -55,17 +55,17 @@ spec:
             httpGet:
               path: /
               port: 8096
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 8096
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: config

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -51,17 +51,17 @@ spec:
             httpGet:
               path: /api?mode=version
               port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /api?mode=version
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: sabnzbd-config

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -38,15 +38,15 @@ spec:
             httpGet:
               path: /
               port: 9000
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 9000
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/applications/network/omada/deployment.yaml
+++ b/k8s/applications/network/omada/deployment.yaml
@@ -109,15 +109,15 @@ spec:
             tcpSocket:
               port: 8088
             initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 8088
-            initialDelaySeconds: 15
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           volumeMounts:
             - name: omada-data

--- a/k8s/applications/tools/it-tools/deployment.yaml
+++ b/k8s/applications/tools/it-tools/deployment.yaml
@@ -59,14 +59,14 @@ spec:
               path: /
               port: 80
             initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/applications/tools/whoami/deployment.yaml
+++ b/k8s/applications/tools/whoami/deployment.yaml
@@ -47,14 +47,14 @@ spec:
               path: /
               port: 80
             initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/applications/web/pedrobot/deployment.yaml
+++ b/k8s/applications/web/pedrobot/deployment.yaml
@@ -43,17 +43,17 @@ spec:
             httpGet:
               path: /health
               port: 3000
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
       volumes:
         - name: logs

--- a/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
@@ -34,15 +34,15 @@ spec:
             tcpSocket:
               port: 27017
             initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 27017
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
   volumeClaimTemplates:
     - metadata:

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -121,15 +121,15 @@ deployment:
 
   livenessProbe:
     failureThreshold: 30
-    initialDelaySeconds: 5
-    periodSeconds: 10
+    initialDelaySeconds: 10
+    periodSeconds: 15
     successThreshold: 1
-    timeoutSeconds: 5
+    timeoutSeconds: 10
 
   readinessProbe:
     failureThreshold: 30
-    initialDelaySeconds: 5
-    periodSeconds: 10
+    initialDelaySeconds: 10
+    periodSeconds: 15
     successThreshold: 1
     timeoutSeconds: 10
 

--- a/k8s/infrastructure/network/coredns/deployment.yaml
+++ b/k8s/infrastructure/network/coredns/deployment.yaml
@@ -75,7 +75,8 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 60
-            timeoutSeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
             successThreshold: 1
             failureThreshold: 5
           readinessProbe:
@@ -83,6 +84,9 @@ spec:
               path: /ready
               port: 8181
               scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -112,15 +112,17 @@ livenessProbe:
   httpGet:
     path: /health
     port: 80
-  initialDelaySeconds: 10
-  periodSeconds: 30
+  initialDelaySeconds: 15
+  periodSeconds: 15
+  timeoutSeconds: 10
 
 readinessProbe:
   httpGet:
     path: /ready
     port: 80
-  initialDelaySeconds: 5
-  periodSeconds: 10
+  initialDelaySeconds: 15
+  periodSeconds: 15
+  timeoutSeconds: 10
 ```
 
 All other deployments now include similar probes to keep services responsive.


### PR DESCRIPTION
## Summary
- raise timeoutSeconds to 10 and align periodSeconds to 15s
- allow longer startup for heavy apps like Immich and Omada
- document new health check settings in utility-tools guide

## Testing
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `kustomize build --enable-helm k8s/applications/media/arr/bazarr`
- `kustomize build --enable-helm k8s/applications/media/arr/prowlarr`
- `kustomize build --enable-helm k8s/applications/media/arr/radarr`
- `kustomize build --enable-helm k8s/applications/media/arr/sonarr`
- `kustomize build --enable-helm k8s/applications/media/immich` *(fails: Forbidden)*
- `kustomize build --enable-helm k8s/applications/media/jellyfin`
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `kustomize build --enable-helm k8s/applications/media/whisperasr`
- `kustomize build --enable-helm k8s/applications/network/omada`
- `kustomize build --enable-helm k8s/applications/tools/it-tools`
- `kustomize build --enable-helm k8s/applications/tools/whoami`
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks` *(fails: Forbidden)*
- `kustomize build --enable-helm k8s/infrastructure/network/coredns`
- `npm install`
- `cd website && npm install && npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6845e332b0a0832296219431f1315ce0