### PR TITLE
refactor(talos): split config into dedicated files

### DIFF
--- a/tofu/talos/config-client.tf
+++ b/tofu/talos/config-client.tf
@@ -1,0 +1,6 @@
+data "talos_client_configuration" "this" {
+  cluster_name         = var.cluster.name
+  client_configuration = talos_machine_secrets.this.client_configuration
+  nodes                = [for k, v in var.nodes : v.ip]
+  endpoints            = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+}

--- a/tofu/talos/config-cluster.tf
+++ b/tofu/talos/config-cluster.tf
@@ -1,0 +1,35 @@
+resource "talos_machine_bootstrap" "this" {
+  depends_on = [
+    talos_machine_configuration_apply.this
+  ]
+  # Bootstrap with the first node. VIP not yet available at this stage, so cant use var.cluster.endpoint as it may be set to VIP
+  # ref - https://www.talos.dev/v1.9/talos-guides/network/vip/#caveats
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  client_configuration = talos_machine_secrets.this.client_configuration
+}
+
+resource "talos_cluster_kubeconfig" "this" {
+  depends_on = [
+    talos_machine_bootstrap.this
+  ]
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  endpoint             = var.cluster.endpoint
+  client_configuration = talos_machine_secrets.this.client_configuration
+  timeouts = {
+    read = "1m"
+  }
+}
+
+data "talos_cluster_health" "this" {
+  depends_on = [
+    talos_cluster_kubeconfig.this,
+    talos_machine_configuration_apply.this
+  ]
+  client_configuration = data.talos_client_configuration.this.client_configuration
+  control_plane_nodes  = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+  worker_nodes         = [for k, v in var.nodes : v.ip if v.machine_type == "worker"]
+  endpoints            = data.talos_client_configuration.this.endpoints
+  timeouts = {
+    read = "3m"
+  }
+}

--- a/tofu/talos/config-secrets.tf
+++ b/tofu/talos/config-secrets.tf
@@ -1,0 +1,3 @@
+resource "talos_machine_secrets" "this" {
+  talos_version = var.cluster.talos_version
+}

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -56,7 +56,10 @@ Worker Nodes:
 ├── terraform.tfvars  # Variable definitions
 ├── talos_image.auto.tfvars  # Talos image settings
 └── talos/            # Talos cluster module
-    ├── config.tf     # Machine configs and bootstrap
+    ├── config-secrets.tf     # Machine secrets
+    ├── config-client.tf      # Client configuration
+    ├── config-machine.tf     # Machine configs
+    ├── config-cluster.tf     # Bootstrap and health checks
     ├── image.tf      # OS image management
     ├── virtual-machines.tf  # Proxmox VM definitions
     ├── machine-config/      # Config templates


### PR DESCRIPTION
## Summary
- separate Talos resources into `config-secrets.tf`, `config-client.tf`, `config-machine.tf` and `config-cluster.tf`
- remove old `config.tf`
- update documentation layout

## Testing
- `npm install`
- `npm run typecheck`
- `tofu fmt -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_68533c74657c8322a3097bb7f3c0558c