### PR TITLE
fix(k8s): mount tmpfs for frigate /run

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -40,9 +40,13 @@ gpu:
     runtimeClassName:
 
 # -- declare extra volumes to use for Frigate
-extraVolumes: []
+extraVolumes:
+  - name: run-tmpfs
+    emptyDir: {}
 # -- declare additional volume mounts
-extraVolumeMounts: []
+extraVolumeMounts:
+  - name: run-tmpfs
+    mountPath: /run
 
 # -- amount of shared memory to use for caching
 shmSize: 1Gi

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -105,7 +105,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts and keep the root filesystem read-only unless the app needs writes
+4. Configure security contexts and keep the root filesystem read-only. If the container relies on s6-overlay (Frigate does), mount /run as an emptyDir volume so writes stay ephemeral
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- mount `/run` as an emptyDir so Frigate keeps a read-only root filesystem
- note the tmpfs requirement in application docs

## Testing
- `kustomize build --enable-helm k8s/applications/automation` *(fails: cannot fetch chart repository)*
- `npm install`
- `npm run typecheck` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849b602ba44832284f29bb1d63ff185