### PR TITLE
fix(k8s): pin image versions and policies

### DIFF
--- a/k8s/applications/ai/karakeep/kustomization.yaml
+++ b/k8s/applications/ai/karakeep/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: karakeep
 configMapGenerator:
 - literals:
   - NEXTAUTH_URL=https://karakeep.pc-tips.se
-  - KARAKEEP_VERSION=0.24.1
+  - KARAKEEP_VERSION=0.25.0
   name: karakeep-configuration
 
 resources:

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -20,7 +20,7 @@ spec:
             claimName: data-pvc
       containers:
         - name: web
-          image: ghcr.io/karakeep-app/karakeep
+          image: ghcr.io/karakeep-app/karakeep # renovate: docker=ghcr.io/karakeep-app/karakeep
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             limits:
               cpu: '400m'
               memory: '1Gi'
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
           env:

--- a/k8s/applications/ai/openwebui/ollama-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/ollama-statefulset.yaml
@@ -23,7 +23,8 @@ spec:
           type: RuntimeDefault
       containers:
       - name: ollama
-        image: ollama/ollama:latest
+        image: ollama/ollama:0.9.0
+        imagePullPolicy: IfNotPresent
         env:
           - name: HOME
             value: /home/ollama

--- a/k8s/applications/ai/openwebui/ollama-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/ollama-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: ollama
-        image: ollama/ollama:0.9.0
+        image: ollama/ollama:0.9.0 # renovate: docker=ollama/ollama
         imagePullPolicy: IfNotPresent
         env:
           - name: HOME

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: sabnzbd
           image: ghcr.io/linuxserver/sabnzbd:4.5.1
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: '100m'

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: sabnzbd
-          image: ghcr.io/linuxserver/sabnzbd:4.5.1
+          image: ghcr.io/linuxserver/sabnzbd:4.5.1 # renovate: docker=ghcr.io/linuxserver/sabnzbd
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: whisperasr
-          image: onerahmet/openai-whisper-asr-webservice:v1.8.2
+          image: onerahmet/openai-whisper-asr-webservice:v1.8.2 # renovate: docker=onerahmet/openai-whisper-asr-webservice
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: whisperasr
           image: onerahmet/openai-whisper-asr-webservice:v1.8.2
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: '500m'

--- a/k8s/applications/network/omada/deployment.yaml
+++ b/k8s/applications/network/omada/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: omada-controller
           image: mbentley/omada-controller:5.15.20.20
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/applications/network/omada/deployment.yaml
+++ b/k8s/applications/network/omada/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: omada-controller
-          image: mbentley/omada-controller:5.15.20.20
+          image: mbentley/omada-controller:5.15.20.20 # renovate: docker=mbentley/omada-controller
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/applications/tools/it-tools/deployment.yaml
+++ b/k8s/applications/tools/it-tools/deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
       containers:
         - name: it-tools
-          image: corentinth/it-tools:2024.10.22-7ca5933
+          image: corentinth/it-tools:2024.10.22-7ca5933 # renovate: docker=corentinth/it-tools
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/k8s/applications/tools/it-tools/deployment.yaml
+++ b/k8s/applications/tools/it-tools/deployment.yaml
@@ -31,8 +31,8 @@ spec:
 
       containers:
         - name: it-tools
-          image: corentinth/it-tools:latest
-          imagePullPolicy: Always
+          image: corentinth/it-tools:2024.10.22-7ca5933
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           securityContext:

--- a/k8s/applications/tools/whoami/deployment.yaml
+++ b/k8s/applications/tools/whoami/deployment.yaml
@@ -26,7 +26,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: whoami
-          image: ghcr.io/traefik/whoami:latest
+          image: ghcr.io/traefik/whoami:v1.11.0
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/applications/tools/whoami/deployment.yaml
+++ b/k8s/applications/tools/whoami/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: whoami
-          image: ghcr.io/traefik/whoami:v1.11.0
+          image: ghcr.io/traefik/whoami:v1.11.0 # renovate: docker=ghcr.io/traefik/whoami
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -91,9 +91,9 @@ deployment:
   replicaCount: 1
 
   image:
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     name: "ghcr.io/zapier/kubechecks"
-    tag: "latest"
+    tag: "v2.4.2"
 
   imagePullSecrets: []
   nodeSelector: {}

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -92,7 +92,7 @@ deployment:
 
   image:
     pullPolicy: IfNotPresent
-    name: "ghcr.io/zapier/kubechecks"
+    name: "ghcr.io/zapier/kubechecks" # renovate: docker=ghcr.io/zapier/kubechecks
     tag: "v2.4.2"
 
   imagePullSecrets: []

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -107,6 +107,7 @@ We use NFS for shared media files:
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.
+8. Pin container images to explicit versions and set `imagePullPolicy: IfNotPresent`.
 
 ## OpenWebUI Notes
 


### PR DESCRIPTION
## Summary
- pin all remaining :latest images
- replace any `imagePullPolicy: Always` with `IfNotPresent`
- set KaraKeep version to `0.25.0`
- document the policy for pinned images

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `kustomize build --enable-helm k8s/applications/tools/it-tools`
- `kustomize build --enable-helm k8s/applications/tools/whoami`
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `kustomize build --enable-helm k8s/applications/media/whisperasr`
- `kustomize build --enable-helm k8s/applications/network/omada`
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`


------
https://chatgpt.com/codex/tasks/task_e_68483ec21c608322ab74cc51c1b17fef