### PR TITLE
fix(k8s): limit kubechecks cpu

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -82,6 +82,7 @@ deployment:
   resources:
     limits:
       memory: 512Mi
+      cpu: 500m
     requests:
       memory: 256Mi
       cpu: 200m

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -49,6 +49,15 @@ This document outlines the core infrastructure controllers deployed in our Kuber
 - Backup capabilities
 - Storage overprovisioning
 
+### Kubechecks
+
+- **Purpose**: Validate ArgoCD applications via policy checks
+- **Version**: Latest stable (automated by Renovate)
+- **Features**:
+  - Schema validation
+  - GitHub integration
+  - Custom webhook support
+
 ## Resource Management
 
 ### Base Resource Configuration
@@ -79,6 +88,7 @@ High-Availability Profile:
 | cert-manager     | 75m         | 96Mi           | 75m       | 96Mi         |
 | External Secrets | 80m         | 100Mi          | 80m       | 100Mi        |
 | Longhorn Manager | 250m        | 256Mi          | 250m      | 256Mi        |
+| Kubechecks       | 200m        | 256Mi          | 500m      | 512Mi        |
 
 ## High Availability
 


### PR DESCRIPTION
## Summary
- set a CPU limit for the kubechecks deployment
- document kubechecks resources and features

## Testing
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks` *(fails: chart repository forbidden)*
- `npm install --silent`
- `npm run typecheck` *(fails: cannot find module 'react-icons/si')*

------
https://chatgpt.com/codex/tasks/task_e_6846bb792c8883228d4f5752bce12ed7