### PR TITLE
fix(auth): increase worker probe timeout

### DIFF
--- a/k8s/infrastructure/auth/authentik/values.yaml
+++ b/k8s/infrastructure/auth/authentik/values.yaml
@@ -144,6 +144,12 @@ server:
 
 worker:
   enabled: true
+  livenessProbe:
+    timeoutSeconds: 5
+  readinessProbe:
+    timeoutSeconds: 5
+  startupProbe:
+    timeoutSeconds: 5
 postgresql:
   enabled: false
 

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -95,6 +95,7 @@ Kube Prometheus Stack provides:
 - PostgreSQL backend
 - Proxy outpost for app protection
 - Configuration via Git
+- Worker liveness probe timeout set to 5 seconds to avoid restarts
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- extend authentik worker health probe timeouts to 5s
- note the new timeout in the infrastructure docs

## Testing
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6846c72ec05c8322b8583a3cd436681e