### PR TITLE
feat(k8s): add probes and pvc updates

### DIFF
--- a/k8s/applications/ai/karakeep/chrome-deployment.yaml
+++ b/k8s/applications/ai/karakeep/chrome-deployment.yaml
@@ -50,3 +50,20 @@ spec:
             limits:
               cpu: '300m'
               memory: '512Mi'
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9222
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9222
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 1
+

--- a/k8s/applications/ai/openwebui/ollama-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/ollama-statefulset.yaml
@@ -47,6 +47,22 @@ spec:
         - name: ollama-volume
           mountPath: /home/ollama/.ollama
         tty: true
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 11434
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 11434
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 1
   volumeClaimTemplates:
   - metadata:
       name: ollama-volume

--- a/k8s/applications/automation/mqtt/deployment.yaml
+++ b/k8s/applications/automation/mqtt/deployment.yaml
@@ -28,6 +28,20 @@ spec:
               mountPath: /mosquitto/config
           ports:
             - containerPort: 1883
+          livenessProbe:
+            tcpSocket:
+              port: 1883
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 1883
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
       volumes:
         - name: config
           projected:

--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -12,8 +12,6 @@ spec:
       app: jellyfin
   template:
     spec:
-      nodeSelector:
-        topology.kubernetes.io/zone: host3
       securityContext:
         runAsNonRoot: true
         runAsUser: 2501

--- a/k8s/applications/tools/unrar/deployment.yaml
+++ b/k8s/applications/tools/unrar/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - "pgrep -f 'unrar x'"
+                - "ps -eo args | grep -E '^unrar x' | grep -v grep"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10

--- a/k8s/applications/tools/unrar/deployment.yaml
+++ b/k8s/applications/tools/unrar/deployment.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         app: unrar
     spec:
-      nodeSelector:
-        topology.kubernetes.io/zone: host3
       securityContext:
         runAsNonRoot: true
         runAsUser: 2501
@@ -53,6 +51,16 @@ spec:
               mountPath: /tmp
             - name: unrar-data
               mountPath: /mnt/data
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'unrar x'"
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 3
       volumes:
         - name: tmp
           emptyDir: {}

--- a/k8s/applications/web/pedrobot/deployment.yaml
+++ b/k8s/applications/web/pedrobot/deployment.yaml
@@ -57,8 +57,8 @@ spec:
             failureThreshold: 3
       volumes:
         - name: logs
-          hostPath:
-            path: /var/log/pedro-bot
+          persistentVolumeClaim:
+            claimName: pedro-bot-logs
         - name: data
-          hostPath:
-            path: /etc/pedro-bot
+          persistentVolumeClaim:
+            claimName: pedro-bot-data

--- a/k8s/applications/web/pedrobot/pvc.yaml
+++ b/k8s/applications/web/pedrobot/pvc.yaml
@@ -10,3 +10,31 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: longhorn
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pedro-bot-logs
+  namespace: pedro-bot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pedro-bot-data
+  namespace: pedro-bot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -107,6 +107,8 @@ policies:
 
 ### Health Checks
 
+Unrar now includes a liveness probe to verify its extraction loop is running.
+
 ```yaml
 livenessProbe:
   httpGet:

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -112,6 +112,9 @@ We use NFS for shared media files:
 OpenWebUI provides a chat interface backed by local AI models. The deployment integrates with Authentik using OIDC. The
 `OLLAMA_BASE_URL` variable is intentionally omitted because the Ollama stack is not managed in this repository.
 
+Chrome and Ollama now define both liveness and readiness probes so Kubernetes can restart them if they crash and only route traffic when each pod is ready.
+Mosquitto and Unrar use similar probes. Pedro Bot now relies on PersistentVolumeClaims for logs and data, and Jellyfin and Unrar are free to run on any available node.
+
 ## BabyBuddy Notes
 
 BabyBuddy runs on port `3000`. Update your service and readiness probes to point


### PR DESCRIPTION
## Summary
- add health probes for Mosquitto MQTT broker
- migrate pedro-bot volumes to PVCs
- remove node pinning for Jellyfin and Unrar
- add liveness check for Unrar
- document new health probes and storage changes

## Testing
- `kustomize build --enable-helm k8s/applications/automation/mqtt`
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `kustomize build --enable-helm k8s/applications/media/jellyfin`
- `kustomize build --enable-helm k8s/applications/tools/unrar`
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684699d45a908322b6f6018f69d1c048