### PR TITLE
fix(k8s): raise immich pod resources

### DIFF
--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -54,10 +54,10 @@ spec:
           resources:
             requests:
               cpu: '200m'
-              memory: '512Mi'
+              memory: '1Gi'
             limits:
               cpu: '1000m'
-              memory: '2Gi'
+              memory: '4Gi'
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/k8s/applications/media/immich/immich-server/statefulset.yaml
+++ b/k8s/applications/media/immich/immich-server/statefulset.yaml
@@ -61,11 +61,11 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              cpu: '250m'
-              memory: '256Mi'
+              cpu: '500m'
+              memory: '512Mi'
             limits:
-              cpu: '1000m'
-              memory: '1Gi'
+              cpu: '2000m'
+              memory: '2Gi'
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -89,3 +89,12 @@ spec:
 
 This Secret is mounted by the StatefulSet at `/config/immich-config.yaml`, allowing the application to start without additional environment variables.
 The machine-learning deployment mounts the same Secret so both components read identical settings.
+
+### Resource Requests
+
+Both pods need enough memory to process photos without crashing. A good starting point is:
+
+| Component | CPU Request | Memory Request | CPU Limit | Memory Limit |
+| --------- | ----------- | -------------- | --------- | ------------ |
+| immich-server | 500m | 512Mi | 2000m | 2Gi |
+| immich-machine-learning | 200m | 1Gi | 1000m | 4Gi |


### PR DESCRIPTION
## Summary
- allocate more CPU and memory for the immich-server StatefulSet
- bump memory for the immich-machine-learning Deployment
- document recommended resource requests

## Testing
- `kustomize build --enable-helm k8s/applications/media/immich/immich-ml`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/media/immich`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6852cd076e5c8322bb3b2fba6fdfa0ed