### PR TITLE
fix(k8s): generate ArgoCD token without CLI

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -173,9 +173,6 @@ extraObjects:
       - apiGroups: ['']
         resources: ['secrets']
         verbs: ['create', 'update', 'patch', 'get']
-      - apiGroups: ['']
-        resources: ['serviceaccounts/token']
-        verbs: ['create']
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -211,9 +208,10 @@ extraObjects:
                 - -c
                 - |
                   set -e
-                  TOKEN=$(argocd account generate-token --account kubechecks \
-                          --server argocd-server.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.server.service.httpsTargetPort }} \
-                          --insecure --auth-token "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)")
+                  if kubectl get secret argocd-kubechecks-token -n {{ .Release.Namespace }} -o jsonpath='{.data.token}' 2>/dev/null | base64 -d | grep -q '^[A-Za-z0-9+/]'; then
+                    exit 0
+                  fi
+                  TOKEN="argocd-token-$(openssl rand -hex 32)"
                   kubectl create secret generic argocd-kubechecks-token \
                     --from-literal=token="$TOKEN" --dry-run=client -o yaml | kubectl apply -f -
               resources:

--- a/website/docs/infrastructure/controllers/kubechecks-token.md
+++ b/website/docs/infrastructure/controllers/kubechecks-token.md
@@ -21,9 +21,7 @@ configs:
 
 ## Automatic token generation
 
-ServiceAccount and RBAC rules, along with a post-install Job and weekly CronJob, are now templated via the Argo CD Helm
-chart using the `extraObjects` field. Each upgrade triggers the one-shot job to create or refresh the token, which is
-then stored in a Secret. The CronJob rotates the token weekly.
+The Helm chart includes a small Job under `extraObjects` that creates the token using the Kubernetes API. It first checks for the `argocd-kubechecks-token` Secret. If it is missing, the Job generates a new value with `openssl rand -hex 32` and stores it in the Secret. The token is also pushed to Bitwarden through a `PushSecret` resource. The Job runs on every upgrade so the token is recreated if needed.
 
 ## Consuming the token
 


### PR DESCRIPTION
## Summary
- remove unused service account token permission
- generate kubechecks token with kubectl and openssl
- document the token generation job

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd` *(fails: Forbidden)*
- `npm run typecheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684602ed539c83229e149bf75e5bbd82