### PR TITLE
fix(k8s): template Cloudflare provider credentials

### DIFF
--- a/k8s/infrastructure/controllers/crossplane/external-secret-cloudflare-token.yaml
+++ b/k8s/infrastructure/controllers/crossplane/external-secret-cloudflare-token.yaml
@@ -11,7 +11,21 @@ spec:
   target:
     name: cloudflare-api-token
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        creds: |
+          {
+            "api_token": "{{ .apiToken }}",
+            "account_id": "{{ .accountId }}"
+          }
   data:
+    - secretKey: apiToken
+      remoteRef:
+        key: 154f7f9b-a324-47d2-b11e-b287015e66a8
+    - secretKey: accountId
+      remoteRef:
+        key: e9f7418e-00ba-4e31-be33-b2f10059f28e
     - secretKey: cloudflare-api-token
       remoteRef:
         key: 154f7f9b-a324-47d2-b11e-b287015e66a8

--- a/k8s/infrastructure/controllers/crossplane/provider-config.yaml
+++ b/k8s/infrastructure/controllers/crossplane/provider-config.yaml
@@ -8,4 +8,4 @@ spec:
     secretRef:
       namespace: crossplane-system
       name: cloudflare-api-token
-      key: cloudflare-api-token
+      key: creds

--- a/website/docs/k8s/cloudflare-dns-records.md
+++ b/website/docs/k8s/cloudflare-dns-records.md
@@ -18,13 +18,13 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
   Deploys Crossplane into the `crossplane-system` namespace to enable its CRDs and controllers.
 
 - **ExternalSecret**
-  Retrieves the Cloudflare API token from a Bitwarden-backed `ClusterSecretStore` into a Kubernetes Secret.
+  Retrieves the Cloudflare API token from a Bitwarden-backed `ClusterSecretStore` and templates a Kubernetes Secret containing a `creds` field with JSON credentials.
 
 - **Provider**
   Installs the Crossplane Cloudflare provider package.
 
 - **ProviderConfig**
-  References the synced Secret to supply credentials to the provider.
+  References the synced Secret's `creds` key to supply credentials to the provider.
 
 ## Prerequisites
 
@@ -46,10 +46,10 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
    Apply the official Crossplane Helm chart into `crossplane-system` via your GitOps tool.
 
 2. **Configure external secrets**
-   Define an `ExternalSecret` pointing to the Bitwarden-backed `ClusterSecretStore` to sync `cloudflare_api_token` into a Kubernetes Secret named `cloudflare-api-token`.
+   Define an `ExternalSecret` pointing to the Bitwarden-backed `ClusterSecretStore` to sync `cloudflare_api_token` and `cloudflare_account_id` into a Kubernetes Secret named `cloudflare-api-token`. The secret includes a `creds` key containing `{ "api_token": "...", "account_id": "..." }`.
 
 3. **Install provider and credentials**
-   Apply the Crossplane `Provider` for Cloudflare and a `ProviderConfig` that references `cloudflare-api-token`.
+   Apply the Crossplane `Provider` for Cloudflare and a `ProviderConfig` that references the `creds` key in `cloudflare-api-token`.
 
 ## Apply DNS records for each service
 


### PR DESCRIPTION
## Summary
- template creds JSON for the Cloudflare provider
- reference the `creds` key in the ProviderConfig
- document how the credentials Secret is structured

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/crossplane`
- `npm install` *(failed: Unknown env config)*
- `npm run typecheck` *(failed to find required node modules)*

------
https://chatgpt.com/codex/tasks/task_e_6846c6f9da08832294e96edcd021d20a