### PR TITLE
feat(infra): enable HA replicas

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -84,6 +84,7 @@ redis:
       memory: 1Gi
 
 server:
+  replicas: 2
   extensions:
     enabled: true
   service:
@@ -99,6 +100,7 @@ server:
       memory: 1Gi
 
 repoServer:
+  replicas: 2
   containerSecurityContext:
     readOnlyRootFilesystem: true
   volumes:
@@ -140,6 +142,7 @@ repoServer:
           name: cmp-tmp
 
 applicationSet:
+  replicas: 2
   resources:
     requests:
       cpu: 50m

--- a/k8s/infrastructure/controllers/cert-manager/values.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/values.yaml
@@ -16,6 +16,7 @@ resources:
   requests:
     cpu: 75m
     memory: 96Mi
+replicaCount: 2
 
 webhook:
   securePort: 10250
@@ -32,6 +33,7 @@ webhook:
       memory: 144Mi
   securityContext:
     runAsNonRoot: true
+  replicaCount: 2
 
 cainjector:
   resources:
@@ -41,3 +43,4 @@ cainjector:
     requests:
       cpu: 40m
       memory: 72Mi
+  replicaCount: 2

--- a/k8s/infrastructure/controllers/external-secrets/values.yaml
+++ b/k8s/infrastructure/controllers/external-secrets/values.yaml
@@ -36,6 +36,7 @@ createOperator: true
 # -- Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at
 # a time.
 concurrent: 1
+replicaCount: 2
 # -- Specifices Log Params to the External Secrets Operator
 log:
   level: info
@@ -203,7 +204,7 @@ webhook:
   certCheckInterval: '5m'
   # -- Specifices the lookaheadInterval for certificate validity
   lookaheadInterval: ''
-  replicaCount: 1
+  replicaCount: 2
   # -- Specifices Log Params to the Webhook
   log:
     level: info
@@ -391,7 +392,7 @@ certController:
   # -- Specifies whether a certificate controller deployment be created.
   create: true
   requeueInterval: '5m'
-  replicaCount: 1
+  replicaCount: 2
   # -- Specifices Log Params to the Certificate Controller
   log:
     level: info

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -97,8 +97,13 @@ High-Availability Profile:
 ```yaml
 Replication:
   argocd-server: 2
-  cert-manager: 2
-  external-secrets: 2
+  argocd-repo-server: 2
+  argocd-applicationset: 2
+  cert-manager-controller: 2
+  cert-manager-webhook: 2
+  cert-manager-cainjector: 2
+  external-secrets-operator: 2
+  external-secrets-webhook: 2
   longhorn-manager: 3 # One per node
 
 Pod Disruption Budget:


### PR DESCRIPTION
## Summary
- set explicit replicas for ArgoCD components
- configure replica counts for cert-manager
- increase External Secrets replicas
- document high availability expectations

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`
- `kustomize build --enable-helm k8s/infrastructure/controllers/cert-manager`
- `kustomize build --enable-helm k8s/infrastructure/controllers/external-secrets` *(fails: Forbidden)*
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6846c3fc36108322b8951ed5992ea33a