### PR TITLE
fix(argocd): include EndpointSlice in resource list

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -7,6 +7,11 @@ configs:
     url: https://argocd.pc-tips.se
     kustomize.buildOptions: '--enable-helm'
     accounts.kubechecks: apiKey
+    resource.inclusions: |
+      - apiGroups:
+          - discovery.k8s.io
+        kinds:
+          - EndpointSlice
     # OIDC Configuration
     dex.config: |
       connectors:


### PR DESCRIPTION
## Summary
- allow ArgoCD to manage EndpointSlice resources by including them in the controller config

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`

------
https://chatgpt.com/codex/tasks/task_e_68519f3361948322b19ef7d4dcafb1b4