### PR TITLE
feat(k8s): enforce securityContext on helm charts

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -286,27 +286,24 @@ resources:
     memory: "1Gi"
 
 # -- Set Frigate Container Security Context
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # privileged: true
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 # -- Set Pod level Security Context
 # -- the container level securiy context defined above
 # -- will override it for frigate container
-podSecurityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # fsGroup: 1000
-  # privileged: true
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Node Selector configuration
 nodeSelector: {}

--- a/k8s/applications/media/jellyseerr/values.yaml
+++ b/k8s/applications/media/jellyseerr/values.yaml
@@ -38,17 +38,20 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -65,6 +65,8 @@ Here's how KaraKeep (`/k8s/applications/ai/karakeep/`) is structured:
    - Runs as non-root
    - Drops unnecessary privileges
    - Uses default security profiles
+   - Helm charts explicitly set `runAsUser`, `runAsGroup`, and `fsGroup` to `1000`
+     with `seccompProfile: RuntimeDefault` and `allowPrivilegeEscalation: false`.
    - Default UID and GID for Meilisearch are set to `1000`. Adjust `runAsUser` and `runAsGroup` in
      `meilisearch-deployment.yaml` if those IDs conflict with your environment.
 


### PR DESCRIPTION
## Summary
- explicitly set container and pod securityContext for Frigate and Jellyseerr
- document the default securityContext values

## Testing
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: helm repo Forbidden)*
- `kustomize build --enable-helm k8s/applications/media/jellyseerr`
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684994d7f7b8832291aeba4021b2ccdb