### PR TITLE
feat(jellyfin): persist cache volume

### DIFF
--- a/k8s/applications/media/jellyfin/deployment.yaml
+++ b/k8s/applications/media/jellyfin/deployment.yaml
@@ -73,5 +73,5 @@ spec:
           persistentVolumeClaim:
             claimName: media-share
         - name: cache
-          emptyDir:
-            medium: Memory
+          persistentVolumeClaim:
+            claimName: jellyfin-cache

--- a/k8s/applications/media/jellyfin/jellyfin-config-pvc.yaml
+++ b/k8s/applications/media/jellyfin/jellyfin-config-pvc.yaml
@@ -10,3 +10,17 @@ spec:
   resources:
     requests:
       storage: 4Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-cache
+  namespace: media
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/website/docs/applications/media-stack.md
+++ b/website/docs/applications/media-stack.md
@@ -99,6 +99,7 @@ Storage Classes:
    - Direct volume mounts for media
    - SSD storage class for metadata
    - Optimized read patterns
+   - Metadata cache stored on a persistent volume
 
 ### \*arr Stack Optimizations
 
@@ -151,7 +152,7 @@ alerts:
 
 - [ ] Integration with Home Assistant for automation
 - [ ] Implementation of cross-node GPU sharing
-- [ ] Enhanced metadata caching layer
+- [x] Enhanced metadata caching layer
 - [ ] Backup strategy improvements
 
 ## Troubleshooting Guide


### PR DESCRIPTION
## Summary
- store Jellyfin cache on a PersistentVolumeClaim instead of in-memory emptyDir
- document the persistent cache

## Testing
- `kustomize build --enable-helm k8s/applications/media/jellyfin`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6846c434147c8322ab869c9191f7d0ea