### PR TITLE
fix(k8s): remove namespace allowlist annotation

### DIFF
--- a/k8s/applications/project.yaml
+++ b/k8s/applications/project.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    argocd.argoproj.io/namespace-resource-allowlist: '[{"group": "", "kind": "Namespace"}]'
 spec:
   description: Applications components managed through GitOps (all resources allowed)
   sourceRepos:

--- a/k8s/infrastructure/project.yaml
+++ b/k8s/infrastructure/project.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    # Allow namespace creation for all kinds of namespaces
-    argocd.argoproj.io/namespace-resource-allowlist: '[{"group": "", "kind": "Namespace"}]'
 spec:
   description: Infrastructure components managed through GitOps (all resources allowed)
   sourceRepos:

--- a/website/docs/infrastructure/controllers/argocd-gitops.md
+++ b/website/docs/infrastructure/controllers/argocd-gitops.md
@@ -197,6 +197,9 @@ argocd app get cilium
    - Check resource limits
    - Verify dependencies
 
+4. **Empty Applications**
+   - Remove leftover `argocd.argoproj.io/namespace-resource-allowlist` annotations on AppProjects
+
 ### Debug Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- remove the namespace allowlist annotation from ArgoCD projects
- add troubleshooting note about namespace allowlist in docs

## Testing
- `kustomize build --enable-helm k8s/infrastructure`
- `kustomize build --enable-helm k8s/applications`
- `npm install && npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6852afe2055c832286d188ea4062ac6d