### PR TITLE
fix(k8s): remove unsupported fields from cloudflare crds

### DIFF
--- a/k8s/infrastructure/controllers/crossplane/account.yaml
+++ b/k8s/infrastructure/controllers/crossplane/account.yaml
@@ -5,12 +5,5 @@ metadata:
 spec:
   forProvider:
     name: pc-tips
-    accountId:
-      valueFrom:
-        secretKeyRef:
-          name: cloudflare-api-token
-          namespace: crossplane-system
-          key: cloudflare-account-id
   providerConfigRef:
     name: cloudflare-provider
-  managementPolicy: ObserveOnly

--- a/k8s/infrastructure/controllers/crossplane/zone.yaml
+++ b/k8s/infrastructure/controllers/crossplane/zone.yaml
@@ -7,4 +7,3 @@ spec:
     zone: pc-tips.se
   providerConfigRef:
     name: cloudflare-provider
-  managementPolicy: ObserveOnly


### PR DESCRIPTION
## Summary
- clean up Cloudflare account and zone manifests
- drop unsupported managementPolicy and accountId fields

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/crossplane`

------
https://chatgpt.com/codex/tasks/task_e_68498a7c00c48322ba2309041062f8ec