### PR TITLE
feat(storage): set longhorn reclaim policy to retain

### DIFF
--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -67,7 +67,7 @@ defaultSettings:
 persistence:
   defaultClass: true
   defaultClassReplicaCount: 3
-  reclaimPolicy: Delete
+  reclaimPolicy: Retain
   defaultFsType: ext4
   snapshotMaxCount: 60
   defaultDataLocality: best-effort

--- a/website/docs/infrastructure/controllers-overview.md
+++ b/website/docs/infrastructure/controllers-overview.md
@@ -47,6 +47,7 @@ This document outlines the core infrastructure controllers deployed in my Kubern
 - Distributed block storage
 - Volume replication
 - Backup capabilities
+- Default reclaim policy set to `Retain`
 - Storage overprovisioning
 
 ### Kubechecks


### PR DESCRIPTION
## Summary
- avoid deleting data by default by setting Longhorn's reclaim policy to `Retain`
- note the new default in the controllers overview

## Testing
- `kustomize build --enable-helm k8s/infrastructure/storage/longhorn`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685273fb9198832292aa5943808c529c