### PR TITLE
fix(k8s): make unrar liveness probe resilient to long extractions

### DIFF
--- a/k8s/applications/tools/unrar/deployment.yaml
+++ b/k8s/applications/tools/unrar/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - "find /tmp/healthy -mmin -le 10"
+                - "pgrep -x unrar >/dev/null || find /tmp/healthy -mmin -le 30"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10

--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -107,7 +107,7 @@ policies:
 
 ### Health Checks
 
-Unrar now uses a simple file-based check. The container updates `/tmp/healthy` during every cycle and the probe verifies that the timestamp is recent.
+The unrar deployment checks for a running extraction process and falls back to a timestamp check on `/tmp/healthy`. This prevents needless restarts when large archives take a while.
 
 ```yaml
 livenessProbe:
@@ -115,7 +115,7 @@ livenessProbe:
     command:
       - /bin/sh
       - -c
-      - "find /tmp/healthy -mmin -le 10"
+      - "pgrep -x unrar >/dev/null || find /tmp/healthy -mmin -le 30"
   initialDelaySeconds: 60
   periodSeconds: 60
   timeoutSeconds: 10


### PR DESCRIPTION
## Summary
- use a combined process/timestamp check in the unrar liveness probe
- document the new probe behaviour

## Testing
- `kustomize build --enable-helm k8s/applications/tools/unrar`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6846c43fd7788322a9249be8149bfd07