### PR TITLE
fix(k8s): run frigate as root for s6-overlay

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -301,10 +301,10 @@ securityContext:
 # -- the container level securiy context defined above
 # -- will override it for frigate container
 podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+  runAsNonRoot: false
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 0
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -105,7 +105,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts and keep the root filesystem read-only. If the container relies on s6-overlay (Frigate does), mount /run as an emptyDir volume so writes stay ephemeral
+4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`) and should mount `/run` as an emptyDir so writes stay ephemeral
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- run Frigate pod as root so s6-overlay can drop privileges
- note the requirement in the application management docs

## Testing
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: 403 Forbidden)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6849e328917483228d7b0128a389bb52