### PR TITLE
feat(tofu): move node configs to tfvars

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -4,54 +4,14 @@ locals {
     controlplane = var.defaults_controlplane
   }
 
-  # Define per-node settings
-  nodes_config = {
-    "ctrl-00" = {
-      machine_type  = "controlplane"
-      ip            = "10.25.150.11"
-      mac_address   = "bc:24:11:e6:ba:07"
-      vm_id         = 8101
-      ram_dedicated = 7168
-    }
-    "ctrl-01" = {
-      machine_type = "controlplane"
-      ip           = "10.25.150.12"
-      mac_address  = "bc:24:11:44:94:5c"
-      vm_id        = 8102
-    }
-    "ctrl-02" = {
-      machine_type = "controlplane"
-      ip           = "10.25.150.13"
-      mac_address  = "bc:24:11:1e:1d:2f"
-      vm_id        = 8103
-    }
-    "work-00" = {
-      machine_type = "worker"
-      ip           = "10.25.150.21"
-      mac_address  = "bc:24:11:64:5b:cb"
-      vm_id        = 8201
-    }
-    "work-01" = {
-      machine_type = "worker"
-      ip           = "10.25.150.22"
-      mac_address  = "bc:24:11:c9:22:c3"
-      vm_id        = 8202
-    }
-    "work-02" = {
-      machine_type = "worker"
-      ip           = "10.25.150.23"
-      mac_address  = "bc:24:11:6f:20:03"
-      vm_id        = 8203
-    }
-  }
 
   # Derive upgrade sequence from machine types
   control_plane_nodes = [
-    for name, config in local.nodes_config : name
+    for name, config in var.nodes_config : name
     if config.machine_type == "controlplane"
   ]
   worker_nodes = [
-    for name, config in local.nodes_config : name
+    for name, config in var.nodes_config : name
     if config.machine_type == "worker"
   ]
 
@@ -67,7 +27,7 @@ locals {
 
   # Prepare nodes configuration with upgrade flags
   nodes_with_upgrade = {
-    for name, config in local.nodes_config :
+    for name, config in var.nodes_config :
     name => merge(
       try(
         local.node_defaults[config.machine_type],
@@ -126,7 +86,7 @@ output "upgrade_info" {
       node     = local.current_upgrade_node
       progress = "${var.upgrade_control.index + 1}/${length(local.upgrade_sequence)}"
       valid    = local.current_upgrade_node != ""
-      ip       = try(local.nodes_config[local.current_upgrade_node].ip, null)
+      ip       = try(var.nodes_config[local.current_upgrade_node].ip, null)
     } : null
   }
   description = "Structured upgrade state information for external automation and monitoring"

--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -1,0 +1,39 @@
+nodes_config = {
+  "ctrl-00" = {
+    machine_type  = "controlplane"
+    ip            = "10.25.150.11"
+    mac_address   = "bc:24:11:e6:ba:07"
+    vm_id         = 8101
+    ram_dedicated = 7168
+  }
+  "ctrl-01" = {
+    machine_type = "controlplane"
+    ip           = "10.25.150.12"
+    mac_address  = "bc:24:11:44:94:5c"
+    vm_id        = 8102
+  }
+  "ctrl-02" = {
+    machine_type = "controlplane"
+    ip           = "10.25.150.13"
+    mac_address  = "bc:24:11:1e:1d:2f"
+    vm_id        = 8103
+  }
+  "work-00" = {
+    machine_type = "worker"
+    ip           = "10.25.150.21"
+    mac_address  = "bc:24:11:64:5b:cb"
+    vm_id        = 8201
+  }
+  "work-01" = {
+    machine_type = "worker"
+    ip           = "10.25.150.22"
+    mac_address  = "bc:24:11:c9:22:c3"
+    vm_id        = 8202
+  }
+  "work-02" = {
+    machine_type = "worker"
+    ip           = "10.25.150.23"
+    mac_address  = "bc:24:11:6f:20:03"
+    vm_id        = 8203
+  }
+}

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -40,3 +40,14 @@ variable "talos_image" {
     proxmox_datastore     = optional(string, "local")
   })
 }
+
+variable "nodes_config" {
+  description = "Per-node configuration map"
+  type = map(object({
+    machine_type  = string
+    ip            = string
+    mac_address   = string
+    vm_id         = number
+    ram_dedicated = optional(number)
+  }))
+}

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -49,7 +49,8 @@ Worker Nodes:
 
 ```
 /tofu/
-├── main.tf           # Main configuration and node definitions
+├── main.tf           # Core configuration
+├── nodes.auto.tfvars # Node definitions
 ├── variables.tf      # Input variables
 ├── output.tf         # Generated outputs (kubeconfig, etc.)
 ├── providers.tf      # Provider configs (Proxmox, Talos)
@@ -207,7 +208,7 @@ I embed essential services in the Talos config:
    }
    ```
 
-2. Set `update = true` for affected nodes if your OpenTofu module supports this flag for triggering upgrades. Otherwise,
+2. Set `update = true` for affected nodes in `tofu/nodes.auto.tfvars` if your OpenTofu module supports this flag for triggering upgrades. Otherwise,
    `tofu apply` will handle changes to version properties.
 
 3. Run:
@@ -220,12 +221,12 @@ I embed essential services in the Talos config:
 
 ### Add/Remove Nodes
 
-1. Modify `nodes` in `main.tf`
+1. Modify the map in `tofu/nodes.auto.tfvars`
 2. Run `tofu apply`
 
 ### Change Resources
 
-1. Update node specs in `main.tf`
+1. Update node specs in `tofu/nodes.auto.tfvars`
 2. Run `tofu apply`
 
 > Note: Resource changes may require VM restarts

--- a/website/docs/tofu/upgrade-talos.md
+++ b/website/docs/tofu/upgrade-talos.md
@@ -24,7 +24,7 @@ The upgrade sequence is automatically derived from your node configuration:
 
 ### Configure Version
 
-Set the version to upgrade to in `main.tf`. The `update_version` is only used when `update = true` is set for a node:
+Set the version to upgrade to in `main.tf`. The `update_version` is only used when `update = true` is set for a node in `tofu/nodes.auto.tfvars`:
 
 ```hcl
 image = {


### PR DESCRIPTION
## Summary
- manage nodes through `nodes.auto.tfvars`
- expose `nodes_config` variable
- reference `nodes.auto.tfvars` in docs

## Testing
- `npm install`
- `npm run typecheck` in website
- `tofu init`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_68533c9f0bd083229bb247e98d48c3e3