### PR TITLE
fix(security): tighten security settings

### DIFF
--- a/images/spilo17-vchord/Dockerfile
+++ b/images/spilo17-vchord/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/zalando/spilo-17:4.0-p2
 # Don't forget to run the update command on postgresql server
 # https://immich.app/docs/administration/postgres-standalone#updating-vectorchord
 ARG VCHORD_VERSION=0.3.0
-ARG VCHORD_SHA256="d68535ca1325d1260d294a7f8d9e4a18b74b8875d6e57f88895a6c7ef13992b5"
+ARG VCHORD_SHA256=d68535ca1325d1260d294a7f8d9e4a18b74b8875d6e57f88895a6c7ef13992b5
 ARG IMAGE_VERSION=0.1.0
 
 RUN curl -fsSL -o vchord.deb https://github.com/tensorchord/VectorChord/releases/download/${VCHORD_VERSION}/postgresql-17-vchord_${VCHORD_VERSION}-1_amd64.deb && \

--- a/images/spilo17-vchord/Dockerfile
+++ b/images/spilo17-vchord/Dockerfile
@@ -3,8 +3,9 @@ FROM ghcr.io/zalando/spilo-17:4.0-p2
 # Don't forget to run the update command on postgresql server
 # https://immich.app/docs/administration/postgres-standalone#updating-vectorchord
 ARG VCHORD_VERSION=0.3.0
+ARG VCHORD_SHA256="d68535ca1325d1260d294a7f8d9e4a18b74b8875d6e57f88895a6c7ef13992b5"
 ARG IMAGE_VERSION=0.1.0
 
-
-RUN curl -o vchord.deb -fsSL https://github.com/tensorchord/VectorChord/releases/download/${VCHORD_VERSION}/postgresql-17-vchord_${VCHORD_VERSION}-1_amd64.deb && \
+RUN curl -fsSL -o vchord.deb https://github.com/tensorchord/VectorChord/releases/download/${VCHORD_VERSION}/postgresql-17-vchord_${VCHORD_VERSION}-1_amd64.deb && \
+    echo "${VCHORD_SHA256}  vchord.deb" | sha256sum -c - && \
     dpkg -i vchord.deb && rm -f vchord.deb

--- a/k8s/applications/media/arr/bazarr/patch.yaml
+++ b/k8s/applications/media/arr/bazarr/patch.yaml
@@ -9,4 +9,4 @@ spec:
       containers:
       - name: bazarr
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false

--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -32,7 +32,7 @@ configs:
           args: [kustomize build --enable-helm]
   params:
     controller.diff.server.side: true
-    server.insecure: true
+    server.insecure: false
   rbac:
     create: true
     policy.csv: |

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml
@@ -45,13 +45,13 @@ deployment:
           name: kubechecks-combined-secret
           key: argocd_api_token
     - name: KUBECHECKS_ARGOCD_API_INSECURE
-      value: "true"
+      value: "false"
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
       value: "argocd-server.argocd.svc.kube.pc-tips.se"
     - name: KUBECHECKS_ARGOCD_API_PLAINTEXT
-      value: "true"
+      value: "false"
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE
-      value: "true"
+      value: "false"
     - name: KUBECHECKS_LOG_LEVEL
       value: "debug"
     - name: KUBECHECKS_SCHEMAS_LOCATION

--- a/k8s/infrastructure/storage/longhorn/kustomization.yaml
+++ b/k8s/infrastructure/storage/longhorn/kustomization.yaml
@@ -16,3 +16,5 @@ helmCharts:
     repo: https://charts.longhorn.io
     valuesFile: values.yaml
     version: 1.9.0
+patches:
+  - path: patch-security.yaml

--- a/k8s/infrastructure/storage/longhorn/patch-security.yaml
+++ b/k8s/infrastructure/storage/longhorn/patch-security.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: longhorn-manager
+  namespace: longhorn-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: longhorn-manager
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - "ALL"

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -19,6 +19,7 @@ This document outlines the core infrastructure controllers deployed in my Kubern
   - Progressive delivery
   - Resource health monitoring
   - Multi-cluster management
+  - TLS-only API access
 
 ### cert-manager
 
@@ -48,6 +49,7 @@ This document outlines the core infrastructure controllers deployed in my Kubern
 - Volume replication
 - Backup capabilities
 - Storage overprovisioning
+- PodSecurity patch applied for restricted containers
 
 ### Kubechecks
 
@@ -185,6 +187,8 @@ Controllers:
 - Namespace isolation
 - Service account restrictions
 - Security context constraints
+- Longhorn DaemonSet patched to run as non-root
+- ArgoCD API served only over TLS
 
 ### Network Policies
 


### PR DESCRIPTION
## Summary
- disable ArgoCD insecure mode
- remove plaintext Kubechecks API settings
- enforce non-root policy for Longhorn with a patch
- stop Bazarr privilege escalation
- verify VectorChord download in Spilo image
- document TLS enforcement and Longhorn patch

## Testing
- `npm install --prefix website`
- `npm run --silent typecheck --prefix website`
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`
- `kustomize build --enable-helm k8s/infrastructure/deployment/kubechecks`
- `kustomize build --enable-helm k8s/infrastructure/storage/longhorn`
- `kustomize build --enable-helm k8s/applications/media/arr/bazarr`


------
https://chatgpt.com/codex/tasks/task_e_684b4ed8e83883229a80f06b787a2ac7