### PR TITLE
fix(k8s): update zone reference for ittools

### DIFF
--- a/k8s/infrastructure/controllers/crossplane/dns-records.yaml
+++ b/k8s/infrastructure/controllers/crossplane/dns-records.yaml
@@ -93,7 +93,8 @@ metadata:
   name: ittools-cname
 spec:
   forProvider:
-    zone: pc-tips.se
+    zoneIdRef:
+      name: pc-tips.se
     name: ittools
     type: CNAME
     value: c1d5dfa0-f165-489e-ade6-248160e48500.cfargotunnel.com


### PR DESCRIPTION
## Summary
- adjust ittools record to use `zoneIdRef`

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/crossplane`

------
https://chatgpt.com/codex/tasks/task_e_6849920ae05c8322833332540da30723