### PR TITLE
feat(tofu): centralize cluster domain

### DIFF
--- a/tofu/locals.tf
+++ b/tofu/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cluster_domain = "kube.pc-tips.se"
+}

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -125,9 +125,11 @@ module "talos" {
     install = file("${path.module}/talos/inline-manifests/coredns-install.yaml")
   }
 
+  cluster_domain = local.cluster_domain
+
   cluster = {
     name               = "talos"
-    endpoint           = "api.kube.pc-tips.se"
+    endpoint           = "api.${local.cluster_domain}"
     gateway            = "10.25.150.1"  # Network gateway
     vip                = "10.25.150.10" # Control plane VIP
     talos_version      = "v1.10.3"

--- a/tofu/talos/config.tf
+++ b/tofu/talos/config.tf
@@ -24,19 +24,21 @@ data "talos_machine_configuration" "this" {
       cluster_name    = var.cluster.proxmox_cluster
       node_ip         = each.value.ip
       cluster         = var.cluster
+      cluster_domain  = var.cluster_domain
       cilium_values   = var.cilium.values
       cilium_install  = var.cilium.install
       coredns_install = var.coredns.install
     })
     ] : [
     templatefile("${path.module}/machine-config/worker.yaml.tftpl", {
-      hostname     = each.key
-      node_name    = each.value.host_node
-      cluster_name = var.cluster.proxmox_cluster
-      node_ip      = each.value.ip
-      cluster      = var.cluster
-      disks        = each.value.disks
-      igpu         = each.value.igpu
+      hostname       = each.key
+      node_name      = each.value.host_node
+      cluster_name   = var.cluster.proxmox_cluster
+      node_ip        = each.value.ip
+      cluster        = var.cluster
+      cluster_domain = var.cluster_domain
+      disks          = each.value.disks
+      igpu           = each.value.igpu
     })
   ]
 }

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -41,17 +41,17 @@ cluster:
   coreDNS:
     disabled: true
   allowSchedulingOnControlPlanes: false
-  clusterName: kube.pc-tips.se
+  clusterName: ${cluster_domain}
   apiServer:
     # extraArgs:
-    #   oidc-issuer-url: https://authelia.kube.pc-tips.se
+    #   oidc-issuer-url: https://authelia.${cluster_domain}
     #   oidc-client-id: kubectl
     #   oidc-username-claim: preferred_username
     #   oidc-username-prefix: 'authelia:'
     #   oidc-groups-claim: groups
     #   oidc-groups-prefix: 'authelia:'
   network:
-    dnsDomain: kube.pc-tips.se
+    dnsDomain: ${cluster_domain}
     cni:
       name: none
   proxy:

--- a/tofu/talos/machine-config/worker.yaml.tftpl
+++ b/tofu/talos/machine-config/worker.yaml.tftpl
@@ -52,6 +52,6 @@ machine:
 %{ endif }
 
 cluster:
-  clusterName: kube.pc-tips.se
+  clusterName: ${cluster_domain}
   network:
-    dnsDomain: kube.pc-tips.se
+    dnsDomain: ${cluster_domain}

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -24,6 +24,11 @@ variable "cluster" {
   })
 }
 
+variable "cluster_domain" {
+  description = "Internal cluster domain"
+  type        = string
+}
+
 
 variable "nodes" {
   description = "Configuration for cluster nodes"

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -76,7 +76,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   initialization {
     datastore_id = each.value.datastore_id
     dns {
-      domain  = "kube.pc-tips.se"
+      domain  = var.cluster_domain
       servers = ["10.25.150.1"]
     }
     ip_config {

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -49,7 +49,7 @@ spec:
 
 ### 2. DNS (CoreDNS)
 
-- Internal domain: kube.your.domain.tld
+- Internal domain: `kube.pc-tips.se` (set in `tofu/locals.tf`)
 - External forwarding to 10.25.150.1, 1.1.1.1, 8.8.8.8
 - Caching enabled
 - Runs as a non-root user (UID/GID 1000) with NET_BIND_SERVICE capability

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -233,7 +233,9 @@ I embed essential services in the Talos config:
 
 ### Configuration
 
-Create `terraform.tfvars` with your environment settings:
+Create `terraform.tfvars` with your environment settings. The internal
+cluster domain defaults to `kube.pc-tips.se` and can be changed in
+`tofu/locals.tf`:
 
 ```hcl
 proxmox = {


### PR DESCRIPTION
## Summary
- add shared `cluster_domain` local
- use it for talos endpoint, machine configs and VM DNS
- document where to change the cluster domain

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685337996c108322a718fee6092ae4a3