### PR TITLE
refactor(k8s): use named secrets for externalsecret lookups

### DIFF
--- a/k8s/applications/ai/karakeep/karakeep-secrets-external.yaml
+++ b/k8s/applications/ai/karakeep/karakeep-secrets-external.yaml
@@ -14,20 +14,20 @@ spec:
   data:
     - secretKey: NEXTAUTH_SECRET
       remoteRef:
-        key: ed921c91-48c8-4e56-8f17-b2cd00e45116
+        key: app-karakeep-nextauth-secret
     - secretKey: MEILI_MASTER_KEY
       remoteRef:
-        key: acb2a570-43d4-43aa-b92c-b2cd00e470a6
+        key: app-karakeep-meili-master-key
     - secretKey: NEXT_PUBLIC_SECRET
       remoteRef:
-        key: e19bedc6-d9c8-464b-b311-b2cd00e48f56
+        key: app-karakeep-next-public-secret
     - secretKey: OPENAI_API_KEY
       remoteRef:
-        key: e3eeac60-822d-45a4-b454-b2cd016ce38c
+        key: global-openai-api-key
     - secretKey: OAUTH_CLIENT_ID
       remoteRef:
-        key: '2eb7074e-20a5-453a-99f9-b2f7016214e8'
+        key: 'app-karakeep-oauth-client-id'
     - secretKey: OAUTH_CLIENT_SECRET
       remoteRef:
-        key: 'a849669c-fe18-4951-9d5e-b2f701624a14'
+        key: 'app-karakeep-oauth-client-secret'
 

--- a/k8s/applications/ai/openwebui/openwebui-secrets-external.yaml
+++ b/k8s/applications/ai/openwebui/openwebui-secrets-external.yaml
@@ -15,10 +15,10 @@ spec:
   data:
     - secretKey: WEBUI_SECRET_KEY
       remoteRef:
-        key: 5885ea99-3aaf-4bf7-b121-b2c40096cdcc
+        key: app-openwebui-secret-key
     - secretKey: OAUTH_CLIENT_ID
       remoteRef:
-        key: "9d5057fc-c56e-4879-bc51-b2f001247da8"
+        key: "app-openwebui-oauth-client-id"
     - secretKey: OAUTH_CLIENT_SECRET
       remoteRef:
-        key: "2c1c9f3f-a8b3-4b62-a41b-b2f001248898"
+        key: "app-openwebui-oauth-client-secret"

--- a/k8s/applications/automation/frigate/externalsecret.yaml
+++ b/k8s/applications/automation/frigate/externalsecret.yaml
@@ -14,19 +14,19 @@ spec:
   data:
     - secretKey: FRIGATE_RTSP_USERNAME
       remoteRef:
-        key: 191e2a17-e7fe-4abb-b061-b2d4013c77e8
+        key: app-frigate-rtsp-username
     - secretKey: FRIGATE_RTSP_PASSWORD
       remoteRef:
-        key: 78361026-625e-4166-9352-b2d4013c9b78
+        key: app-frigate-rtsp-password
     - secretKey: FRIGATE_RTSP_SUB
       remoteRef:
-        key: 34890eb6-91fc-49ff-bd76-b2d40138fa28
+        key: app-frigate-rtsp-sub-stream-url
     - secretKey: FRIGATE_RTSP_MAIN
       remoteRef:
-        key: 8b20e489-2fb0-457a-af15-b2d40139d025
+        key: app-frigate-rtsp-main-stream-url
     - secretKey: FRIGATE_ONVIF
       remoteRef:
-        key: 83a74433-75d5-40d6-9616-b2d4013b3685
+        key: app-frigate-onvif-password
     - secretKey: FRIGATE_MQTT_PASSWORD
       remoteRef:
-        key: e60a8c39-80ad-4e8c-8869-b2d401149702
+        key: app-frigate-mqtt-password

--- a/k8s/applications/automation/mqtt/externalsecret.yaml
+++ b/k8s/applications/automation/mqtt/externalsecret.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: password.txt
       remoteRef:
