### PR TITLE
refactor(tofu): remove unused talos variables

### DIFF
--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -74,20 +74,6 @@ variable "coredns" {
 #     vm_id     = number
 #   })
 # }
-variable "inline_manifests" {
-  description = "Inline manifests to apply after bootstrap with dependencies"
-  type = list(object({
-    name         = string
-    content      = string
-    dependencies = optional(list(string), [])
-  }))
-  default = []
-}
 
-variable "download_node" {
-  description = "Proxmox node to use for downloading Talos images"
-  type        = string
-  default     = "host3" # For backward compatibility
-}
 
 


### PR DESCRIPTION
## Summary
- drop `download_node` and `inline_manifests` from talos variables
- run `tofu fmt`

## Testing
- `tofu fmt -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6852deed23748322868e106cd5f13a64