### PR TITLE
feat(k8s): add pdbs for critical services

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -101,6 +101,9 @@ server:
 
 repoServer:
   replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
   containerSecurityContext:
     readOnlyRootFilesystem: true
   volumes:
@@ -143,6 +146,9 @@ repoServer:
 
 applicationSet:
   replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
   resources:
     requests:
       cpu: 50m

--- a/k8s/infrastructure/monitoring/prometheus-stack/grafana-pdb.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/grafana-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: grafana-pdb
+  namespace: monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kube-prometheus-stack-grafana

--- a/k8s/infrastructure/monitoring/prometheus-stack/kustomization.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - grafana-http-route.yaml
   - grafana-oauth-secret.yaml
   - prometheus-http-route.yaml
+  - grafana-pdb.yaml
 
 helmCharts:
   - name: kube-prometheus-stack

--- a/k8s/infrastructure/monitoring/prometheus-stack/values.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/values.yaml
@@ -52,6 +52,7 @@ prometheusOperator:
 
 prometheus:
   prometheusSpec:
+    replicas: 2
     resources:
       requests:
         cpu: 500m
@@ -59,3 +60,13 @@ prometheus:
       limits:
         cpu: 1000m
         memory: 1Gi
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+alertmanager:
+  alertmanagerSpec:
+    replicas: 2
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1

--- a/k8s/infrastructure/network/coredns/kustomization.yaml
+++ b/k8s/infrastructure/network/coredns/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/k8s/infrastructure/network/coredns/pdb.yaml
+++ b/k8s/infrastructure/network/coredns/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns-pdb
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/website/docs/k8s/cluster-config-overview.md
+++ b/website/docs/k8s/cluster-config-overview.md
@@ -90,3 +90,5 @@ node drain. Most of our applications run a single replica, so each namespace
 defines a simple PDB with `maxUnavailable: 0`. When you drain a node hosting
 one of these pods, the operation waits until another replica is available or the
 PDB is removed. This prevents accidental outages during routine maintenance.
+Multi-replica services like CoreDNS, Argo CD, and the monitoring stack also
+have PDBs defined to ensure at least one instance stays online during upgrades.


### PR DESCRIPTION
## Summary
- add PodDisruptionBudget for CoreDNS
- enable PDBs for Argo CD repo-server and applicationSet controller
- enable PDBs for Prometheus stack components and add Grafana PDB
- document new multi-replica PDBs

## Testing
- `kustomize build --enable-helm k8s/infrastructure/network/coredns`
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`
- `kustomize build --enable-helm k8s/infrastructure/monitoring/prometheus-stack`
- `npm install`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846da3e116c8322b815f1852dc68b79