### PR TITLE
fix(frigate): allow setuid and writable root

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -292,7 +292,7 @@ resources:
 # -- Set Frigate Container Security Context
 securityContext:
   allowPrivilegeEscalation: true
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   capabilities:
     drop:
       - ALL
@@ -300,6 +300,7 @@ securityContext:
       - CHOWN
       - FOWNER
       - SETGID
+      - SETUID
 
 # -- Set Pod level Security Context
 # -- the container level securiy context defined above

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -105,7 +105,7 @@ We use NFS for shared media files:
 1. Use Kustomize for configuration
 2. Store secrets in Bitwarden
 3. Set resource limits
-4. Configure security contexts and keep the root filesystem read-only. s6-overlay containers like Frigate must run as root (`runAsUser: 0`), should mount `/run` as an emptyDir so writes stay ephemeral, and need the `CHOWN`, `FOWNER`, and `SETGID` capabilities so startup scripts can change permissions
+4. Configure security contexts and keep the root filesystem read-only when possible. s6-overlay containers like Frigate must run as root (`runAsUser: 0`), mount `/run` as an emptyDir so writes stay ephemeral, and require the `CHOWN`, `FOWNER`, `SETGID`, and `SETUID` capabilities so startup scripts can change permissions. If the container needs to write to `/etc` during startup, disable `readOnlyRootFilesystem` for that pod
 5. Use automated sync with ArgoCD
 6. Use the `Recreate` strategy for any Deployment that mounts a PVC.
 7. Be aware that `Recreate` causes downtime during updates, so plan a short maintenance window.


### PR DESCRIPTION
## Summary
- allow writes and add SETUID capability for Frigate
- document when a writable root is required

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/automation/frigate` *(fails: helm repo 403)*

------
https://chatgpt.com/codex/tasks/task_e_6849fed1de488322a8af37be4abc5780