### PR TITLE
fix(k8s): read immich config from secret

### DIFF
--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -103,6 +103,7 @@ spec:
           projected:
             sources:
               - secret:
-                  name: immich-config
-              - configMap:
-                  name: immich-immich-config
+                  name: immich-immich-config-secret
+                  items:
+                    - key: immich-config.yaml
+                      path: immich-config.yaml

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -88,3 +88,4 @@ spec:
 ```
 
 This Secret is mounted by the StatefulSet at `/config/immich-config.yaml`, allowing the application to start without additional environment variables.
+The machine-learning deployment mounts the same Secret so both components read identical settings.


### PR DESCRIPTION
## Summary
- ensure immich-machine-learning reads the shared configuration secret
- document how both deployments mount the same secret

## Testing
- `kustomize build --enable-helm k8s/applications/media/immich/immich-ml`
- `kustomize build --enable-helm k8s/applications/media/immich`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684ffd2cc76c8322adf33b20b7e2223f