### PR TITLE
chore(k8s): comment out openai summary for kubechecks

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
@@ -21,6 +21,6 @@ spec:
     - secretKey: webhook_hmac
       remoteRef:
         key: aa211860-aeb4-44fc-98b7-b2c600feb358
-    - secretKey: openai_key
-      remoteRef:
-        key: e3eeac60-822d-45a4-b454-b2cd016ce38c
+    # - secretKey: openai_key
+    #   remoteRef:
+    #     key: e3eeac60-822d-45a4-b454-b2cd016ce38c

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -22,11 +22,11 @@ deployment:
       value: "https://kubechecks.pc-tips.se"
     - name: KUBECHECKS_ENSURE_WEBHOOKS
       value: "true"
-    - name: KUBECHECKS_OPENAI_API_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: kubechecks-combined-secret
-          key: openai_key
+    # - name: KUBECHECKS_OPENAI_API_TOKEN
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: kubechecks-combined-secret
+    #       key: openai_key
     - name: KUBECHECKS_WEBHOOK_SECRET
       valueFrom:
         secretKeyRef:

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -58,6 +58,7 @@ This document outlines the core infrastructure controllers deployed in our Kuber
   - GitHub integration
   - Custom webhook support
   - Writable `/tmp` mount to support repo clones
+  - Optional OpenAI summaries (currently disabled)
 
 ### Velero
 


### PR DESCRIPTION
## Summary
- disable OpenAI integration in kubechecks values
- comment out OpenAI key in kubechecks secret
- note optional OpenAI summaries in docs

## Testing
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684ab12b91d48322b825a3e2a5bc1cfe