### PR TITLE
fix(website): fetch repo stats and logos from GitHub

### DIFF
--- a/website/src/components/Homepage/ProjectStats/index.tsx
+++ b/website/src/components/Homepage/ProjectStats/index.tsx
@@ -26,12 +26,10 @@ export function ProjectStats(): JSX.Element {
 
   useEffect(() => {
     async function fetchStats(): Promise<void> {
-      const repo = await fetch(
-        'https://api.github.com/repos/theepicsaxguy/homelab',
-      ).then((r) => r.json());
-      const commit = await fetch(
-        'https://api.github.com/repos/theepicsaxguy/homelab/commits?per_page=1',
-      ).then((r) => r.json());
+      const [repo, commit] = await Promise.all([
+        fetch('https://api.github.com/repos/theepicsaxguy/homelab').then((r) => r.json()),
+        fetch('https://api.github.com/repos/theepicsaxguy/homelab/commits?per_page=1').then((r) => r.json()),
+      ]);
       setStats({
         stars: repo.stargazers_count.toString(),
         forks: repo.forks_count.toString(),

--- a/website/src/components/Homepage/ProjectStats/index.tsx
+++ b/website/src/components/Homepage/ProjectStats/index.tsx
@@ -1,24 +1,57 @@
-import React, { JSX } from 'react';
+import React, { JSX, useEffect, useState } from 'react';
 import styles from './styles.module.css';
 
-const stats = [
-  { label: 'Stars', value: '1.2k' },
-  { label: 'Forks', value: '150' },
-  { label: 'Open Issues', value: '12' },
-  { label: 'Last Commit', value: 'Today' },
-];
+interface RepoStats {
+  stars: string;
+  forks: string;
+  issues: string;
+  lastCommit: string;
+}
 
 export function ProjectStats(): JSX.Element {
+  const [stats, setStats] = useState<RepoStats>();
+
+  useEffect(() => {
+    async function fetchStats(): Promise<void> {
+      const repo = await fetch(
+        'https://api.github.com/repos/theepicsaxguy/homelab',
+      ).then((r) => r.json());
+      const commit = await fetch(
+        'https://api.github.com/repos/theepicsaxguy/homelab/commits?per_page=1',
+      ).then((r) => r.json());
+      setStats({
+        stars: repo.stargazers_count.toString(),
+        forks: repo.forks_count.toString(),
+        issues: repo.open_issues_count.toString(),
+        lastCommit: new Date(commit[0].commit.committer.date).toLocaleDateString(),
+      });
+    }
+    fetchStats();
+  }, []);
   return (
     <section className={styles.statsSection}>
       <div className="container">
         <div className={styles.statsGrid}>
-          {stats.map((stat, idx) => (
-            <div key={idx} className={styles.statItem}>
-              <div className={styles.statValue}>{stat.value}</div>
-              <div className={styles.statLabel}>{stat.label}</div>
-            </div>
-          ))}
+          {stats && (
+            <>
+              <div className={styles.statItem}>
+                <div className={styles.statValue}>{stats.stars}</div>
+                <div className={styles.statLabel}>Stars</div>
+              </div>
+              <div className={styles.statItem}>
+                <div className={styles.statValue}>{stats.forks}</div>
+                <div className={styles.statLabel}>Forks</div>
+              </div>
+              <div className={styles.statItem}>
+                <div className={styles.statValue}>{stats.issues}</div>
+                <div className={styles.statLabel}>Open Issues</div>
+              </div>
+              <div className={styles.statItem}>
+                <div className={styles.statValue}>{stats.lastCommit}</div>
+                <div className={styles.statLabel}>Last Commit</div>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </section>

--- a/website/src/components/Homepage/ProjectStats/index.tsx
+++ b/website/src/components/Homepage/ProjectStats/index.tsx
@@ -8,6 +8,19 @@ interface RepoStats {
   lastCommit: string;
 }
 
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const minutes = Math.floor(diffMs / (1000 * 60));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString();
+}
+
 export function ProjectStats(): JSX.Element {
   const [stats, setStats] = useState<RepoStats>();
 
@@ -23,7 +36,7 @@ export function ProjectStats(): JSX.Element {
         stars: repo.stargazers_count.toString(),
         forks: repo.forks_count.toString(),
         issues: repo.open_issues_count.toString(),
-        lastCommit: new Date(commit[0].commit.committer.date).toLocaleDateString(),
+        lastCommit: formatRelativeTime(new Date(commit[0].commit.committer.date)),
       });
     }
     fetchStats();

--- a/website/src/components/Homepage/TechStack/index.tsx
+++ b/website/src/components/Homepage/TechStack/index.tsx
@@ -4,7 +4,12 @@ interface Technology {
   name: string;
   logo: string;
 }
-const techConfigs = [
+interface TechConfig {
+  name: string;
+  repo?: string;
+  org?: string;
+}
+const techConfigs: TechConfig[] = [
   { name: 'Kubernetes', repo: 'kubernetes/kubernetes' },
   { name: 'Talos', repo: 'siderolabs/talos' },
   { name: 'ArgoCD', repo: 'argoproj/argo-cd' },

--- a/website/src/components/Homepage/TechStack/index.tsx
+++ b/website/src/components/Homepage/TechStack/index.tsx
@@ -1,46 +1,44 @@
-import React, { JSX } from 'react';
+import React, { JSX, useEffect, useState } from 'react';
 import styles from './styles.module.css';
 interface Technology {
   name: string;
   logo: string;
 }
-const technologies: Technology[] = [
-  {
-    name: 'Kubernetes',
-    logo:
-      'https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/icon/color/kubernetes.svg',
-  },
-  {
-    name: 'Talos',
-    logo:
-      'https://raw.githubusercontent.com/siderolabs/talos/master/website/static/img/talos-logo.svg',
-  },
-  {
-    name: 'ArgoCD',
-    logo:
-      'https://raw.githubusercontent.com/argoproj/argo-cd/master/docs/assets/logo.png',
-  },
-  {
-    name: 'OpenTofu',
-    logo:
-      'https://raw.githubusercontent.com/opentofu/artwork/main/horizontal/color/opentofu-horizontal-color.svg',
-  },
-  {
-    name: 'Prometheus',
-    logo:
-      'https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/icon/color/prometheus-icon-color.svg',
-  },
-  {
-    name: 'Grafana',
-    logo:
-      'https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg',
-  },
-  {
-    name: 'Proxmox',
-    logo: 'https://www.proxmox.com/images/proxmox_logo.png',
-  },
+const techConfigs = [
+  { name: 'Kubernetes', repo: 'kubernetes/kubernetes' },
+  { name: 'Talos', repo: 'siderolabs/talos' },
+  { name: 'ArgoCD', repo: 'argoproj/argo-cd' },
+  { name: 'OpenTofu', repo: 'opentofu/opentofu' },
+  { name: 'Prometheus', repo: 'prometheus/prometheus' },
+  { name: 'Grafana', repo: 'grafana/grafana' },
+  { name: 'Proxmox', org: 'proxmox' },
 ];
+
 export function TechStack(): JSX.Element {
+  const [technologies, setTechnologies] = useState<Technology[]>([]);
+
+  useEffect(() => {
+    async function fetchLogos(): Promise<void> {
+      const items: Technology[] = await Promise.all(
+        techConfigs.map(async (cfg) => {
+          try {
+            const url = cfg.repo
+              ? `https://api.github.com/repos/${cfg.repo}`
+              : `https://api.github.com/orgs/${cfg.org}`;
+            const res = await fetch(url);
+            const data = await res.json();
+            const logo = data.owner ? data.owner.avatar_url : data.avatar_url;
+            return { name: cfg.name, logo };
+          } catch {
+            return { name: cfg.name, logo: '' };
+          }
+        }),
+      );
+      setTechnologies(items);
+    }
+    fetchLogos();
+  }, []);
+
   return (
     <section className={styles.techStack}>
       <div className="container">


### PR DESCRIPTION
## Summary
- fix broken Proxmox, Talos, Kubernetes and OpenTofu logos by pulling avatar images from GitHub
- fetch repository stars, forks, issues and last commit from GitHub API

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684ad602423c8322931f971e152ec4ca