-        key: 186f58c7-f967-4be9-b912-b2d40142d2a7
+        key: app-mqtt-password-file

--- a/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
+++ b/k8s/applications/media/immich/immich-server/immich-config-external-secret.yaml
@@ -154,7 +154,7 @@ spec:
   data:
     - secretKey: clientId
       remoteRef:
-        key: 3b511ff8-2630-472d-bc6e-b2e3013cb601
+        key: app-immich-oauth-client-id
     - secretKey: clientSecret
       remoteRef:
-        key: 3c78fc60-c8b2-499c-9e03-b2e3013ce060
+        key: app-immich-oauth-client-secret

--- a/k8s/applications/media/jellyseerr-secrets.yaml
+++ b/k8s/applications/media/jellyseerr-secrets.yaml
@@ -14,7 +14,7 @@ spec:
   data:
     - secretKey: JELLYFIN_URL
       remoteRef:
-        key: "8c7abede-48a3-4026-971a-b2f50114319f"
+        key: "app-jellyseerr-jellyfin-url"
     - secretKey: JELLYFIN_API_KEY
       remoteRef:
-        key: "94a92430-ce0d-4a99-8fa1-b2f50114aad9"
+        key: "app-jellyseerr-jellyfin-api-key"

--- a/k8s/applications/web/babybuddy/babybuddy-external-secret.yaml
+++ b/k8s/applications/web/babybuddy/babybuddy-external-secret.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: SECRET_KEY         # ← must be exactly SECRET_KEY
       remoteRef:
-        key: b679882a-62a1-45b6-945c-b2c400ffcd85  # sample Bitwarden item ID
+        key: app-babybuddy-secret-key  # sample Bitwarden item ID

--- a/k8s/applications/web/pedrobot/pedro-bot-external-secret.yaml
+++ b/k8s/applications/web/pedrobot/pedro-bot-external-secret.yaml
@@ -14,10 +14,10 @@ spec:
   data:
     - secretKey: DISCORD_TOKEN
       remoteRef:
-        key: e799eef9-162b-4fbf-be96-b2cc00bcd612
+        key: app-pedrobot-discord-token
     - secretKey: CLIENT_ID
       remoteRef:
-        key: 25373172-fca5-40fd-85df-b2cc00bcb73a
+        key: app-pedrobot-discord-client-id
     - secretKey: GUILD_ID
       remoteRef:
-        key: 1f3fcdd4-5ae3-4001-be27-b2cc00bceb14
+        key: app-pedrobot-discord-guild-id

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -18,26 +18,26 @@ spec:
     # Changed from 'secret-key' to 'AUTHENTIK_SECRET_KEY' for env var usage
     - secretKey: AUTHENTIK_SECRET_KEY
       remoteRef:
-        key: '49416301-9093-4c1d-b713-b2d500632388'
+        key: 'app-authentik-secret-key'
 
     # --- Redis Password ---
     - secretKey: redis-password
       remoteRef:
-        key: 'cb26a5a7-3a42-425d-98cd-b2d500f984e7'
+        key: 'app-authentik-redis-password'
 
     - secretKey: AUTHENTIK_REDIS__PASSWORD
       remoteRef:
-        key: 'cb26a5a7-3a42-425d-98cd-b2d500f984e7'
+        key: 'app-authentik-redis-password'
     # --- Bootstrap Credentials ---
     - secretKey: AUTHENTIK_BOOTSTRAP_TOKEN
       remoteRef:
-        key: '1c460c2a-c0e7-4a93-8a0f-b2d301342555'
+        key: 'app-authentik-bootstrap-token'
     - secretKey: AUTHENTIK_BOOTSTRAP_PASSWORD
       remoteRef:
-        key: 'a72fef1f-af7f-4c92-889c-b2d500f9a2c1'
+        key: 'app-authentik-bootstrap-password'
     - secretKey: AUTHENTIK_BOOTSTRAP_EMAIL
       remoteRef:
