### PR TITLE
feat(tofu): use defaults for node configs

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -1,86 +1,72 @@
 locals {
-  # Define base node configurations
+  # Common configuration for worker nodes
+  worker_defaults = {
+    host_node     = "host3"
+    machine_type  = "worker"
+    cpu           = 8
+    ram_dedicated = 10240
+    igpu          = false
+    disks = {
+      longhorn = {
+        device     = "/dev/sdb"
+        size       = "180G"
+        type       = "scsi"
+        mountpoint = "/var/lib/longhorn"
+      }
+    }
+  }
+
+  # Common configuration for control plane nodes
+  controlplane_defaults = {
+    host_node     = "host3"
+    machine_type  = "controlplane"
+    cpu           = 6
+    ram_dedicated = 6144
+  }
+
+  node_defaults = {
+    worker       = local.worker_defaults
+    controlplane = local.controlplane_defaults
+  }
+
+  # Define per-node settings
   nodes_config = {
     "ctrl-00" = {
-      host_node     = "host3"
       machine_type  = "controlplane"
       ip            = "10.25.150.11"
       mac_address   = "bc:24:11:e6:ba:07"
       vm_id         = 8101
-      cpu           = 6
       ram_dedicated = 7168
     }
     "ctrl-01" = {
-      host_node     = "host3"
-      machine_type  = "controlplane"
-      ip            = "10.25.150.12"
-      mac_address   = "bc:24:11:44:94:5c"
-      vm_id         = 8102
-      cpu           = 6
-      ram_dedicated = 6144
+      machine_type = "controlplane"
+      ip           = "10.25.150.12"
+      mac_address  = "bc:24:11:44:94:5c"
+      vm_id        = 8102
     }
     "ctrl-02" = {
-      host_node     = "host3"
-      machine_type  = "controlplane"
-      ip            = "10.25.150.13"
-      mac_address   = "bc:24:11:1e:1d:2f"
-      vm_id         = 8103
-      cpu           = 6
-      ram_dedicated = 6144
+      machine_type = "controlplane"
+      ip           = "10.25.150.13"
+      mac_address  = "bc:24:11:1e:1d:2f"
+      vm_id        = 8103
     }
     "work-00" = {
-      host_node     = "host3"
-      machine_type  = "worker"
-      ip            = "10.25.150.21"
-      mac_address   = "bc:24:11:64:5b:cb"
-      vm_id         = 8201
-      cpu           = 8
-      ram_dedicated = 10240
-      igpu          = false
-      disks = {
-        longhorn = {
-          device     = "/dev/sdb"
-          size       = "180G"
-          type       = "scsi"
-          mountpoint = "/var/lib/longhorn"
-        }
-      }
+      machine_type = "worker"
+      ip           = "10.25.150.21"
+      mac_address  = "bc:24:11:64:5b:cb"
+      vm_id        = 8201
     }
     "work-01" = {
-      host_node     = "host3"
-      machine_type  = "worker"
-      ip            = "10.25.150.22"
-      mac_address   = "bc:24:11:c9:22:c3"
-      vm_id         = 8202
-      cpu           = 8
-      ram_dedicated = 10240
-      igpu          = false
-      disks = {
-        longhorn = {
-          device     = "/dev/sdb"
-          size       = "180G"
-          type       = "scsi"
-          mountpoint = "/var/lib/longhorn"
-        }
-      }
+      machine_type = "worker"
+      ip           = "10.25.150.22"
+      mac_address  = "bc:24:11:c9:22:c3"
+      vm_id        = 8202
     }
     "work-02" = {
-      host_node     = "host3"
-      machine_type  = "worker"
-      ip            = "10.25.150.23"
-      mac_address   = "bc:24:11:6f:20:03"
-      vm_id         = 8203
-      cpu           = 8
-      ram_dedicated = 10240
-      igpu          = false
-      disks = {
-        longhorn = {
-          device     = "/dev/sdb"
-          size       = "180G"
-          type       = "scsi"
-          mountpoint = "/var/lib/longhorn"
-        }
-      }
+      machine_type = "worker"
+      ip           = "10.25.150.23"
+      mac_address  = "bc:24:11:6f:20:03"
+      vm_id        = 8203
     }
   }
 
@@ -106,9 +92,14 @@ locals {
 
   # Prepare nodes configuration with upgrade flags
   nodes_with_upgrade = {
-    for name, config in local.nodes_config : name => merge(config, {
-      update = var.upgrade_control.enabled && name == local.current_upgrade_node
-    })
+    for name, config in local.nodes_config :
+    name => merge(
+      local.node_defaults[config.machine_type],
+      config,
+      {
+        update = var.upgrade_control.enabled && name == local.current_upgrade_node
+      }
+    )
   }
 }
 

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -94,7 +94,10 @@ locals {
   nodes_with_upgrade = {
     for name, config in local.nodes_config :
     name => merge(
-      lookup(local.node_defaults, config.machine_type, {}),
+      try(
+        local.node_defaults[config.machine_type],
+        error("machine_type '${config.machine_type}' has no defaults")
+      ),
       config,
       {
         update = var.upgrade_control.enabled && name == local.current_upgrade_node

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Common configuration for worker nodes
-  worker_defaults = {
+  defaults_worker = {
     host_node     = "host3"
     machine_type  = "worker"
     cpu           = 8
@@ -17,7 +17,7 @@ locals {
   }
 
   # Common configuration for control plane nodes
-  controlplane_defaults = {
+  defaults_controlplane = {
     host_node     = "host3"
     machine_type  = "controlplane"
     cpu           = 6
@@ -25,8 +25,8 @@ locals {
   }
 
   node_defaults = {
-    worker       = local.worker_defaults
-    controlplane = local.controlplane_defaults
+    worker       = local.defaults_worker
+    controlplane = local.defaults_controlplane
   }
 
   # Define per-node settings
@@ -94,7 +94,7 @@ locals {
   nodes_with_upgrade = {
     for name, config in local.nodes_config :
     name => merge(
-      local.node_defaults[config.machine_type],
+      lookup(local.node_defaults, config.machine_type, {}),
       config,
       {
         update = var.upgrade_control.enabled && name == local.current_upgrade_node

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -87,7 +87,7 @@ Talos is my node OS because it offers:
 
 ### Node Specs
 
-Node definitions now pull from two local maps—`worker_defaults` and `controlplane_defaults`. Each node only declares what differs from these defaults.
+- Node definitions now pull from two local maps—`defaults_worker` and `defaults_controlplane`. Each node only declares what differs from these defaults.
 
 ```hcl
 module "talos" {
@@ -104,7 +104,7 @@ module "talos" {
       ip           = "10.0.0.2"
       mac_address  = "00:00:00:00:00:02"
       vm_id        = 8201
-      # inherits disk and resource values from worker_defaults
+      # inherits disk and resource values from defaults_worker
     }
   }
 }

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -87,34 +87,30 @@ Talos is my node OS because it offers:
 
 ### Node Specs
 
-Define nodes in `/tofu/main.tf` with:
+Node definitions now pull from two local maps—`worker_defaults` and `controlplane_defaults`. Each node only declares what differs from these defaults.
 
 ```hcl
 module "talos" {
   nodes = {
-    "node1" = {
-      host_node    = "proxmox1"
-      machine_type = "controlplane"
-      ip           = "10.0.0.1" # Example IP
-      cpu          = 4
-      ram_dedicated = 8192
-      disks = {
-        # Example: a primary disk for the OS (often handled by the image cloning)
-        # and an additional disk for Longhorn.
-        # The exact structure depends on your module's variables.tf.
-        # This example assumes a structure like the one found in the repository:
-        longhorn = { # Key for the disk, e.g., 'longhorn' or 'data'
-          device     = "/dev/sdb" # Or another available device
-          size       = "180G"
-          type       = "scsi"     # Or 'virtio', 'sata'
-          mountpoint = "/var/lib/longhorn" # If applicable for Talos config
-        }
-        # os_disk = { ... } # If explicitly defining the OS disk
-      }
+    "ctrl-00" = {
+      machine_type  = "controlplane"
+      ip            = "10.0.0.1"
+      mac_address   = "00:00:00:00:00:01"
+      vm_id         = 8101
+      ram_dedicated = 7168 # overrides the control plane default
+    }
+    "work-00" = {
+      machine_type = "worker"
+      ip           = "10.0.0.2"
+      mac_address  = "00:00:00:00:00:02"
+      vm_id        = 8201
+      # inherits disk and resource values from worker_defaults
     }
   }
 }
 ```
+
+The defaults keep shared settings like CPU, RAM, and disk layout in one place.
 
 ### Custom Images
 

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -111,6 +111,7 @@ module "talos" {
 ```
 
 The defaults keep shared settings like CPU, RAM, and disk layout in one place.
+If a node's `machine_type` doesn't match a key in the defaults table, the plan fails with an explicit error.
 
 ### Custom Images
 


### PR DESCRIPTION
## Summary
- add `worker_defaults` and `controlplane_defaults`
- merge these defaults when creating `nodes_with_upgrade`
- update docs with an example of the new defaults

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm install`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685303d16fd4832298a9913b432ed404