### PR TITLE
fix(k8s): add tmp and run volumes for karakeep

### DIFF
--- a/k8s/applications/ai/karakeep/web-deployment.yaml
+++ b/k8s/applications/ai/karakeep/web-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: data-pvc
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
       containers:
         - name: web
           image: ghcr.io/karakeep-app/karakeep # renovate: docker=ghcr.io/karakeep-app/karakeep
@@ -56,6 +60,10 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /run
+              name: run
           envFrom:
             - secretRef:
                 name: karakeep-secrets

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -122,6 +122,7 @@ Mosquitto and Unrar use similar probes. Pedro Bot relies on PersistentVolumeClai
 ## Karakeep Notes
 
 Karakeep authenticates through Authentik using OIDC. The client ID and secret live in Bitwarden and sync to a Kubernetes secret via ExternalSecrets. Password logins are disabled so users sign in only with Authentik.
+The container keeps its root filesystem read-only. Temporary paths like `/run` and `/tmp` come from `emptyDir` volumes so s6-overlay can write runtime files.
 
 ## BabyBuddy Notes
 


### PR DESCRIPTION
## Summary
- update KaraKeep deployment to mount /tmp and /run as emptyDir
- document KaraKeep's read-only root filesystem

## Testing
- `kustomize build --enable-helm k8s/applications/ai/karakeep`
- `npm run typecheck` in `website/`


------
https://chatgpt.com/codex/tasks/task_e_6849b5d46c8c8322bb4acecf902083cb