### PR TITLE
fix(k8s): keep karakeep rootfs writable

### DIFF
--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           image: ghcr.io/karakeep-app/karakeep # renovate: docker=ghcr.io/karakeep-app/karakeep
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             capabilities:
               drop: ['ALL']
           resources:

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -65,6 +65,9 @@ Here's how KaraKeep (`/k8s/applications/ai/karakeep/`) is structured:
    - Runs as non-root
    - Drops unnecessary privileges
    - Uses default security profiles
+   - Keeps the root filesystem writable. KaraKeep relies on the s6 overlay,
+     which expects directories like `/run` to be writable. Setting
+     `readOnlyRootFilesystem` caused startup failures.
    - Default UID and GID for Meilisearch are set to `1000`. Adjust `runAsUser` and `runAsGroup` in
      `meilisearch-deployment.yaml` if those IDs conflict with your environment.
 


### PR DESCRIPTION
## Summary
- allow KaraKeep's main container to write to its root filesystem
- document the reason for not using `readOnlyRootFilesystem`

## Testing
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68499525101c83228eea63ac69a09aa1