### PR TITLE
fix(k8s): enforce read-only root filesystem

### DIFF
--- a/k8s/applications/ai/karakeep/chrome-deployment.yaml
+++ b/k8s/applications/ai/karakeep/chrome-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           image: gcr.io/zenika-hub/alpine-chrome:124
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ['ALL']
           volumeMounts:

--- a/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           image: getmeili/meilisearch:v1.15.0
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ['ALL']
           resources:

--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           image: ghcr.io/karakeep-app/karakeep # renovate: docker=ghcr.io/karakeep-app/karakeep
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ['ALL']
           resources:

--- a/k8s/applications/ai/openwebui/ollama-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/ollama-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
         ports:

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -111,7 +111,7 @@ deployment:
     capabilities:
       drop:
         - ALL
-    readOnlyRootFilesystem: false
+    readOnlyRootFilesystem: true
 
   envFrom: []
 

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -103,7 +103,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts
+4. Configure security contexts and keep the root filesystem read-only unless the app needs writes
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- enforce readOnlyRootFilesystem across ai deployments
- document our read-only filesystem policy

## Testing
- `npm install`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`


------
https://chatgpt.com/codex/tasks/task_e_68497b3fcb808322ac9185bc642db2f8