### PR TITLE
fix(kubechecks): add cloudflare schemas

### DIFF
--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -55,7 +55,7 @@ deployment:
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
     - name: KUBECHECKS_SCHEMAS_LOCATION
-      value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/package/crds/dns.cloudflare.upbound.io_records.yaml, https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json"
+      value: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/package/crds/cloudflare.upbound.io_providerconfigs.yaml,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/package/crds/account.cloudflare.upbound.io_accounts.yaml,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/package/crds/zone.cloudflare.upbound.io_zones.yaml,https://raw.githubusercontent.com/cdloh/provider-cloudflare/refs/heads/main/package/crds/dns.cloudflare.upbound.io_records.yaml, https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json"
     - name: KUBECHECKS_GITHUB_APP_ID
       value: "1243453"
     - name: KUBECHECKS_GITHUB_INSTALLATION_ID

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -59,6 +59,7 @@ This document outlines the core infrastructure controllers deployed in our Kuber
   - Custom webhook support
   - Writable `/tmp` mount to support repo clones
   - Optional OpenAI summaries (currently disabled)
+  - Loads Cloudflare provider CRDs so kubeconform validates Crossplane resources
 
 ### Velero
 


### PR DESCRIPTION
## Summary
- configure Kubechecks with Cloudflare CRDs so kubeconform validates Crossplane resources
- document the schema addition in the controllers overview

## Testing
- `npm install`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`

------
https://chatgpt.com/codex/tasks/task_e_684ab2a57f34832286cec01dc1c7ed6c