### PR TITLE
feat(tofu): add disk unit numbers

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -8,10 +8,11 @@ locals {
     igpu          = false
     disks = {
       longhorn = {
-        device     = "/dev/sdb"
-        size       = "180G"
-        type       = "scsi"
-        mountpoint = "/var/lib/longhorn"
+        device      = "/dev/sdb"
+        size        = "180G"
+        type        = "scsi"
+        mountpoint  = "/var/lib/longhorn"
+        unit_number = 1
       }
     }
   }

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -39,10 +39,11 @@ variable "nodes" {
     update        = optional(bool, false)
     igpu          = optional(bool, false)
     disks = optional(map(object({
-      device     = string
-      size       = string
-      type       = string
-      mountpoint = string
+      device      = string
+      size        = string
+      type        = string
+      mountpoint  = string
+      unit_number = number
     })), {})
   }))
 }

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -51,7 +51,7 @@ resource "proxmox_virtual_environment_vm" "this" {
     for_each = each.value.disks
     content {
       datastore_id = each.value.datastore_id
-      interface    = "${disk.value.type}${disk.key == "longhorn" ? "1" : index(keys(each.value.disks), disk.key) + 1}"
+      interface    = "${disk.value.type}${disk.value.unit_number}"
       iothread     = true
       cache        = "writethrough"
       discard      = "on"

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -113,6 +113,23 @@ module "talos" {
 The defaults keep shared settings like CPU, RAM, and disk layout in one place.
 If a node's `machine_type` doesn't match a key in the defaults table, the plan fails with an explicit error.
 
+### Disk Layout
+
+Additional disks are defined per node in a `disks` map. Each disk now requires a
+`unit_number` which determines the Proxmox interface, for example `scsi1`:
+
+```hcl
+disks = {
+  longhorn = {
+    device      = "/dev/sdb"
+    size        = "180G"
+    type        = "scsi"
+    mountpoint  = "/var/lib/longhorn"
+    unit_number = 1
+  }
+}
+```
+
 ### Custom Images
 
 - Built via Talos Image Factory


### PR DESCRIPTION
## Summary
- require `unit_number` for each disk in nodes variable
- add `unit_number` in default worker disk
- map Proxmox disk interface directly to `unit_number`
- document disk layout example with `unit_number`

## Testing
- `tofu validate`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853105530f0832280858fdf8ef55197