### PR TITLE
refactor(talos): deduplicate image downloads

### DIFF
--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -137,6 +137,7 @@ disks = {
   - QEMU guest agent
   - iSCSI tools
 - Automatically downloaded to Proxmox
+- Downloads are deduplicated using a map keyed by host node and image version, so each Proxmox node pulls a version only once
 
 ## Machine Configuration
 


### PR DESCRIPTION
## Summary
- dedupe Proxmox image downloads with a host/version map
- clarify deduplication behavior in docs

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853130e15b88322b8e53a36cf3524a0