### PR TITLE
feat(tofu): validate nodes_config variable

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -30,54 +30,14 @@ locals {
     controlplane = local.defaults_controlplane
   }
 
-  # Define per-node settings
-  nodes_config = {
-    "ctrl-00" = {
-      machine_type  = "controlplane"
-      ip            = "10.25.150.11"
-      mac_address   = "bc:24:11:e6:ba:07"
-      vm_id         = 8101
-      ram_dedicated = 7168
-    }
-    "ctrl-01" = {
-      machine_type = "controlplane"
-      ip           = "10.25.150.12"
-      mac_address  = "bc:24:11:44:94:5c"
-      vm_id        = 8102
-    }
-    "ctrl-02" = {
-      machine_type = "controlplane"
-      ip           = "10.25.150.13"
-      mac_address  = "bc:24:11:1e:1d:2f"
-      vm_id        = 8103
-    }
-    "work-00" = {
-      machine_type = "worker"
-      ip           = "10.25.150.21"
-      mac_address  = "bc:24:11:64:5b:cb"
-      vm_id        = 8201
-    }
-    "work-01" = {
-      machine_type = "worker"
-      ip           = "10.25.150.22"
-      mac_address  = "bc:24:11:c9:22:c3"
-      vm_id        = 8202
-    }
-    "work-02" = {
-      machine_type = "worker"
-      ip           = "10.25.150.23"
-      mac_address  = "bc:24:11:6f:20:03"
-      vm_id        = 8203
-    }
-  }
 
   # Derive upgrade sequence from machine types
   control_plane_nodes = [
-    for name, config in local.nodes_config : name
+    for name, config in var.nodes_config : name
     if config.machine_type == "controlplane"
   ]
   worker_nodes = [
-    for name, config in local.nodes_config : name
+    for name, config in var.nodes_config : name
     if config.machine_type == "worker"
   ]
 
@@ -93,7 +53,7 @@ locals {
 
   # Prepare nodes configuration with upgrade flags
   nodes_with_upgrade = {
-    for name, config in local.nodes_config :
+    for name, config in var.nodes_config :
     name => merge(
       try(
         local.node_defaults[config.machine_type],
@@ -150,7 +110,7 @@ output "upgrade_info" {
       node     = local.current_upgrade_node
       progress = "${var.upgrade_control.index + 1}/${length(local.upgrade_sequence)}"
       valid    = local.current_upgrade_node != ""
-      ip       = try(local.nodes_config[local.current_upgrade_node].ip, null)
+      ip       = try(var.nodes_config[local.current_upgrade_node].ip, null)
     } : null
   }
   description = "Structured upgrade state information for external automation and monitoring"

--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -1,0 +1,39 @@
+nodes_config = {
+  "ctrl-00" = {
+    machine_type  = "controlplane"
+    ip            = "10.25.150.11"
+    mac_address   = "bc:24:11:e6:ba:07"
+    vm_id         = 8101
+    ram_dedicated = 7168
+  }
+  "ctrl-01" = {
+    machine_type = "controlplane"
+    ip           = "10.25.150.12"
+    mac_address  = "bc:24:11:44:94:5c"
+    vm_id        = 8102
+  }
+  "ctrl-02" = {
+    machine_type = "controlplane"
+    ip           = "10.25.150.13"
+    mac_address  = "bc:24:11:1e:1d:2f"
+    vm_id        = 8103
+  }
+  "work-00" = {
+    machine_type = "worker"
+    ip           = "10.25.150.21"
+    mac_address  = "bc:24:11:64:5b:cb"
+    vm_id        = 8201
+  }
+  "work-01" = {
+    machine_type = "worker"
+    ip           = "10.25.150.22"
+    mac_address  = "bc:24:11:c9:22:c3"
+    vm_id        = 8202
+  }
+  "work-02" = {
+    machine_type = "worker"
+    ip           = "10.25.150.23"
+    mac_address  = "bc:24:11:6f:20:03"
+    vm_id        = 8203
+  }
+}

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -40,3 +40,29 @@ variable "talos_image" {
     proxmox_datastore     = optional(string, "local")
   })
 }
+
+variable "nodes_config" {
+  description = "Configuration map for cluster nodes"
+  type = map(object({
+    machine_type  = string
+    ip            = string
+    mac_address   = string
+    vm_id         = number
+    ram_dedicated = optional(number)
+    cpu           = optional(number)
+    igpu          = optional(bool)
+    host_node     = optional(string)
+    disks = optional(map(object({
+      device      = string
+      size        = string
+      type        = string
+      mountpoint  = string
+      unit_number = optional(number)
+    })))
+  }))
+  default = {}
+  validation {
+    condition     = length(var.nodes_config) > 0
+    error_message = "nodes_config must not be empty. Ensure nodes.auto.tfvars is loaded."
+  }
+}

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -49,11 +49,12 @@ Worker Nodes:
 
 ```
 /tofu/
-├── main.tf           # Main configuration and node definitions
+├── main.tf           # Core configuration
 ├── variables.tf      # Input variables
 ├── output.tf         # Generated outputs (kubeconfig, etc.)
 ├── providers.tf      # Provider configs (Proxmox, Talos)
 ├── upgrade-k8s.sh    # Kubernetes upgrade helper
+├── nodes.auto.tfvars # Node definitions
 ├── terraform.tfvars  # Variable definitions
 └── talos/            # Talos cluster module
     ├── config.tf     # Machine configs and bootstrap
@@ -212,13 +213,17 @@ I embed essential services in the Talos config:
 
 ### Add/Remove Nodes
 
-1. Modify `nodes` in `main.tf`
+1. Modify `nodes_config` in `nodes.auto.tfvars`
 2. Run `tofu apply`
+   - OpenTofu automatically loads `nodes.auto.tfvars` when you run the command in the `tofu` directory.
+   - If you invoke `tofu` from elsewhere, pass `-var-file=nodes.auto.tfvars`.
 
 ### Change Resources
 
-1. Update node specs in `main.tf`
+1. Update node specs in `nodes.auto.tfvars`
 2. Run `tofu apply`
+   - OpenTofu automatically loads `nodes.auto.tfvars` when executed from this directory.
+   - If run from elsewhere, include `-var-file=nodes.auto.tfvars`.
 
 > Note: Resource changes may require VM restarts
 
@@ -254,7 +259,7 @@ cluster = {
   vip               = "10.25.150.10"  # Control plane VIP
 }
 
-nodes = {
+nodes_config = {
   "ctrl-00" = {
     host_node     = "host3"
     machine_type  = "controlplane"

--- a/website/docs/tofu/upgrade-talos.md
+++ b/website/docs/tofu/upgrade-talos.md
@@ -8,7 +8,8 @@ This upgrade process uses a controlled index-based approach to upgrade Talos nod
 
 ## Upgrade Sequence
 
-The upgrade sequence is automatically derived from your node configuration:
+The upgrade sequence is automatically derived from your node configuration (stored in `nodes.auto.tfvars`).
+OpenTofu loads this file automatically when you run commands from the `tofu` directory.
 
 1. **Control Plane Nodes** (upgraded first for quorum safety)
    - `ctrl-00` (index 0)


### PR DESCRIPTION
## Summary
- validate nodes_config so it's not empty and set default {}
- note that OpenTofu auto-loads nodes.auto.tfvars

## Testing
- `tofu fmt -recursive`
- `tofu validate`
- `npm install`
- `npm run typecheck` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853371b88ec832294d41493ad2fddbf