### PR TITLE
docs: replace example domains with placeholders

### DIFF
--- a/website/docs/applications/utility-tools.md
+++ b/website/docs/applications/utility-tools.md
@@ -13,7 +13,7 @@ This document covers the utility tools and applications deployed in our cluster 
 ### IT Tools
 
 - **Purpose**: Collection of utilities for IT operations
-- **Access**: https://it-tools.pc-tips.se (via Authentik SSO)
+- **Access**: https://it-tools.your.domain.tld (via Authentik SSO)
 - **Features**:
   - String manipulation
   - Encoding/decoding
@@ -54,7 +54,7 @@ All tools are exposed through Cilium Gateway API with the following configuratio
 ```yaml
 Gateway Configuration:
   - IT Tools:
-      host: it-tools.pc-tips.se
+      host: it-tools.your.domain.tld
       service: it-tools
       port: 80
       backendRefs:
@@ -63,7 +63,7 @@ Gateway Configuration:
           port: 9000 # Authentik SSO
 
   - Whoami:
-      host: whoami.pc-tips.se
+      host: whoami.your.domain.tld
       service: whoami
       port: 80
       backendRefs:

--- a/website/docs/infrastructure/auth/authentik-setup.md
+++ b/website/docs/infrastructure/auth/authentik-setup.md
@@ -16,7 +16,7 @@ Authentik is deployed with two main components:
    - Core authentication service
    - User management interface
    - Policy configuration
-   - Accessible at https://sso.pc-tips.se
+   - Accessible at https://sso.your.domain.tld
 
 2. **Proxy Outpost**
    - Authentication proxy (ports 9000/9443)
@@ -40,11 +40,11 @@ graph LR
 
 #### Step 1: Authentik Configuration
 
-1. Access Authentik admin interface (https://sso.pc-tips.se)
+1. Access Authentik admin interface (https://sso.your.domain.tld)
 2. Create a new Proxy Provider:
    ```yaml
    name: my-application
-   external_host: app.pc-tips.se
+   external_host: app.your.domain.tld
    internal_host: http://my-service.namespace.svc:8080
    mode: forward_single
    ```
@@ -71,7 +71,7 @@ spec:
     - name: external  # or internal based on access needs
       namespace: gateway
   hostnames:
-    - "app.pc-tips.se"
+    - "app.your.domain.tld"
   rules:
     - matches:
         - path:
@@ -135,7 +135,7 @@ kubectl -n auth get ciliumnetworkpolicies
 
 3. Test Authentication Flow:
 ```bash
-curl -v https://app.pc-tips.se
+curl -v https://app.your.domain.tld
 # Should redirect to SSO
 ```
 
@@ -172,7 +172,7 @@ spec:
     - name: external
       namespace: gateway
   hostnames:
-    - "webapp.pc-tips.se"
+    - "webapp.your.domain.tld"
   rules:
     - matches:
         - path:
@@ -198,7 +198,7 @@ spec:
     - name: internal
       namespace: gateway
   hostnames:
-    - "api.internal.pc-tips.se"
+    - "api.internal.your.domain.tld"
   rules:
     - matches:
         - path:

--- a/website/docs/infrastructure/controllers/external-secrets-setup.md
+++ b/website/docs/infrastructure/controllers/external-secrets-setup.md
@@ -51,7 +51,7 @@ spec:
           key: token
           name: bitwarden-access-token
           namespace: external-secrets
-      url: https://bitwarden.pc-tips.se
+      url: https://bitwarden.your.domain.tld
 ```
 
 ## Usage Examples
@@ -182,7 +182,7 @@ spec:
       app.kubernetes.io/name: external-secrets
   egress:
     - toFQDNs:
-        - matchName: bitwarden.pc-tips.se
+        - matchName: bitwarden.your.domain.tld
       toPorts:
         - ports:
             - port: "443"
@@ -245,5 +245,5 @@ kubectl get externalsecret -A
 # Test Bitwarden access
 kubectl -n external-secrets exec -it \
   $(kubectl -n external-secrets get pod -l app.kubernetes.io/name=external-secrets -o name) \
-  -- curl -v https://bitwarden.pc-tips.se
+  -- curl -v https://bitwarden.your.domain.tld
 ```

--- a/website/docs/k8s/cloudflare-dns-records.md
+++ b/website/docs/k8s/cloudflare-dns-records.md
@@ -70,4 +70,4 @@ Repeat for Immich, Jellyfin, Jellyseerr, Baby Buddy, IT Tools, Authentik, etc., 
   Run `kubectl get records.dns.cloudflare.upbound.io -A` and confirm each record’s status is `READY`.
 
 - **Cloudflare dashboard**
-  In Cloudflare UI, go to **DNS → pc-tips.se** and verify that CNAME entries point to the correct Tunnel hostnames.
+  In Cloudflare UI, go to **DNS → your.domain.tld** and verify that CNAME entries point to the correct Tunnel hostnames.

--- a/website/docs/k8s/helm-chart.md
+++ b/website/docs/k8s/helm-chart.md
@@ -69,7 +69,7 @@ The following directory structure represents the standard layout for application
         - name: external
           namespace: gateway
       hostnames:
-        - "<app-name>.pc-tips.se"
+        - "<app-name>.your.domain.tld"
       rules:
         - matches:
             - path:

--- a/website/docs/k8s/infrastructure/dex-configuration.md
+++ b/website/docs/k8s/infrastructure/dex-configuration.md
@@ -49,7 +49,7 @@ configs:
     dex.config: |
       connectors:
       - config:
-          issuer: https://sso.pc-tips.se/application/o/argocd/
+          issuer: https://sso.your.domain.tld/application/o/argocd/
           clientID: $dex.authentik.clientId
           clientSecret: $dex.authentik.clientSecret
           insecureEnableGroups: true

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -49,7 +49,7 @@ spec:
 
 ### 2. DNS (CoreDNS)
 
-- Internal domain: kube.pc-tips.se
+- Internal domain: kube.your.domain.tld
 - External forwarding to 10.25.150.1, 1.1.1.1, 8.8.8.8
 - Caching enabled
 

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -230,7 +230,7 @@ proxmox = {
 
 cluster = {
   name               = "talos"        # Cluster name
-  endpoint           = "api.kube.pc-tips.se"  # API endpoint
+  endpoint           = "api.kube.your.domain.tld"  # API endpoint
   kubernetes_version = "<see https://github.com/kubernetes/kubernetes/releases>"       # Kubernetes version
   talos_version     = "<see https://github.com/siderolabs/talos/releases>"      # Talos version
   gateway           = "10.25.150.1"   # Network gateway


### PR DESCRIPTION
## Summary
- use `your.domain.tld` placeholders instead of the pc-tips.se domain

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68497b0e24048322838054bab1ccb6c8