### PR TITLE
fix(k8s): allow velero node-agent on baseline clusters

### DIFF
--- a/k8s/infrastructure/controllers/velero/namespace.yaml
+++ b/k8s/infrastructure/controllers/velero/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: velero
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/website/docs/infrastructure/controllers/velero-backup.md
+++ b/website/docs/infrastructure/controllers/velero-backup.md
@@ -14,5 +14,6 @@ Velero manages cluster backups and restores. The configuration deploys the Helm 
 - Backups are stored in the `velero` bucket on the cluster's Minio instance.
 - Snapshots are handled by the Velero CSI plugin.
 - Metrics are exposed via a ServiceMonitor for Prometheus.
+- The `velero` namespace is labeled `pod-security.kubernetes.io/enforce: privileged` so the node-agent can mount required host paths.
 
 Once ArgoCD syncs the manifests, verify pods are running in `velero` before creating backups.


### PR DESCRIPTION
## Summary
- allow `velero` namespace to run privileged pods
- note PodSecurity label in backup docs

## Testing
- `npm install`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/infrastructure/controllers/velero`
- `kustomize build --enable-helm k8s/infrastructure/controllers`

------
https://chatgpt.com/codex/tasks/task_e_684dfe856df88322a8c5b6d9c48931c7