### PR TITLE
feat(k8s): increase database replicas

### DIFF
--- a/k8s/applications/media/immich/immich-server/database.yaml
+++ b/k8s/applications/media/immich/immich-server/database.yaml
@@ -8,7 +8,7 @@ spec:
   volume:
     size: 10Gi
   dockerImage: ghcr.io/theepicsaxguy/spilo17-vchord:0.1.0
-  numberOfInstances: 1
+  numberOfInstances: 2
   users:
     immich:
       - superuser

--- a/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pedro-bot
 spec:
   serviceName: 'mongodb'
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: mongodb

--- a/k8s/infrastructure/auth/authentik/database.yaml
+++ b/k8s/infrastructure/auth/authentik/database.yaml
@@ -7,7 +7,7 @@ spec:
   teamId: "auth"
   volume:
     size: 10Gi
-  numberOfInstances: 1
+  numberOfInstances: 2
   users:
     authentik_user:
       - superuser

--- a/website/docs/infrastructure/auth/authentik-setup.md
+++ b/website/docs/infrastructure/auth/authentik-setup.md
@@ -34,6 +34,10 @@ graph LR
     C -.-> F[Authentik Server]
 ```
 
+## Database Reliability
+
+The Authentik database now runs two PostgreSQL instances via the Zalando operator. The manifest sets `numberOfInstances: 2` in `database.yaml`. This offers pod-level failover using Longhorn storage. It's not a multi-region cluster, but it prevents outages from a single pod failure.
+
 ## Configuration Guide
 
 ### 1. Protecting a New Application

--- a/website/docs/infrastructure/overview.md
+++ b/website/docs/infrastructure/overview.md
@@ -161,6 +161,8 @@ kubectl logs -n <namespace> <pod> -f
 3. **High Availability**
    - Component redundancy
    - Data replication
+   - Primary databases run with two instances
+   - MongoDB replica set not yet configured
    - Failure domain isolation
 
 ## Monitoring & Alerting

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -33,14 +33,17 @@ By default, the Zalando operator won't install `pgvector` and `vectorchord` unle
 In `database.yaml`, specify each extension under `spec.preparedDatabases` so the operator creates them at startup:
 
 ```yaml
-# k8s/applications/media/immich/database.yaml
+# k8s/applications/media/immich/immich-server/database.yaml
 spec:
+  numberOfInstances: 2
   preparedDatabases:
     immich:
       extensions:
         pgvector: public
         vectorchord: public
 ```
+
+This setup runs two database pods for basic failover. It still relies on shared storage and isn't a multi-region solution, but it avoids a single point of failure in normal operations.
 
 ---
 


### PR DESCRIPTION
## Summary
- bump database replicas for Authentik, Immich, and Pedro bot
- document new PostgreSQL and MongoDB settings

## Testing
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `npm install` *(failed: ECONNRESET)*
- `npm run typecheck` *(failed: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3f5b98c832281b38313bf15685d