### PR TITLE
fix(k8s): address container startup issues

### DIFF
--- a/k8s/applications/media/arr/base/patch.yaml
+++ b/k8s/applications/media/arr/base/patch.yaml
@@ -47,3 +47,13 @@
   value:
     name: tmp
     emptyDir: {}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: run
+    emptyDir: {}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: run
+    mountPath: /run

--- a/k8s/applications/media/jellyseerr/values.yaml
+++ b/k8s/applications/media/jellyseerr/values.yaml
@@ -81,14 +81,18 @@ resources:
     memory: '768Mi'
 
 # -- Additional volumes on the output Deployment definition.
-volumes: []
+volumes:
+  - name: tmp
+    emptyDir: {}
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 # -- Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -36,14 +36,14 @@ spec:
               path: /
               port: 9000
             initialDelaySeconds: 30
-            periodSeconds: 15
+            periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 9000
-            initialDelaySeconds: 20
-            periodSeconds: 15
+            initialDelaySeconds: 60
+            periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3

--- a/k8s/infrastructure/network/coredns/deployment.yaml
+++ b/k8s/infrastructure/network/coredns/deployment.yaml
@@ -87,17 +87,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                  - NET_BIND_SERVICE
-                drop:
-                  - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              runAsUser: 1000
-              runAsGroup: 1000
       dnsPolicy: Default
       volumes:
         - name: config-volume

--- a/website/docs/applications/media-stack.md
+++ b/website/docs/applications/media-stack.md
@@ -52,8 +52,9 @@ practices.
 
 The \*arr applications share a common Kustomize base located in `k8s/applications/media/arr/base`. This base injects
 node selectors, security settings, environment variables, and shared volume mounts via a JSON patch. Each individual
-application kustomization references this base and only defines its unique image and resource requirements.
-Bazarr requires a small exception here: the container's `allowPrivilegeEscalation`
+application kustomization references this base and only defines its unique image and resource requirements. The base
+also mounts ephemeral volumes at `/tmp` and `/run` so the applications can write temporary data despite the
+read-only root filesystem. Bazarr requires a small exception here: the container's `allowPrivilegeEscalation`
 flag must be enabled so its s6-init scripts can drop privileges correctly.
 
 ### Storage Layout


### PR DESCRIPTION
## Summary
- mount `/run` for ARR apps
- mount `/tmp` for Jellyseerr
- clean up CoreDNS manifest
- relax WhisperASR health checks
- document ARR base volumes

## Testing
- `kustomize build --enable-helm k8s/applications/media/arr`
- `kustomize build --enable-helm k8s/applications/media/jellyseerr`
- `kustomize build --enable-helm k8s/infrastructure/network/coredns`
- `kustomize build --enable-helm k8s/applications/media/whisperasr`
- `npm install` & `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684a76ac9a6483229b65c0dd1453e855