### PR TITLE
fix(k8s): use minio keys for velero

### DIFF
--- a/k8s/infrastructure/controllers/velero/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/velero/externalsecret.yaml
@@ -11,13 +11,21 @@ spec:
   target:
     name: velero-minio-credentials
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        cloud: |
+          [default]
+          aws_access_key_id={{ .MINIO_ACCESS_KEY }}
+          aws_secret_access_key={{ .MINIO_SECRET_KEY }}
+          aws_endpoint={{ .MINIO_ENDPOINT }}
   data:
-    - secretKey: AWS_ACCESS_KEY_ID
+    - secretKey: MINIO_ACCESS_KEY
       remoteRef:
         key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
-    - secretKey: AWS_SECRET_ACCESS_KEY
+    - secretKey: MINIO_SECRET_KEY
       remoteRef:
         key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
-    - secretKey: AWS_ENDPOINTS
+    - secretKey: MINIO_ENDPOINT
       remoteRef:
         key: da1cf25e-0219-401f-9063-b2e400c1e12a

--- a/website/docs/infrastructure/controllers/velero-backup.md
+++ b/website/docs/infrastructure/controllers/velero-backup.md
@@ -17,3 +17,14 @@ Velero manages cluster backups and restores. The configuration deploys the Helm 
 - The `velero` namespace is labeled `pod-security.kubernetes.io/enforce: privileged` so the node-agent can mount required host paths.
 
 Once ArgoCD syncs the manifests, verify pods are running in `velero` before creating backups.
+
+## Credentials Format
+
+The `velero-minio-credentials` secret must expose three values:
+
+- `MINIO_ACCESS_KEY`
+- `MINIO_SECRET_KEY`
+- `MINIO_ENDPOINT`
+
+These values come from Bitwarden. The `ExternalSecret` assembles them into a
+`cloud` file so Velero can read standard AWS-style credentials.


### PR DESCRIPTION
## Summary
- template velero minio credentials
- explain how the `cloud` file is generated

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/velero`
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684e102285d083228b7a6c7a1cbf95d7