### PR TITLE
feat(k8s): add velero backup controller

### DIFF
--- a/k8s/infrastructure/controllers/kustomization.yaml
+++ b/k8s/infrastructure/controllers/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - cert-manager
 - external-secrets
 - crossplane
+- velero

--- a/k8s/infrastructure/controllers/project.yaml
+++ b/k8s/infrastructure/controllers/project.yaml
@@ -14,6 +14,8 @@ spec:
       server: '*'
     - namespace: 'kube-system'
       server: '*'
+    - namespace: 'velero'
+      server: '*'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/k8s/infrastructure/controllers/velero/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/velero/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: velero-minio-credentials
+  namespace: velero
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: velero-minio-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        cloud: |
+          [default]
+          aws_access_key_id={{ .minio_access_key }}
+          aws_secret_access_key={{ .minio_secret_key }}
+  data:
+    - secretKey: minio_access_key
+      remoteRef:
+        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
+    - secretKey: minio_secret_key
+      remoteRef:
+        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6

--- a/k8s/infrastructure/controllers/velero/kustomization.yaml
+++ b/k8s/infrastructure/controllers/velero/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+
+helmCharts:
+  - name: velero
+    repo: https://vmware-tanzu.github.io/helm-charts
+    version: 8.1.0
+    releaseName: velero
+    namespace: velero
+    valuesFile: values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/infrastructure/controllers/velero/namespace.yaml
+++ b/k8s/infrastructure/controllers/velero/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero

--- a/k8s/infrastructure/controllers/velero/values.yaml
+++ b/k8s/infrastructure/controllers/velero/values.yaml
@@ -1,0 +1,49 @@
+upgradeCRDs: true
+deployNodeAgent: true
+initContainers:
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.10.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+  - name: velero-plugin-for-longhorn
+    image: longhornio/velero-plugin-longhorn:v1.9.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+rbac:
+  create: true
+  clusterAdministrator: true
+serviceAccount:
+  server:
+    create: true
+credentials:
+  useSecret: true
+  existingSecret: velero-minio-credentials
+configuration:
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: velero
+      default: true
+      config:
+        region: us-east-1
+        s3ForcePathStyle: "true"
+        s3Url: http://longhorn-minio-service.longhorn-system.svc:9000
+  volumeSnapshotLocation:
+    - name: default
+      provider: longhorn.io/longhorn
+features: "EnableCSI"
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -59,6 +59,16 @@ This document outlines the core infrastructure controllers deployed in our Kuber
   - Custom webhook support
   - Writable `/tmp` mount to support repo clones
 
+### Velero
+
+- **Purpose**: Cluster backup and restore
+- **Version**: Latest stable (automated by Renovate)
+- **Features**:
+  - Object storage backups via Minio
+  - Volume snapshots through Longhorn
+  - Node-agent deployment for filesystem backup
+  - Prometheus metrics
+
 ## Resource Management
 
 ### Base Resource Configuration

--- a/website/docs/infrastructure/controllers/velero-backup.md
+++ b/website/docs/infrastructure/controllers/velero-backup.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 4
+title: Velero Backup Setup
+description: Install Velero for cluster recovery using Minio and Longhorn
+---
+
+# Velero Installation and Usage
+
+Velero manages cluster backups and restores. The configuration deploys the Helm chart in the `velero` namespace, pulls credentials from Bitwarden, and enables the node-agent for volume snapshots.
+
+## Key Points
+
+- Credentials come from the `ExternalSecret` named `velero-minio-credentials`.
+- Backups are stored in the `velero` bucket on the cluster's Minio instance.
+- Longhorn snapshots are handled by the Longhorn Velero plugin.
+- Metrics are exposed via a ServiceMonitor for Prometheus.
+
+Once ArgoCD syncs the manifests, verify pods are running in `velero` before creating backups.


### PR DESCRIPTION
## Summary
- add velero controller manifests
- wire velero into controller project
- document velero setup

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/velero` *(fails: repo forbidden)*
- `kustomize build --enable-helm k8s/infrastructure/controllers` *(fails: repo forbidden)*
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684a7ff55bec83229c9a6b635d3a585c