-        key: 'f00c9b32-da26-4dee-8cbf-b2d500f6fd2b'
+        key: 'app-authentik-admin-email'
 
 ---
 apiVersion: external-secrets.io/v1
@@ -56,116 +56,116 @@ spec:
   data:
     - secretKey: AUTHENTIK_BLUEPRINTS_NOTIFICATIONS_SLACK_WEBHOOK
       remoteRef:
-        key: '5bc23bdf-75c4-4e97-a19b-b2ec0130cad4'
+        key: 'app-authentik-notifications-slack-webhook'
 
     # --- User Emails ---
     - secretKey: ARGOCD_ADMIN_EMAIL
       remoteRef:
-        key: 'f00c9b32-da26-4dee-8cbf-b2d500f6fd2b' # Replace with actual Bitwarden item ID
+        key: 'app-authentik-admin-email' # Replace with actual Bitwarden item ID
     - secretKey: GRAFANA_VIEWER_EMAIL
       remoteRef:
-        key: 'f00c9b32-da26-4dee-8cbf-b2d500f6fd2b' # Replace with actual Bitwarden item ID
+        key: 'app-authentik-admin-email' # Replace with actual Bitwarden item ID
 
     # --- ArgoCD ---
     - secretKey: ARGOCD_CLIENT_ID
       remoteRef:
-        key: '119b379d-c30f-410a-86c4-b2e200988e9a'
+        key: 'app-argocd-oauth-client-id'
     - secretKey: ARGOCD_CLIENT_SECRET
       remoteRef:
-        key: 'ee2da933-0e5a-469e-bf64-b2890117e1a4'
+        key: 'app-argocd-oauth-client-secret'
 
     # --- Grafana ---
     - secretKey: GRAFANA_CLIENT_ID
       remoteRef:
-        key: 'e0653cbf-e89e-4c7f-bf15-b2f4014daf64'
+        key: 'app-grafana-oauth-client-id'
     - secretKey: GRAFANA_CLIENT_SECRET
       remoteRef:
-        key: '56041409-832c-4d56-8688-b2f4014dc3cc'
+        key: 'app-grafana-oauth-client-secret'
 
     # --- Immich ---
     - secretKey: IMMICH_CLIENT_ID
       remoteRef:
-        key: '3b511ff8-2630-472d-bc6e-b2e3013cb601'
+        key: 'app-immich-oauth-client-id'
     - secretKey: IMMICH_CLIENT_SECRET
       remoteRef:
-        key: '3c78fc60-c8b2-499c-9e03-b2e3013ce060'
+        key: 'app-immich-oauth-client-secret'
 
     # --- Jellyfin ---
     - secretKey: JELLYFIN_CLIENT_ID
       remoteRef:
-        key: '2d32cc07-d060-448a-b50b-b2f4014ef5b2'
+        key: 'app-jellyfin-oauth-client-id'
     - secretKey: JELLYFIN_CLIENT_SECRET
       remoteRef:
-        key: 'd850f612-c9a0-4633-bd82-b2f4014f08c4'
+        key: 'app-jellyfin-oauth-client-secret'
 
     # --- Bazarr ---
     - secretKey: BAZARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: BAZARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Lidarr ---
     - secretKey: LIDARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: LIDARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Prowlarr ---
     - secretKey: PROWLARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: PROWLARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Radarr ---
     - secretKey: RADARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: RADARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Readarr ---
     - secretKey: READARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: READARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Sonarr ---
     - secretKey: SONARR_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: SONARR_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- SABnzbd ---
     - secretKey: SABNZBD_CLIENT_ID
       remoteRef:
-        key: '7d34c677-6eb9-432f-9d07-b2f4014f485e'
+        key: 'app-servarr-oauth-client-id'
     - secretKey: SABNZBD_CLIENT_SECRET
       remoteRef:
