### PR TITLE
feat(tofu): add node validation

### DIFF
--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -51,6 +51,23 @@ variable "nodes" {
     condition     = length([for n in values(var.nodes) : n if n.machine_type == "controlplane"]) > 0
     error_message = "You must define at least one node with machine_type \"controlplane\"."
   }
+
+  validation {
+    condition     = length(distinct([for n in values(var.nodes) : n.ip])) == length(var.nodes)
+    error_message = "Node IP addresses must be unique."
+  }
+
+  validation {
+    condition     = length(distinct([for n in values(var.nodes) : n.vm_id])) == length(var.nodes)
+    error_message = "Node VM IDs must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for n in values(var.nodes) : can(regex("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$", n.mac_address))
+    ])
+    error_message = "MAC addresses must use the format 00:11:22:33:44:55."
+  }
 }
 
 variable "cilium" {

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -115,6 +115,12 @@ If a node's `machine_type` doesn't match a key in the defaults table, the plan f
 
 > Note: At least one node must have `machine_type` set to `controlplane`. OpenTofu validates this during `tofu plan`.
 
+OpenTofu also enforces a few sanity checks:
+
+- IP addresses must be unique across nodes.
+- VM IDs must be unique.
+- `mac_address` values must follow the `00:11:22:33:44:55` format.
+
 ### Disk Layout
 
 Additional disks are defined per node in a `disks` map. Each disk now requires a


### PR DESCRIPTION
## Summary
- ensure node IP addresses, VM IDs, and MAC addresses are validated
- mention stricter validation in provisioning docs

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68533791324c8322b54d7feb287ef5b0