### PR TITLE
fix(network): run CoreDNS as non-root

### DIFF
--- a/k8s/infrastructure/network/coredns/deployment.yaml
+++ b/k8s/infrastructure/network/coredns/deployment.yaml
@@ -87,14 +87,17 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              add:
-                - NET_BIND_SERVICE
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                  - NET_BIND_SERVICE
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
       dnsPolicy: Default
       volumes:
         - name: config-volume

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -52,6 +52,7 @@ spec:
 - Internal domain: kube.pc-tips.se
 - External forwarding to 10.25.150.1, 1.1.1.1, 8.8.8.8
 - Caching enabled
+- Runs as a non-root user (UID/GID 1000) with NET_BIND_SERVICE capability
 
 ### 3. Gateway API
 


### PR DESCRIPTION
## Summary
- run CoreDNS with explicit UID and GID
- document that CoreDNS runs as a non-root user

## Testing
- `kustomize build --enable-helm k8s/infrastructure/network/coredns`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68497b2909e883228727c45a3325c81d