-        key: '875a2c71-8426-4de8-b247-b2f4014f6307'
+        key: 'app-servarr-oauth-client-secret'
 
     # --- Open WebUI ---
     - secretKey: OPENWEBUI_CLIENT_ID
       remoteRef:
-        key: '9d5057fc-c56e-4879-bc51-b2f001247da8'
+        key: 'app-openwebui-oauth-client-id'
     - secretKey: OPENWEBUI_CLIENT_SECRET
       remoteRef:
-        key: '2c1c9f3f-a8b3-4b62-a41b-b2f001248898'
+        key: 'app-openwebui-oauth-client-secret'
     # --- Karakeep ---
     - secretKey: KARAKEEP_CLIENT_ID
       remoteRef:
-        key: '2eb7074e-20a5-453a-99f9-b2f7016214e8'
+        key: 'app-karakeep-oauth-client-id'
     - secretKey: KARAKEEP_CLIENT_SECRET
       remoteRef:
-        key: 'a849669c-fe18-4951-9d5e-b2f701624a14'
+        key: 'app-karakeep-oauth-client-secret'
 

--- a/k8s/infrastructure/auth/authentik/outpost-externalsecret.yaml
+++ b/k8s/infrastructure/auth/authentik/outpost-externalsecret.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: 8d257027-d623-4781-8079-b2d800e3e8d6
+        key: app-authentik-outpost-token

--- a/k8s/infrastructure/controllers/argocd/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/argocd/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
   data:
     - secretKey: dex.authentik.clientSecret
       remoteRef:
-        key: ee2da933-0e5a-469e-bf64-b2890117e1a4
+        key: app-argocd-oauth-client-secret
     - secretKey: dex.authentik.clientId
       remoteRef:
-        key: 119b379d-c30f-410a-86c4-b2e200988e9a
+        key: app-argocd-oauth-client-id

--- a/k8s/infrastructure/controllers/cert-manager/cert-manager-secrets-external.yaml
+++ b/k8s/infrastructure/controllers/cert-manager/cert-manager-secrets-external.yaml
@@ -18,7 +18,7 @@ spec:
   data:
   - secretKey: cloudflare_api_token
     remoteRef:
-      key: 154f7f9b-a324-47d2-b11e-b287015e66a8
+      key: infra-cloudflare-api-token
   - secretKey: email
     remoteRef:
-      key: e0f77c49-54b7-43e1-902e-b29701526934
+      key: infra-cloudflare-admin-email

--- a/k8s/infrastructure/controllers/crossplane/external-secret-cloudflare-token.yaml
+++ b/k8s/infrastructure/controllers/crossplane/external-secret-cloudflare-token.yaml
@@ -22,13 +22,13 @@ spec:
   data:
     - secretKey: apiToken
       remoteRef:
-        key: 154f7f9b-a324-47d2-b11e-b287015e66a8
+        key: infra-cloudflare-api-token
     - secretKey: accountId
       remoteRef:
-        key: e9f7418e-00ba-4e31-be33-b2f10059f28e
+        key: infra-cloudflare-account-id
     - secretKey: cloudflare-api-token
       remoteRef:
-        key: 154f7f9b-a324-47d2-b11e-b287015e66a8
+        key: infra-cloudflare-api-token
     - secretKey: cloudflare-account-id
       remoteRef:
-        key: e9f7418e-00ba-4e31-be33-b2f10059f28e
+        key: infra-cloudflare-account-id

--- a/k8s/infrastructure/controllers/velero/externalsecret.yaml
+++ b/k8s/infrastructure/controllers/velero/externalsecret.yaml
@@ -22,10 +22,10 @@ spec:
   data:
     - secretKey: MINIO_ACCESS_KEY
       remoteRef:
-        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
+        key: infra-minio-s3-access-key
     - secretKey: MINIO_SECRET_KEY
       remoteRef:
-        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
+        key: infra-minio-s3-secret-key
     - secretKey: MINIO_ENDPOINT
       remoteRef:
-        key: da1cf25e-0219-401f-9063-b2e400c1e12a
+        key: infra-minio-s3-endpoint-url

