### PR TITLE
fix(k8s): declare CSI snapshot location

### DIFF
--- a/k8s/infrastructure/controllers/velero/values.yaml
+++ b/k8s/infrastructure/controllers/velero/values.yaml
@@ -35,7 +35,8 @@ configuration:
         s3Url: http://longhorn-minio-service.longhorn-system.svc:9000
   volumeSnapshotLocation:
     - name: default
-      provider: longhorn.io/longhorn
+      provider: csi
+      config: {}
 features: "EnableCSI"
 resources:
   requests:


### PR DESCRIPTION
## Summary
- ensure the Helm chart includes an empty `config` block so Velero's CSI snapshot location passes schema validation

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/velero`


------
https://chatgpt.com/codex/tasks/task_e_684ab464b3f08322bdad6b75f69590f7