### PR TITLE
feat(k8s): enable ha mode for argocd

### DIFF
--- a/k8s/infrastructure/controllers/argocd/argocd-redis-network-policy.yaml
+++ b/k8s/infrastructure/controllers/argocd/argocd-redis-network-policy.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: argocd
 spec:
   description: "Restrict Redis access to ArgoCD components while allowing necessary egress"
+  # Target all components of the HA Redis cluster (master, replicas, and sentinels)
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: argocd-redis
+      app.kubernetes.io/name: redis-ha
   egress:
     - toPorts:
         - ports:
@@ -25,6 +26,8 @@ spec:
             app.kubernetes.io/name: argocd-repo-server
         - matchLabels:
             app.kubernetes.io/name: argocd-application-controller
+        - matchLabels:
+            app.kubernetes.io/name: redis-ha
       toPorts:
         - ports:
             - port: "6379"

--- a/k8s/infrastructure/controllers/argocd/kustomization.yaml
+++ b/k8s/infrastructure/controllers/argocd/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - rolebinding.yaml
   - role.yaml
   - externalsecret.yaml
-  - pdb.yaml
 
 helmCharts:
 - name: argo-cd

--- a/k8s/infrastructure/controllers/argocd/pdb.yaml
+++ b/k8s/infrastructure/controllers/argocd/pdb.yaml
@@ -1,9 +1,0 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: argocd-server-pdb
-spec:
-  maxUnavailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-server

--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -58,6 +58,7 @@ crds:
   keep: false
 
 controller:
+  replicas: 1
   resources:
     requests:
       cpu: 100m
@@ -75,16 +76,13 @@ dex:
     limits:
       memory: 128Mi
 
-redis:
-  resources:
-    requests:
-      cpu: 100m
-      memory: 64Mi
-    limits:
-      memory: 1Gi
+redis-ha:
+  enabled: true
 
 server:
-  replicas: 2
+  autoscaling:
+    enabled: true
+    minReplicas: 2
   extensions:
     enabled: true
   service:
@@ -100,7 +98,9 @@ server:
       memory: 1Gi
 
 repoServer:
-  replicas: 2
+  autoscaling:
+    enabled: true
+    minReplicas: 2
   pdb:
     enabled: true
     minAvailable: 1

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -107,8 +107,8 @@ High-Availability Profile:
 
 ```yaml
 Replication:
-  argocd-server: 2
-  argocd-repo-server: 2
+  argocd-server: autoscaled (min 2)
+  argocd-repo-server: autoscaled (min 2)
   argocd-applicationset: 2
   cert-manager-controller: 2
   cert-manager-webhook: 2

--- a/website/docs/k8s/cluster-config-overview.md
+++ b/website/docs/k8s/cluster-config-overview.md
@@ -89,8 +89,10 @@ node drain. Most of our applications run a single replica, so each namespace
 defines a simple PDB with `maxUnavailable: 0`. When you drain a node hosting
 one of these pods, the operation waits until another replica is available or the
 PDB is removed. This prevents accidental outages during routine maintenance.
-Multi-replica services like CoreDNS, Argo CD, and the monitoring stack also
+Multi-replica services like CoreDNS and the monitoring stack also
 have PDBs defined to ensure at least one instance stays online during upgrades.
+Argo CD runs in high availability mode, and the Helm chart automatically
+creates PDBs for each component.
 The Cloudflare tunnel runs as a DaemonSet and uses `maxUnavailable: 1` so that
 only one pod restarts at a time. Startup and readiness probes hold the update
 until the new pod is ready.


### PR DESCRIPTION
## Summary
- switch to Redis HA and HPA for server components
- drop manual PDB in favor of chart defaults
- adjust network policy to match redis-ha labels
- document autoscaling and HA PDB management

## Testing
- `npm run typecheck`
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`

------
https://chatgpt.com/codex/tasks/task_e_684aa9e024f08322af008f733643f1e2