--- a/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
+++ b/k8s/infrastructure/deployment/kubechecks/kubechecks-secret-external.yaml
@@ -14,13 +14,13 @@ spec:
   data:
     - secretKey: github_token
       remoteRef:
-        key: 7ecb4650-ab7a-42f7-b9d1-b2d501183924
+        key: app-kubechecks-github-app-key
     - secretKey: argocd_api_token
       remoteRef:
-        key: 0d2a2732-db70-49b7-b64a-b29400a92230
+        key: app-kubechecks-argocd-api-token
     - secretKey: webhook_hmac
       remoteRef:
-        key: aa211860-aeb4-44fc-98b7-b2c600feb358
+        key: app-kubechecks-webhook-hmac-secret
     # - secretKey: openai_key
     #   remoteRef:
-    #     key: e3eeac60-822d-45a4-b454-b2cd016ce38c
+    #     key: global-openai-api-key

--- a/k8s/infrastructure/monitoring/prometheus-stack/grafana-oauth-secret.yaml
+++ b/k8s/infrastructure/monitoring/prometheus-stack/grafana-oauth-secret.yaml
@@ -19,9 +19,9 @@ spec:
   data:
     - secretKey: clientId
       remoteRef:
-        key: e0653cbf-e89e-4c7f-bf15-b2f4014daf64
+        key: app-grafana-oauth-client-id
         property: value
     - secretKey: clientSecret
       remoteRef:
-        key: 56041409-832c-4d56-8688-b2f4014dc3cc
+        key: app-grafana-oauth-client-secret
         property: value

--- a/k8s/infrastructure/network/cloudflared/tunnel-credentials.yaml
+++ b/k8s/infrastructure/network/cloudflared/tunnel-credentials.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: credentials.json
       remoteRef:
-        key: 10b5b4b6-c836-46d0-926b-b2890117b661
+        key: infra-cloudflared-tunnel-credentials-json

--- a/k8s/infrastructure/storage/longhorn/externalsecret.yaml
+++ b/k8s/infrastructure/storage/longhorn/externalsecret.yaml
@@ -14,10 +14,10 @@ spec:
   data:
     - secretKey: AWS_ACCESS_KEY_ID
       remoteRef:
-        key: 361e17bd-beb7-4f9b-b3c0-b2e400b21185
+        key: infra-minio-s3-access-key
     - secretKey: AWS_SECRET_ACCESS_KEY
       remoteRef:
-        key: d1b2c6a5-236e-4313-92a2-b2e400be72c6
+        key: infra-minio-s3-secret-key
     - secretKey: AWS_ENDPOINTS
       remoteRef:
-        key: da1cf25e-0219-401f-9063-b2e400c1e12a
+        key: infra-minio-s3-endpoint-url

--- a/website/docs/infrastructure/controllers/kubechecks-token.md
+++ b/website/docs/infrastructure/controllers/kubechecks-token.md
@@ -30,7 +30,7 @@ Generate a token in ArgoCD for the `kubechecks` account and save it to Bitwarden
 ```yaml
 - secretKey: argocd_api_token
   remoteRef:
-    key: 0d2a2732-db70-49b7-b64a-b29400a92230
+    key: app-kubechecks-argocd-api-token
 ```
 
 The secret is referenced by the Kubechecks Helm chart so the token never lives in the repository.

--- a/website/docs/infrastructure/monitoring.md
+++ b/website/docs/infrastructure/monitoring.md
@@ -24,11 +24,11 @@ Ensure the secret keys reference the correct Bitwarden entries before deploying:
 data:
   - secretKey: clientId
     remoteRef:
-      key: e0653cbf-e89e-4c7f-bf15-b2f4014daf64
+      key: app-grafana-oauth-client-id
       property: value
   - secretKey: clientSecret
     remoteRef:
