### PR TITLE
fix(k8s): enable privilege escalation for bazarr and frigate

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -291,7 +291,7 @@ resources:
 
 # -- Set Frigate Container Security Context
 securityContext:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
   readOnlyRootFilesystem: true
   capabilities:
     drop:

--- a/k8s/applications/media/arr/bazarr/kustomization.yaml
+++ b/k8s/applications/media/arr/bazarr/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - svc.yaml
   - http-route.yaml
   - deployment.yaml
+patchesStrategicMerge:
+  - patch.yaml

--- a/k8s/applications/media/arr/bazarr/patch.yaml
+++ b/k8s/applications/media/arr/bazarr/patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  template:
+    spec:
+      containers:
+      - name: bazarr
+        securityContext:
+          allowPrivilegeEscalation: true

--- a/website/docs/applications/media-stack.md
+++ b/website/docs/applications/media-stack.md
@@ -53,6 +53,8 @@ practices.
 The \*arr applications share a common Kustomize base located in `k8s/applications/media/arr/base`. This base injects
 node selectors, security settings, environment variables, and shared volume mounts via a JSON patch. Each individual
 application kustomization references this base and only defines its unique image and resource requirements.
+Bazarr requires a small exception here: the container's `allowPrivilegeEscalation`
+flag must be enabled so its s6-init scripts can drop privileges correctly.
 
 ### Storage Layout
 


### PR DESCRIPTION
## Summary
- patch Bazarr deployment to allow privilege escalation
- enable allowPrivilegeEscalation in Frigate Helm values
- document the Bazarr exception in media stack docs

## Testing
- `kustomize build --enable-helm k8s/applications/media/arr`
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: Forbidden access to helm repo)*
- `npm install`
- `npm run typecheck` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849c3adcf448322958f3f8d83778a4a