### PR TITLE
fix(k8s): enable HA for critical databases

### DIFF
--- a/k8s/applications/media/immich/immich-server/database.yaml
+++ b/k8s/applications/media/immich/immich-server/database.yaml
@@ -8,7 +8,7 @@ spec:
   volume:
     size: 10Gi
   dockerImage: ghcr.io/theepicsaxguy/spilo17-vchord:0.1.0
-  numberOfInstances: 1
+  numberOfInstances: 2
   users:
     immich:
       - superuser

--- a/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
+++ b/k8s/applications/web/pedrobot/mongodb-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pedro-bot
 spec:
   serviceName: 'mongodb'
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: mongodb

--- a/k8s/infrastructure/auth/authentik/database.yaml
+++ b/k8s/infrastructure/auth/authentik/database.yaml
@@ -7,7 +7,7 @@ spec:
   teamId: "auth"
   volume:
     size: 10Gi
-  numberOfInstances: 1
+  numberOfInstances: 2
   users:
     authentik_user:
       - superuser

--- a/website/docs/k8s/helm-chart.md
+++ b/website/docs/k8s/helm-chart.md
@@ -178,7 +178,7 @@ The following directory structure represents the standard layout for application
       teamId: "<team>"
       volume:
         size: <size>
-      numberOfInstances: 1
+      numberOfInstances: 2
       resources:
         requests:
           cpu: 100m

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -104,5 +104,6 @@ Kube Prometheus Stack provides:
 3. Use internal CA for service mesh
 4. Monitor with Prometheus
 5. Implement proper backup strategies
+6. Run databases with at least two instances to avoid single points of failure
 
 Need help? Check component examples in `/k8s/infrastructure/` for reference implementations.


### PR DESCRIPTION
## Summary
- increase instance count for Authentik and Immich PostgreSQL
- bump replicas for pedrobot MongoDB
- note replica settings in documentation

## Testing
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/web/pedrobot`
- `npm install` *(in repo root)*
- `npm install` *(in website/)*
- `npm run typecheck` *(failed; see log)*


------
https://chatgpt.com/codex/tasks/task_e_6846d9d6d1fc8322b8512895d10e17e4