### PR TITLE
fix(argocd): use label tracking

### DIFF
--- a/k8s/infrastructure/controllers/argocd/values.yaml
+++ b/k8s/infrastructure/controllers/argocd/values.yaml
@@ -2,7 +2,7 @@
 configs:
   cm:
     create: true
-    application.resourceTrackingMethod: annotation+label
+    application.resourceTrackingMethod: label
     admin.enabled: false
     url: https://argocd.pc-tips.se
     kustomize.buildOptions: '--enable-helm'

--- a/website/docs/infrastructure/controllers/argocd-gitops.md
+++ b/website/docs/infrastructure/controllers/argocd-gitops.md
@@ -210,6 +210,22 @@ kubectl -n argocd logs -l app.kubernetes.io/name=argocd-application-controller
 argocd app resources cilium
 ```
 
+## Resource Tracking
+
+Argo CD identifies resources by the labels and annotations it adds during
+deployment. Two modes exist:
+
+- **label** — Only the `app.kubernetes.io/instance` label is required. This is
+  the simpler option and works well for most clusters.
+- **annotation+label** — Adds the label and the
+  `argocd.argoproj.io/tracking-id` annotation. Both must be present for Argo CD
+  to manage the object.
+
+If you switch from `label` to `annotation+label`, existing resources that only
+have the label will be ignored because the annotation is missing. Server-side
+apply cannot fix this, as it happens after resource discovery. Changing back to
+`label` brings those resources under management again.
+
 ## Best Practices
 
 1. **Wave Management**


### PR DESCRIPTION
## Summary
- switch Argo CD resource tracking to label mode
- document how resource tracking modes work

## Testing
- `kustomize build --enable-helm k8s/infrastructure/controllers/argocd`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68527d695c548322b9728672ceb37c4c