### PR TITLE
fix(k8s): update velero plugin configuration

### DIFF
--- a/k8s/infrastructure/controllers/velero/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/velero/externalsecret.yaml
@@ -11,17 +11,13 @@ spec:
   target:
     name: velero-minio-credentials
     creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        cloud: |
-          [default]
-          aws_access_key_id={{ .minio_access_key }}
-          aws_secret_access_key={{ .minio_secret_key }}
   data:
-    - secretKey: minio_access_key
+    - secretKey: AWS_ACCESS_KEY_ID
       remoteRef:
         key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
-    - secretKey: minio_secret_key
+    - secretKey: AWS_SECRET_ACCESS_KEY
       remoteRef:
         key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: da1cf25e-0219-401f-9063-b2e400c1e12a

--- a/k8s/infrastructure/controllers/velero/values.yaml
+++ b/k8s/infrastructure/controllers/velero/values.yaml
@@ -1,5 +1,6 @@
 upgradeCRDs: true
 deployNodeAgent: true
+snapshotsEnabled: true
 initContainers:
   - name: velero-plugin-for-aws
     image: velero/velero-plugin-for-aws:v1.12.1
@@ -7,8 +8,8 @@ initContainers:
     volumeMounts:
       - mountPath: /target
         name: plugins
-  - name: velero-plugin-for-longhorn
-    image: longhornio/velero-plugin-longhorn:v1.9.0
+  - name: velero-plugin-for-csi
+    image: velero/velero-plugin-for-csi:v0.6.2
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target

--- a/website/docs/infrastructure/controllers/velero-backup.md
+++ b/website/docs/infrastructure/controllers/velero-backup.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: Velero Backup Setup
-description: Install Velero for cluster recovery using Minio and Longhorn
+description: Install Velero for cluster recovery using Minio and the CSI plugin
 ---
 
 # Velero Installation and Usage
@@ -12,7 +12,7 @@ Velero manages cluster backups and restores. The configuration deploys the Helm 
 
 - Credentials come from the `ExternalSecret` named `velero-minio-credentials`.
 - Backups are stored in the `velero` bucket on the cluster's Minio instance.
-- Longhorn snapshots are handled by the Longhorn Velero plugin.
+- Snapshots are handled by the Velero CSI plugin.
 - Metrics are exposed via a ServiceMonitor for Prometheus.
 
 Once ArgoCD syncs the manifests, verify pods are running in `velero` before creating backups.


### PR DESCRIPTION
## Summary
- use the shared MinIO credentials in Velero
- switch from the deprecated Longhorn plugin to the official CSI plugin
- document the plugin change

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/velero`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684ab0e467208322b44b6cc35ee7a87c