### PR TITLE
docs(tofu): remove upgrade helper from diagram

### DIFF
--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -53,15 +53,14 @@ Worker Nodes:
 ├── variables.tf      # Input variables
 ├── output.tf         # Generated outputs (kubeconfig, etc.)
 ├── providers.tf      # Provider configs (Proxmox, Talos)
-├── upgrade-k8s.sh    # Kubernetes upgrade helper
 ├── terraform.tfvars  # Variable definitions
+├── talos_image.auto.tfvars  # Talos image settings
 └── talos/            # Talos cluster module
     ├── config.tf     # Machine configs and bootstrap
     ├── image.tf      # OS image management
     ├── virtual-machines.tf  # Proxmox VM definitions
-    └── manifests/    # Kubernetes bootstrap manifests
-    ├── machine-config/     # Config templates
-    └── inline-manifests/   # Core component YAMLs
+    ├── machine-config/      # Config templates
+    └── inline-manifests/    # Core component YAMLs
 ```
 
 # Core Components


### PR DESCRIPTION
## Summary
- update the OpenTofu provisioning docs to remove the unused `upgrade-k8s.sh` mention
- keep the project structure diagram in sync with repo layout

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853374dce008322bc8ebf0eb94c694f