### PR TITLE
fix(k8s): set explicit security context

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -286,27 +286,23 @@ resources:
     memory: "1Gi"
 
 # -- Set Frigate Container Security Context
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # privileged: true
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ['ALL']
 
 # -- Set Pod level Security Context
 # -- the container level securiy context defined above
 # -- will override it for frigate container
-podSecurityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # fsGroup: 1000
-  # privileged: true
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Node Selector configuration
 nodeSelector: {}

--- a/k8s/applications/media/jellyseerr/values.yaml
+++ b/k8s/applications/media/jellyseerr/values.yaml
@@ -38,17 +38,19 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ['ALL']
 
 service:
   type: ClusterIP

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -103,7 +103,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts
+4. Configure security contexts: run pods as non-root, drop all capabilities, block privilege escalation, and use the RuntimeDefault seccomp profile.
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- enforce stricter security context for Frigate and Jellyseerr
- clarify security context best practice in docs

## Testing
- `npm install`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: 403 Forbidden fetching chart)*
- `kustomize build --enable-helm k8s/applications/media/jellyseerr`

------
https://chatgpt.com/codex/tasks/task_e_68497b3476508322894221e56e3ce215