### PR TITLE
fix(pedrobot): separate mongo backup storage

### DIFF
--- a/k8s/applications/web/pedrobot/mongodb-backup-cronjob.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-backup-cronjob.yaml
@@ -22,4 +22,4 @@ spec:
           volumes:
             - name: backup
               persistentVolumeClaim:
-                claimName: mongo-data
+                claimName: mongo-backup

--- a/k8s/applications/web/pedrobot/pvc.yaml
+++ b/k8s/applications/web/pedrobot/pvc.yaml
@@ -29,6 +29,20 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: mongo-backup
+  namespace: pedro-bot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: pedro-bot-data
   namespace: pedro-bot
 spec:

--- a/website/docs/disaster/disaster-recovery.md
+++ b/website/docs/disaster/disaster-recovery.md
@@ -233,7 +233,7 @@ After successful recovery:
 
 1. **Update Monitoring**: Ensure all monitoring and alerting is functional
 2. **Test Backups**: Verify new backup jobs are running correctly
-   - Automated CronJobs handle MongoDB and Meilisearch snapshots. Confirm recent successful runs with `kubectl get jobs -n <namespace>`.
+   - Automated CronJobs handle MongoDB and Meilisearch snapshots. The MongoDB job writes backups to a separate `mongo-backup` volume. Confirm recent successful runs with `kubectl get jobs -n <namespace>`.
 3. **Document Changes**: Record any configuration changes made during recovery
 4. **Schedule DR Test**: Plan the next disaster recovery test
 


### PR DESCRIPTION
## Summary
- use dedicated mongo-backup PVC
- document new backup volume

## Testing
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `npm run typecheck` *(fails: Cannot find module 'react-icons/si')*

------
https://chatgpt.com/codex/tasks/task_e_6846c414a5888322a18d09568f990c5c