### PR TITLE
feat(k8s): enhance immich configuration

### DIFF
--- a/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
+++ b/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
@@ -88,6 +88,8 @@ spec:
               logging:
                 enabled: true
                 level: log
+              server:
+                externalDomain: photo.pc-tips.se
               machineLearning:
                 clip:
                   enabled: true
@@ -102,6 +104,8 @@ spec:
                   minFaces: 1
                   minScore: 0.7
                   modelName: buffalo_l
+                urls:
+                  - http://immich-machine-learning:3003
               map:
                 darkStyle: https://tiles.immich.cloud/v1/style/dark.json
                 enabled: true
@@ -121,7 +125,7 @@ spec:
                 clientId: "{{ .clientId }}"
                 clientSecret: "{{ .clientSecret }}"
               passwordLogin:
-                enabled: true
+                enabled: false
               reverseGeocoding:
                 enabled: true
               theme:
@@ -129,6 +133,22 @@ spec:
               trash:
                 days: 30
                 enabled: true
+              backup:
+                database:
+                  enabled: true
+                  cronExpression: "0 02 * * *"
+                  keepLastAmount: 14
+              notifications:
+                smtp:
+                  enabled: false
+                  from: ""
+                  replyTo: ""
+                  transport:
+                    ignoreCert: false
+                    host: ""
+                    port: 587
+                    username: ""
+                    password: ""
               user:
                 deleteDelay: 7
   data:

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -70,17 +70,21 @@ Immich expects the OAuth client details inside its config file. The `immich-conf
 spec:
   template:
     data:
-      immich-config.yaml: |
-        ...
-        oauth:
-          enabled: true
-          issuerUrl: "https://sso.pc-tips.se/application/o/immich/"
-          scope: "openid email profile"
-          autoLaunch: true
-          autoRegister: true
-          buttonText: "Login with SSO"
-          clientId: "{{ .clientId }}"
-          clientSecret: "{{ .clientSecret }}"
+        immich-config.yaml: |
+          ...
+          server:
+            externalDomain: photo.pc-tips.se
+          oauth:
+            enabled: true
+            issuerUrl: "https://sso.pc-tips.se/application/o/immich/"
+            scope: "openid email profile"
+            autoLaunch: true
+            autoRegister: true
+            buttonText: "Login with SSO"
+            clientId: "{{ .clientId }}"
+            clientSecret: "{{ .clientSecret }}"
+          passwordLogin:
+            enabled: false
 ```
 
 This Secret is mounted by the StatefulSet at `/config/immich-config.yaml`, allowing the application to start without additional environment variables.


### PR DESCRIPTION
## Summary
- disable password login in Immich config
- add externalDomain, machine learning URL, and backup settings
- provide optional SMTP settings
- streamline OAuth snippet in docs

## Testing
- `npm install`
- `npm run typecheck` *(fails: Missing script)*
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/media/immich`


------
https://chatgpt.com/codex/tasks/task_e_684f4001bb148322866d1c0f16d05ee0