### PR TITLE
refactor(k8s): consolidate arr configs and scope secrets

### DIFF
--- a/k8s/applications/media/arr/bazarr/deployment.yaml
+++ b/k8s/applications/media/arr/bazarr/deployment.yaml
@@ -25,21 +25,12 @@ spec:
               containerPort: 6767
               protocol: TCP
           env:
-            - name: PUID
-              value: '2501'
             - name: VPN_ENABLED
               value: 'false'
-            - name: PGID
-              value: '2501'
-            - name: TZ
-              value: 'Etc/UTC'
             - name: UMASK
               value: '002'
             - name: WEBUI_PORTS
               value: '6767/tcp,6767/udp'
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           volumeMounts:
             - name: bazarr-config
               mountPath: /config

--- a/k8s/applications/media/arr/bazarr/kustomization.yaml
+++ b/k8s/applications/media/arr/bazarr/kustomization.yaml
@@ -2,18 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../base
-- pvc.yaml
-- svc.yaml
-- http-route.yaml
-- deployment.yaml
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-configMapGenerator:
-- literals:
-  - PUID=2501
-  - PGID=2501
-  - TZ=Europe/Stockholm
-  name: bazarr-env
+  - pvc.yaml
+  - svc.yaml
+  - http-route.yaml
+  - deployment.yaml

--- a/k8s/applications/media/arr/kustomization.yaml
+++ b/k8s/applications/media/arr/kustomization.yaml
@@ -4,7 +4,12 @@ kind: Kustomization
 configMapGenerator:
 - literals:
   - TZ="Europe/Oslo"
+  - PUID="2501"
+  - PGID="2501"
   name: common-env
+
+generatorOptions:
+  disableNameSuffixHash: true
 
 namespace: media
 
@@ -13,3 +18,9 @@ resources:
 - radarr
 - sonarr
 - bazarr
+
+patches:
+  - path: base/patch.yaml
+    target:
+      kind: Deployment
+      labelSelector: app in (bazarr, prowlarr, radarr, sonarr)

--- a/k8s/applications/media/arr/prowlarr/deployment.yaml
+++ b/k8s/applications/media/arr/prowlarr/deployment.yaml
@@ -23,9 +23,6 @@ spec:
           ports:
             - name: http
               containerPort: 9696
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           volumeMounts:
             - name: prowlarr-config
               mountPath: /config

--- a/k8s/applications/media/arr/prowlarr/kustomization.yaml
+++ b/k8s/applications/media/arr/prowlarr/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../base
-- pvc.yaml
-- svc.yaml
-- http-route.yaml
-- deployment.yaml
+  - pvc.yaml
+  - svc.yaml
+  - http-route.yaml
+  - deployment.yaml

--- a/k8s/applications/media/arr/radarr/deployment.yaml
+++ b/k8s/applications/media/arr/radarr/deployment.yaml
@@ -23,9 +23,6 @@ spec:
           ports:
             - name: http
               containerPort: 7878
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           volumeMounts:
             - name: radarr-config
               mountPath: /config

--- a/k8s/applications/media/arr/radarr/kustomization.yaml
+++ b/k8s/applications/media/arr/radarr/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../base
-- pvc.yaml
-- svc.yaml
-- http-route.yaml
-- deployment.yaml
+  - pvc.yaml
+  - svc.yaml
+  - http-route.yaml
+  - deployment.yaml

--- a/k8s/applications/media/arr/sonarr/deployment.yaml
+++ b/k8s/applications/media/arr/sonarr/deployment.yaml
@@ -23,9 +23,6 @@ spec:
           ports:
             - name: http
               containerPort: 8989
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           volumeMounts:
             - name: sonarr-config
               mountPath: /config

--- a/k8s/applications/media/arr/sonarr/kustomization.yaml
+++ b/k8s/applications/media/arr/sonarr/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../base
-- pvc.yaml
-- svc.yaml
-- http-route.yaml
-- deployment.yaml
+  - pvc.yaml
+  - svc.yaml
+  - http-route.yaml
+  - deployment.yaml

--- a/k8s/applications/media/jellyseerr-secrets.yaml
+++ b/k8s/applications/media/jellyseerr-secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: jellyseerr-jellyfin
+  name: jellyseerr-secrets
   namespace: media
 spec:
   refreshInterval: 1h
@@ -9,7 +9,7 @@ spec:
     name: bitwarden-backend
     kind: ClusterSecretStore
   target:
-    name: jellyseerr-jellyfin
+    name: jellyseerr-secrets
     creationPolicy: Owner
   data:
     - secretKey: JELLYFIN_URL

--- a/k8s/applications/media/jellyseerr/values.yaml
+++ b/k8s/applications/media/jellyseerr/values.yaml
@@ -21,7 +21,7 @@ extraEnv: []
 # -- Environment variables from secrets or configmaps to add to the jellyseerr pods
 extraEnvFrom:
   - secretRef:
-      name: jellyseerr-jellyfin
+      name: jellyseerr-secrets
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/k8s/applications/media/kustomization.yaml
+++ b/k8s/applications/media/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - arr
 - media-share-pvc.yaml
 - nfs-pv.yaml
-- externalsecret.yaml
+- jellyseerr-secrets.yaml
 - jellyseerr
 - sabnzbd
 - whisperasr

--- a/k8s/applications/media/sabnzbd/deployment.yaml
+++ b/k8s/applications/media/sabnzbd/deployment.yaml
@@ -37,9 +37,6 @@ spec:
               value: 'Europe/Stockholm'
             - name: HOST_WHITELIST_ENTRIES
               value: 'sabnzbd,sabnzbd.media,sabnzbd.media.svc,sabnzbd.media.svc.cluster.local,sabnzbd.pc-tips.se'
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           volumeMounts:
             - name: sabnzbd-config
               mountPath: /config

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -31,9 +31,6 @@ spec:
               value: 'small'
             - name: ASR_ENGINE
               value: 'faster_whisper'
-          envFrom:
-            - secretRef:
-                name: jellyseerr-jellyfin
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Summary
- simplify arr layering and share environment config
- drop jellyfin credentials from arr apps and sabnzbd
- rename jellyseerr secret for clarity

## Testing
- `kustomize build --enable-helm k8s/applications/media/arr`
- `kustomize build --enable-helm k8s/applications/media/arr/bazarr`
- `kustomize build --enable-helm k8s/applications/media/arr/prowlarr`
- `kustomize build --enable-helm k8s/applications/media/arr/radarr`
- `kustomize build --enable-helm k8s/applications/media/arr/sonarr`
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `kustomize build --enable-helm k8s/applications/media/jellyseerr`
- `kustomize build --enable-helm k8s/applications/media/whisperasr`
- `kustomize build --enable-helm k8s/applications/media` *(fails: helm pull 403)*


------
https://chatgpt.com/codex/tasks/task_e_68497a5bc030832282a98683bb3b5474