### PR TITLE
refactor(tofu): centralize provider version constraints

### DIFF
--- a/tofu/talos/providers.tf
+++ b/tofu/talos/providers.tf
@@ -1,12 +1,10 @@
 terraform {
   required_providers {
     proxmox = {
-      source  = "bpg/proxmox"
-      version = ">=0.66.1"
+      source = "bpg/proxmox"
     }
     talos = {
-      source  = "siderolabs/talos"
-      version = ">=0.6.0"
+      source = "siderolabs/talos"
     }
   }
 }

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -64,6 +64,9 @@ Worker Nodes:
     └── inline-manifests/   # Core component YAMLs
 ```
 
+All provider version constraints live in this root `providers.tf` file. The
+subdirectory modules inherit those settings so updates happen in one place.
+
 # Core Components
 
 ## Proxmox Provider


### PR DESCRIPTION
## Summary
- keep provider versioning in `tofu/providers.tf`
- reference the single source in provisioning docs

## Testing
- `npm install`
- `npm run typecheck`
- `tofu -chdir=tofu init`
- `tofu -chdir=tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6853377671a88322958e043c3e449fff