### PR TITLE
feat(k8s): add cloudflared probes and pdb

### DIFF
--- a/k8s/infrastructure/network/cloudflared/daemon-set.yaml
+++ b/k8s/infrastructure/network/cloudflared/daemon-set.yaml
@@ -6,6 +6,10 @@ metadata:
   name: cloudflared
   namespace: cloudflared
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: cloudflared
@@ -23,13 +27,27 @@ spec:
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 12
           livenessProbe:
             httpGet:
               path: /ready
               port: 2000
-            initialDelaySeconds: 60
-            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            initialDelaySeconds: 5
             periodSeconds: 10
+            failureThreshold: 1
           resources:
             requests:
               cpu: 50m

--- a/k8s/infrastructure/network/cloudflared/kustomization.yaml
+++ b/k8s/infrastructure/network/cloudflared/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ns.yaml
   - tunnel-credentials.yaml
   - daemon-set.yaml
+  - pdb.yaml

--- a/k8s/infrastructure/network/cloudflared/pdb.yaml
+++ b/k8s/infrastructure/network/cloudflared/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared-pdb
+  namespace: cloudflared
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: cloudflared

--- a/website/docs/k8s/cluster-config-overview.md
+++ b/website/docs/k8s/cluster-config-overview.md
@@ -91,3 +91,6 @@ one of these pods, the operation waits until another replica is available or the
 PDB is removed. This prevents accidental outages during routine maintenance.
 Multi-replica services like CoreDNS, Argo CD, and the monitoring stack also
 have PDBs defined to ensure at least one instance stays online during upgrades.
+The Cloudflare tunnel runs as a DaemonSet and uses `maxUnavailable: 1` so that
+only one pod restarts at a time. Startup and readiness probes hold the update
+until the new pod is ready.


### PR DESCRIPTION
## Summary
- keep the Cloudflare tunnel up during rolling updates
- ensure at most one pod can be disrupted at once
- document the new PDB and probes for cloudflared

## Testing
- `kustomize build --enable-helm k8s/infrastructure/network/cloudflared`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684a836e44ec832298293f2cb6f66da4