### PR TITLE
refactor(tofu): expose node defaults as variables

### DIFF
--- a/tofu/defaults.tf
+++ b/tofu/defaults.tf
@@ -1,0 +1,49 @@
+variable "defaults_worker" {
+  description = "Default configuration for worker nodes"
+  type = object({
+    host_node     = string
+    machine_type  = string
+    cpu           = number
+    ram_dedicated = number
+    igpu          = bool
+    disks = map(object({
+      device      = string
+      size        = string
+      type        = string
+      mountpoint  = string
+      unit_number = number
+    }))
+  })
+  default = {
+    host_node     = "host3"
+    machine_type  = "worker"
+    cpu           = 8
+    ram_dedicated = 10240
+    igpu          = false
+    disks = {
+      longhorn = {
+        device      = "/dev/sdb"
+        size        = "180G"
+        type        = "scsi"
+        mountpoint  = "/var/lib/longhorn"
+        unit_number = 1
+      }
+    }
+  }
+}
+
+variable "defaults_controlplane" {
+  description = "Default configuration for control plane nodes"
+  type = object({
+    host_node     = string
+    machine_type  = string
+    cpu           = number
+    ram_dedicated = number
+  })
+  default = {
+    host_node     = "host3"
+    machine_type  = "controlplane"
+    cpu           = 6
+    ram_dedicated = 6144
+  }
+}

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -1,33 +1,7 @@
 locals {
-  # Common configuration for worker nodes
-  defaults_worker = {
-    host_node     = "host3"
-    machine_type  = "worker"
-    cpu           = 8
-    ram_dedicated = 10240
-    igpu          = false
-    disks = {
-      longhorn = {
-        device      = "/dev/sdb"
-        size        = "180G"
-        type        = "scsi"
-        mountpoint  = "/var/lib/longhorn"
-        unit_number = 1
-      }
-    }
-  }
-
-  # Common configuration for control plane nodes
-  defaults_controlplane = {
-    host_node     = "host3"
-    machine_type  = "controlplane"
-    cpu           = 6
-    ram_dedicated = 6144
-  }
-
   node_defaults = {
-    worker       = local.defaults_worker
-    controlplane = local.defaults_controlplane
+    worker       = var.defaults_worker
+    controlplane = var.defaults_controlplane
   }
 
   # Define per-node settings

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -87,7 +87,7 @@ Talos is my node OS because it offers:
 
 ### Node Specs
 
-- Node definitions now pull from two local maps—`defaults_worker` and `defaults_controlplane`. Each node only declares what differs from these defaults.
+- Node definitions now pull from two variables—`defaults_worker` and `defaults_controlplane`. Each node only declares what differs from these defaults.
 
 ```hcl
 module "talos" {


### PR DESCRIPTION
## Summary
- support configuring defaults via variables
- document the new defaults behaviour

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685337818b008322ab2bf691c0a5a600