### PR TITLE
fix(k8s): mount tmp dir for kubechecks

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -74,6 +74,8 @@ deployment:
   volumeMounts:
     - name: home
       mountPath: /home/kubechecks
+    - name: home
+      mountPath: /tmp
 
   annotations: {}
   podAnnotations: {}

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -57,6 +57,7 @@ This document outlines the core infrastructure controllers deployed in our Kuber
   - Schema validation
   - GitHub integration
   - Custom webhook support
+  - Writable `/tmp` mount to support repo clones
 
 ## Resource Management
 


### PR DESCRIPTION
## Summary
- mount the existing writable volume at `/tmp` so kubechecks can clone repos
- note the writable temp mount in the controller docs

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`

------
https://chatgpt.com/codex/tasks/task_e_684996f2731083228fcaaa325e8b0a95