### PR TITLE
fix(frigate): allow group changes

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -299,6 +299,7 @@ securityContext:
     add:
       - CHOWN
       - FOWNER
+      - SETGID
 
 # -- Set Pod level Security Context
 # -- the container level securiy context defined above

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -105,7 +105,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`), should mount `/run` as an emptyDir so writes stay ephemeral, and need the `CHOWN` and `FOWNER` capabilities so startup scripts can change log ownership
+4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`), should mount `/run` as an emptyDir so writes stay ephemeral, and need the `CHOWN`, `FOWNER`, and `SETGID` capabilities so startup scripts can change permissions
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- allow SETGID for frigate so s6-overlay can drop privileges
- mention SETGID capability in the docs

## Testing
- `npm install`
- `npm run typecheck` *(fails: Missing script)*
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: chart repo 403)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6ed97b483228b18346a46ca9887