### PR TITLE
feat(tofu): enforce control plane node validation

### DIFF
--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -46,6 +46,11 @@ variable "nodes" {
       unit_number = number
     })), {})
   }))
+
+  validation {
+    condition     = length([for n in values(var.nodes) : n if n.machine_type == "controlplane"]) > 0
+    error_message = "You must define at least one node with machine_type \"controlplane\"."
+  }
 }
 
 variable "cilium" {

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -113,6 +113,8 @@ module "talos" {
 The defaults keep shared settings like CPU, RAM, and disk layout in one place.
 If a node's `machine_type` doesn't match a key in the defaults table, the plan fails with an explicit error.
 
+> Note: At least one node must have `machine_type` set to `controlplane`. OpenTofu validates this during `tofu plan`.
+
 ### Disk Layout
 
 Additional disks are defined per node in a `disks` map. Each disk now requires a


### PR DESCRIPTION
## Summary
- require at least one control plane node in `nodes` variable
- document the new validation in the provisioning guide

## Testing
- `npm install`
- `npm run typecheck`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6853130426b48322aaa919a06b79a4e3