### PR TITLE
fix(k8s): adjust immich resources and domain url

### DIFF
--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -53,11 +53,11 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: '150m'
-              memory: '256Mi'
+              cpu: '200m'
+              memory: '512Mi'
             limits:
-              cpu: '750m'
-              memory: '1Gi'
+              cpu: '1000m'
+              memory: '2Gi'
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/k8s/applications/media/immich/immich-redis/values.yaml
+++ b/k8s/applications/media/immich/immich-redis/values.yaml
@@ -11,8 +11,8 @@ primary:
     size: 1Gi
   resources:
     requests:
-      cpu: 80m
-      memory: 100Mi
+      cpu: 100m
+      memory: 128Mi
     limits:
-      cpu: 150m
-      memory: 256Mi
+      cpu: 200m
+      memory: 512Mi

--- a/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
+++ b/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
@@ -89,7 +89,7 @@ spec:
                 enabled: true
                 level: log
               server:
-                externalDomain: photo.pc-tips.se
+                externalDomain: https://photo.pc-tips.se
               machineLearning:
                 clip:
                   enabled: true

--- a/k8s/applications/media/immich/immich-server/statefulset.yaml
+++ b/k8s/applications/media/immich/immich-server/statefulset.yaml
@@ -61,11 +61,11 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: '100m'
-              memory: '128Mi'
+              cpu: '250m'
+              memory: '256Mi'
             limits:
-              cpu: '500m'
-              memory: '512Mi'
+              cpu: '1000m'
+              memory: '1Gi'
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -73,7 +73,7 @@ spec:
         immich-config.yaml: |
           ...
           server:
-            externalDomain: photo.pc-tips.se
+            externalDomain: https://photo.pc-tips.se
           oauth:
             enabled: true
             issuerUrl: "https://sso.pc-tips.se/application/o/immich/"


### PR DESCRIPTION
## Summary
- update Immich externalDomain to include protocol
- increase resource requests and limits for Immich pods
- document updated externalDomain value

## Testing
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-ml`
- `npm install`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-redis` *(failed: empty output)*

------
https://chatgpt.com/codex/tasks/task_e_684faee6862883229fe481e820670ade