### PR TITLE
feat(k8s): integrate Karakeep with Authentik

### DIFF
--- a/k8s/applications/ai/karakeep/karakeep-secrets-external.yaml
+++ b/k8s/applications/ai/karakeep/karakeep-secrets-external.yaml
@@ -24,3 +24,10 @@ spec:
     - secretKey: OPENAI_API_KEY
       remoteRef:
         key: e3eeac60-822d-45a4-b454-b2cd016ce38c
+    - secretKey: OAUTH_CLIENT_ID
+      remoteRef:
+        key: '2eb7074e-20a5-453a-99f9-b2f7016214e8'
+    - secretKey: OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: 'a849669c-fe18-4951-9d5e-b2f701624a14'
+

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -37,6 +37,16 @@ spec:
           ports:
             - containerPort: 3000
           env:
+            - name: OAUTH_WELLKNOWN_URL
+              value: https://sso.pc-tips.se/application/o/karakeep/.well-known/openid-configuration
+            - name: OAUTH_PROVIDER_NAME
+              value: authentik
+            - name: OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING
+              value: "true"
+            - name: DISABLE_PASSWORD_AUTH
+              value: "true"
+            - name: DISABLE_SIGNUPS
+              value: "true"
             - name: MEILI_ADDR
               value: http://meilisearch:7700
             - name: BROWSER_WEB_URL

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-karakeep.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-karakeep.yaml
@@ -1,0 +1,58 @@
+# k8s/infrastructure/auth/authentik/extra/blueprints/apps-karakeep.yaml
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable-file
+# prettier-ignore-start
+# eslint-disable
+---
+version: 1
+metadata:
+  name: Apps - Karakeep
+entries:
+  - id: karakeep-provider
+    model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: k8s.pc-tips.se/ai-karakeep
+    attrs:
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-authorization-implicit-consent"],
+        ]
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, "authentik Self-signed Certificate"],
+        ]
+      client_type: confidential
+      redirect_uris:
+        - url: https://karakeep.pc-tips.se/api/auth/callback/custom
+          matching_mode: strict
+      client_id: !Env KARAKEEP_CLIENT_ID
+      client_secret: !Env KARAKEEP_CLIENT_SECRET
+      access_code_validity: minutes=1
+      refresh_token_validity: days=30
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
+        - !Find [authentik_core.propertymapping, [name, "OAuth mapping: OpenID 'email' with mailPrimaryAddress"]]
+
+  - id: karakeep-application
+    model: authentik_core.application
+    identifiers:
+      slug: karakeep
+    attrs:
+      name: Karakeep
+      group: AI
+      meta_description: "A self-hostable bookmark-everything app with AI-based automatic tagging."
+      icon: https://raw.githubusercontent.com/karakeep/karakeep/main/public/logo_512.png
+      provider: !KeyOf karakeep-provider
+      policy_engine_mode: any
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf karakeep-application
+      group: !Find [authentik_core.group, [name, "users"]]
+    attrs:
+      order: 1
+

--- a/k8s/infrastructure/auth/authentik/extra/kustomization.yml
+++ b/k8s/infrastructure/auth/authentik/extra/kustomization.yml
@@ -18,6 +18,7 @@ configMapGenerator:
       - ./blueprints/apps-jellyfin.yaml
       - ./blueprints/apps-media.yaml
       - ./blueprints/apps-openwebui.yaml
+      - ./blueprints/apps-karakeep.yaml
       - ./blueprints/groups.yaml
       - ./blueprints/users.yaml
       - ./blueprints/brands.yaml

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -152,3 +152,11 @@ spec:
     - secretKey: OPENWEBUI_CLIENT_SECRET
       remoteRef:
         key: '2c1c9f3f-a8b3-4b62-a41b-b2f001248898'
+    # --- Karakeep ---
+    - secretKey: KARAKEEP_CLIENT_ID
+      remoteRef:
+        key: '2eb7074e-20a5-453a-99f9-b2f7016214e8'
+    - secretKey: KARAKEEP_CLIENT_SECRET
+      remoteRef:
+        key: 'a849669c-fe18-4951-9d5e-b2f701624a14'
+

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -116,9 +116,9 @@ OpenWebUI provides a chat interface backed by local AI models. The deployment in
 Chrome and Ollama now define both liveness and readiness probes so Kubernetes can restart them if they crash and only route traffic when each pod is ready.
 Mosquitto and Unrar use similar probes. Pedro Bot now relies on PersistentVolumeClaims for logs and data, and Jellyfin and Unrar are free to run on any available node.
 
-## KaraKeep Notes
+## Karakeep Notes
 
-KaraKeep now authenticates through Authentik using OIDC. The client ID and secret live in Bitwarden and sync to a Kubernetes secret via ExternalSecrets. Password logins are disabled so users sign in only with Authentik.
+Karakeep now authenticates through Authentik using OIDC. The client ID and secret live in Bitwarden and sync to a Kubernetes secret via ExternalSecrets. Password logins are disabled so users sign in only with Authentik.
 
 ## BabyBuddy Notes
 

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -116,6 +116,10 @@ OpenWebUI provides a chat interface backed by local AI models. The deployment in
 Chrome and Ollama now define both liveness and readiness probes so Kubernetes can restart them if they crash and only route traffic when each pod is ready.
 Mosquitto and Unrar use similar probes. Pedro Bot now relies on PersistentVolumeClaims for logs and data, and Jellyfin and Unrar are free to run on any available node.
 
+## KaraKeep Notes
+
+KaraKeep now authenticates through Authentik using OIDC. The client ID and secret live in Bitwarden and sync to a Kubernetes secret via ExternalSecrets. Password logins are disabled so users sign in only with Authentik.
+
 ## BabyBuddy Notes
 
 BabyBuddy runs on port `3000` and is deployed purely with Kustomize manifests. We removed an unused `values.yaml` file to avoid confusion. Update your service and readiness probes to point to this port if you override the default configuration.


### PR DESCRIPTION
## Summary
- configure Karakeep OIDC provider in Authentik
- expose new secrets for Authentik credentials
- update Karakeep deployment with OIDC environment
- document how Karakeep uses Authentik

## Testing
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik/extra`
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684752f20de88322b58f26339c582573