### PR TITLE
fix(unrar): improve liveness probe

### DIFF
--- a/k8s/applications/tools/unrar/deployment.yaml
+++ b/k8s/applications/tools/unrar/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           args:
             [
               '-c',
-              "while true; do find /mnt/data -name '*.rar' -exec unrar x -o+ {} $(dirname {}) \\; && sleep 300; done",
+              "touch /tmp/healthy; while true; do find /mnt/data -name '*.rar' -exec unrar x -o+ {} $(dirname {}) \\; ; touch /tmp/healthy; sleep 300; done",
             ]
           securityContext:
             allowPrivilegeEscalation: false
@@ -56,7 +56,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - "ps -eo args | grep -E '^unrar x' | grep -v grep"
+                - "find /tmp/healthy -mmin -le 10"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10

--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -107,23 +107,17 @@ policies:
 
 ### Health Checks
 
-Unrar now includes a liveness probe to verify its extraction loop is running.
+Unrar now uses a simple file-based check. The container updates `/tmp/healthy` during every cycle and the probe verifies that the timestamp is recent.
 
 ```yaml
 livenessProbe:
-  httpGet:
-    path: /health
-    port: 80
-  initialDelaySeconds: 15
-  periodSeconds: 15
-  timeoutSeconds: 10
-
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 80
-  initialDelaySeconds: 15
-  periodSeconds: 15
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - "find /tmp/healthy -mmin -le 10"
+  initialDelaySeconds: 60
+  periodSeconds: 60
   timeoutSeconds: 10
 ```
 


### PR DESCRIPTION
## Summary
- update unrar deployment liveness probe to use file timestamp
- document new probe in utility tools guide

## Testing
- `kustomize build --enable-helm k8s/applications/tools/unrar`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6846bbc516188322b441d1967fbfb04b