### PR TITLE
feat(k8s): add pod disruption budgets

### DIFF
--- a/k8s/applications/automation/frigate/kustomization.yaml
+++ b/k8s/applications/automation/frigate/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - externalsecret.yaml
   - http-route.yaml
+  - pdb.yaml
 
 configMapGenerator:
 - name: frigate-env

--- a/k8s/applications/automation/frigate/pdb.yaml
+++ b/k8s/applications/automation/frigate/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frigate-pdb
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frigate

--- a/k8s/infrastructure/controllers/argocd/kustomization.yaml
+++ b/k8s/infrastructure/controllers/argocd/kustomization.yaml
@@ -2,14 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- namespace.yaml
-- http-route.yaml
-- http-route-api.yaml
-- argocd-tls.yaml
-- rolebinding.yaml
-- role.yaml
-- externalsecret.yaml
-- token-pushsecret.yaml
+  - namespace.yaml
+  - http-route.yaml
+  - http-route-api.yaml
+  - argocd-tls.yaml
+  - rolebinding.yaml
+  - role.yaml
+  - externalsecret.yaml
+  - token-pushsecret.yaml
+  - pdb.yaml
 
 helmCharts:
 - name: argo-cd

--- a/k8s/infrastructure/controllers/argocd/pdb.yaml
+++ b/k8s/infrastructure/controllers/argocd/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argocd-server-pdb
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server

--- a/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - kubechecks-secret-external.yaml
   - http-route.yaml
+  - pdb.yaml
 
 helmCharts:
   - name: kubechecks

--- a/k8s/infrastructure/deployment/kubechecks/pdb.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/pdb.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: kubechecks-pdb
 spec:
-  maxUnavailable: 0
+  minAvailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: kubechecks

--- a/k8s/infrastructure/deployment/kubechecks/pdb.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubechecks-pdb
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubechecks

--- a/website/docs/k8s/cluster-config-overview.md
+++ b/website/docs/k8s/cluster-config-overview.md
@@ -82,3 +82,11 @@ kubectl uncordon node-name
 - Monitor node health after maintenance
 - Ensure cluster has capacity for workload redistribution
 - Consider impact on stateful applications
+
+### Pod Disruption Budgets
+
+PodDisruptionBudgets (PDBs) keep critical pods running during a voluntary
+node drain. Most of our applications run a single replica, so each namespace
+defines a simple PDB with `maxUnavailable: 0`. When you drain a node hosting
+one of these pods, the operation waits until another replica is available or the
+PDB is removed. This prevents accidental outages during routine maintenance.


### PR DESCRIPTION
## Summary
- prevent evictions during node drains with PodDisruptionBudgets
- document how PDBs help protect single-replica workloads

## Testing
- `npm install`
- `npm run typecheck` *(fails: Missing script)*
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd` *(fails: Forbidden)*
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks` *(fails: Forbidden)*
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846bbec482083229398ae3da7dab209