### PR TITLE
fix(frigate): allow chown on log tmpfs

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -296,6 +296,9 @@ securityContext:
   capabilities:
     drop:
       - ALL
+    add:
+      - CHOWN
+      - FOWNER
 
 # -- Set Pod level Security Context
 # -- the container level securiy context defined above

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -105,7 +105,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`) and should mount `/run` as an emptyDir so writes stay ephemeral
+4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`), should mount `/run` as an emptyDir so writes stay ephemeral, and need the `CHOWN` and `FOWNER` capabilities so startup scripts can change log ownership
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- add CHOWN/FOWNER capabilities for Frigate container
- note the capability requirement in the app management docs

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: Get "https://blakeblackshear.github.io/blakeshome-charts/index.yaml": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849e68963e88322adcd490b3a486403