### PR TITLE
refactor(talos): split config into dedicated files

### DIFF
--- a/tofu/talos/config-client.tf
+++ b/tofu/talos/config-client.tf
@@ -1,0 +1,7 @@
+data "talos_client_configuration" "this" {
+  cluster_name         = var.cluster.name
+  client_configuration = talos_machine_secrets.this.client_configuration
+  nodes                = [for k, v in var.nodes : v.ip]
+  endpoints            = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+}
+

--- a/tofu/talos/config-cluster.tf
+++ b/tofu/talos/config-cluster.tf
@@ -1,0 +1,35 @@
+resource "talos_machine_bootstrap" "this" {
+  depends_on = [
+    talos_machine_configuration_apply.this
+  ]
+  # Bootstrap with the first node. VIP not yet available at this stage, so cant use var.cluster.endpoint as it may be set to VIP
+  # ref - https://www.talos.dev/v1.9/talos-guides/network/vip/#caveats
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  client_configuration = talos_machine_secrets.this.client_configuration
+}
+
+resource "talos_cluster_kubeconfig" "this" {
+  depends_on = [
+    talos_machine_bootstrap.this
+  ]
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  endpoint             = var.cluster.endpoint
+  client_configuration = talos_machine_secrets.this.client_configuration
+  timeouts = {
+    read = "1m"
+  }
+}
+
+data "talos_cluster_health" "this" {
+  depends_on = [
+    talos_cluster_kubeconfig.this,
+    talos_machine_configuration_apply.this
+  ]
+  client_configuration = data.talos_client_configuration.this.client_configuration
+  control_plane_nodes  = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+  worker_nodes         = [for k, v in var.nodes : v.ip if v.machine_type == "worker"]
+  endpoints            = data.talos_client_configuration.this.endpoints
+  timeouts = {
+    read = "3m"
+  }
+}

--- a/tofu/talos/config-machine.tf
+++ b/tofu/talos/config-machine.tf
@@ -1,14 +1,3 @@
-resource "talos_machine_secrets" "this" {
-  talos_version = var.cluster.talos_version
-}
-
-data "talos_client_configuration" "this" {
-  cluster_name         = var.cluster.name
-  client_configuration = talos_machine_secrets.this.client_configuration
-  nodes                = [for k, v in var.nodes : v.ip]
-  endpoints            = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
-}
-
 data "talos_machine_configuration" "this" {
   for_each           = var.nodes
   cluster_name       = var.cluster.name
@@ -57,38 +46,3 @@ resource "talos_machine_configuration_apply" "this" {
   }
 }
 
-resource "talos_machine_bootstrap" "this" {
-  depends_on = [
-    talos_machine_configuration_apply.this
-  ]
-  # Bootstrap with the first node. VIP not yet available at this stage, so cant use var.cluster.endpoint as it may be set to VIP
-  # ref - https://www.talos.dev/v1.9/talos-guides/network/vip/#caveats
-  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
-  client_configuration = talos_machine_secrets.this.client_configuration
-}
-
-resource "talos_cluster_kubeconfig" "this" {
-  depends_on = [
-    talos_machine_bootstrap.this
-  ]
-  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
-  endpoint             = var.cluster.endpoint
-  client_configuration = talos_machine_secrets.this.client_configuration
-  timeouts = {
-    read = "1m"
-  }
-}
-
-data "talos_cluster_health" "this" {
-  depends_on = [
-    talos_cluster_kubeconfig.this,
-    talos_machine_configuration_apply.this
-  ]
-  client_configuration = data.talos_client_configuration.this.client_configuration
-  control_plane_nodes  = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
-  worker_nodes         = [for k, v in var.nodes : v.ip if v.machine_type == "worker"]
-  endpoints            = data.talos_client_configuration.this.endpoints
-  timeouts = {
-    read = "3m"
-  }
-}

--- a/tofu/talos/config-secrets.tf
+++ b/tofu/talos/config-secrets.tf
@@ -1,0 +1,4 @@
+resource "talos_machine_secrets" "this" {
+  talos_version = var.cluster.talos_version
+}
+

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -56,12 +56,15 @@ Worker Nodes:
 ├── upgrade-k8s.sh    # Kubernetes upgrade helper
 ├── terraform.tfvars  # Variable definitions
 └── talos/            # Talos cluster module
-    ├── config.tf     # Machine configs and bootstrap
-    ├── image.tf      # OS image management
+    ├── config-secrets.tf   # Machine secrets
+    ├── config-client.tf    # Client configuration
+    ├── config-machine.tf   # Machine configs and apply
+    ├── config-cluster.tf   # Bootstrap and health checks
+    ├── image.tf            # OS image management
     ├── virtual-machines.tf  # Proxmox VM definitions
-    └── manifests/    # Kubernetes bootstrap manifests
-    ├── machine-config/     # Config templates
-    └── inline-manifests/   # Core component YAMLs
+    └── manifests/          # Kubernetes bootstrap manifests
+        ├── machine-config/     # Config templates
+        └── inline-manifests/   # Core component YAMLs
 ```
 
 # Core Components


### PR DESCRIPTION
## Summary
- break out machine secrets, client config, machine config, and cluster config
- update OpenTofu docs to show the new layout

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68533749da38832297c1154d2591e03d