-      key: 56041409-832c-4d56-8688-b2f4014dc3cc
+      key: app-grafana-oauth-client-secret
       property: value
 ```
 

--- a/website/docs/k8s/cloudflare-dns-records.md
+++ b/website/docs/k8s/cloudflare-dns-records.md
@@ -29,7 +29,7 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
 ## Prerequisites
 
 - A Kubernetes cluster with `kubectl` access.
-- A `ClusterSecretStore` containing a valid Cloudflare API token under the key `cloudflare_api_token`.
+- A `ClusterSecretStore` containing a valid Cloudflare API token under the key `infra-cloudflare-api-token`.
 - GitOps tooling (Argo CD, Flux, etc.) configured to apply this repository.
 
 ## Overview of steps
@@ -46,7 +46,7 @@ Maintain manifest definitions in `k8s/infrastructure/controllers/crossplane/` an
    Apply the official Crossplane Helm chart into `crossplane-system` via your GitOps tool.
 
 2. **Configure external secrets**
-   Define an `ExternalSecret` pointing to the Bitwarden-backed `ClusterSecretStore` to sync `cloudflare_api_token` and `cloudflare_account_id` into a Kubernetes Secret named `cloudflare-api-token`. The secret includes a `creds` key containing `{ "api_token": "...", "account_id": "..." }`.
+   Define an `ExternalSecret` pointing to the Bitwarden-backed `ClusterSecretStore` to sync `infra-cloudflare-api-token` and `infra-cloudflare-account-id` into a Kubernetes Secret named `cloudflare-api-token`. The secret includes a `creds` key containing `{ "api_token": "...", "account_id": "..." }`.
 
 3. **Install provider and credentials**
    Apply the Crossplane `Provider` for Cloudflare and a `ProviderConfig` that references the `creds` key in `cloudflare-api-token`.

--- a/website/docs/k8s/secret-management.md
+++ b/website/docs/k8s/secret-management.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 4
+title: Secret Management
+description: How to manage secrets using External Secrets and Bitwarden.
+---
+
+# Secret Management Strategy
+
+This project uses the [External Secrets Operator](https://external-secrets.io/) to securely pull secrets from [Bitwarden](https://bitwarden.com/) into the cluster. This means sensitive data never lives in Git.
+
+## Core Concepts
+
+1. **Bitwarden as the Source of Truth** – every token, password, and key lives in Bitwarden.
+2. **External Secrets Operator** – syncs those secrets into Kubernetes at runtime.
+3. **Name-Based Lookups** – we store secrets in Bitwarden using a human-friendly naming convention instead of UUIDs.
+
+## Naming Convention
+
+All Bitwarden secrets follow the `{scope}-{service-or-app}-{description}` pattern.
+
+- **`{scope}`** – high-level category like `infra`, `app`, or `global`.
+- **`{service-or-app}`** – the specific component name (e.g., `argocd`, `cloudflare`).
+- **`{description}`** – short purpose description such as `api-token`, `oauth-client-id`, or `db-password`.
+
+Example: the client ID for ArgoCD's OIDC setup is stored as `app-argocd-oauth-client-id`.
+
+## Workflow for Adding a Secret
+
+1. **Create the secret in Bitwarden** – use the naming convention, store the value.
+2. **Reference it in an `ExternalSecret` manifest** – point the `remoteRef.key` to the Bitwarden name.
+3. **Commit the manifest** – once merged, ArgoCD applies it and the operator syncs the secret into the cluster.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: newapp-secrets
+  namespace: newapp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-backend
+  target:
+    name: newapp-k8s-secret
+  data:
+    - secretKey: API_KEY
+      remoteRef:
+        key: app-newapp-api-key
+```
+
+This setup keeps credentials out of the repository while making manifest files self-explanatory.


### PR DESCRIPTION
## Summary
- migrate ExternalSecret resources from UUID references to descriptive Bitwarden names
- update docs to reference new secret names

## Testing
- `npm install`
- `npm run typecheck` within `website`
- `kustomize build --enable-helm` on modified directories

------
https://chatgpt.com/codex/tasks/task_e_684fccb5eb0083229ab3ea540066c033