### PR TITLE
refactor(talos): externalize inline manifests

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -90,14 +90,6 @@ module "talos" {
 
   talos_image = var.talos_image
 
-  cilium = {
-    values  = file("${path.module}/../k8s/infrastructure/network/cilium/values.yaml")
-    install = file("${path.module}/talos/inline-manifests/cilium-install.yaml")
-  }
-
-  coredns = {
-    install = file("${path.module}/talos/inline-manifests/coredns-install.yaml")
-  }
 
   cluster_domain = local.cluster_domain
 

--- a/tofu/talos/config.tf
+++ b/tofu/talos/config.tf
@@ -19,15 +19,12 @@ data "talos_machine_configuration" "this" {
   kubernetes_version = var.cluster.kubernetes_version
   config_patches = each.value.machine_type == "controlplane" ? [
     templatefile("${path.module}/machine-config/control-plane.yaml.tftpl", {
-      hostname        = each.key
-      node_name       = each.value.host_node
-      cluster_name    = var.cluster.proxmox_cluster
-      node_ip         = each.value.ip
-      cluster         = var.cluster
-      cluster_domain  = var.cluster_domain
-      cilium_values   = var.cilium.values
-      cilium_install  = var.cilium.install
-      coredns_install = var.coredns.install
+      hostname       = each.key
+      node_name      = each.value.host_node
+      cluster_name   = var.cluster.proxmox_cluster
+      node_ip        = each.value.ip
+      cluster        = var.cluster
+      cluster_domain = var.cluster_domain
     })
     ] : [
     templatefile("${path.module}/machine-config/worker.yaml.tftpl", {

--- a/tofu/talos/inline-manifests/cilium-values.yaml
+++ b/tofu/talos/inline-manifests/cilium-values.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-values
+  namespace: kube-system
+data:
+  values.yaml: |-
+          # https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml
+          cluster:
+            name: talos
+            id: 1
+          
+          kubeProxyReplacement:
+            true
+          
+            # Talos specific
+          k8sServiceHost: localhost
+          k8sServicePort: 7445
+          securityContext:
+            capabilities:
+              ciliumAgent:
+                [CHOWN, KILL, NET_ADMIN, NET_RAW, IPC_LOCK, SYS_ADMIN, SYS_RESOURCE, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
+              cleanCiliumState: [NET_ADMIN, SYS_ADMIN, SYS_RESOURCE]
+          
+          cgroup:
+            autoMount:
+              enabled: false
+            hostRoot: /sys/fs/cgroup
+          
+          # https://www.talos.dev/latest/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns
+          # https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
+          bpf:
+            hostLegacyRouting: true
+          
+          # https://docs.cilium.io/en/stable/network/concepts/ipam/
+          ipam:
+            mode: kubernetes
+            multiPoolPreAllocation: ''
+          
+          operator:
+            rollOutPods: true
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
+          
+          # Roll out cilium agent pods automatically when ConfigMap is updated.
+          rollOutCiliumPods: true
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          
+          #debug:
+          #  enabled: true
+          
+          # Increase rate limit when doing L2 announcements
+          k8sClientRateLimit:
+            qps: 20
+            burst: 100
+          
+          l2announcements:
+            enabled: true
+          
+          externalIPs:
+            enabled: true
+          
+          enableCiliumEndpointSlice: true
+          
+          loadBalancer:
+            # https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#maglev-consistent-hashing
+            algorithm: maglev
+          
+          gatewayAPI:
+            enabled: true
+          envoy:
+            securityContext:
+              capabilities:
+                keepCapNetBindService: true
+                envoy: [NET_ADMIN, PERFMON, BPF]
+          
+          hubble:
+            peerService:
+              clusterDomain: kube.pc-tips.se
+            enabled: true
+            relay:
+              enabled: true
+              rollOutPods: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+            ui:
+              enabled: true
+              rollOutPods: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+          
+          ingressController:
+            enabled: false
+            default: true
+            loadbalancerMode: shared
+            service:
+              annotations:
+                io.cilium/lb-ipam-ips: 10.25.150.223
+          
+          # mTLS
+          authentication:
+            enabled: false
+            mutual:
+              spire:
+                enabled: false
+                install:
+                  server:
+                    dataStorage:
+                      storageClass: cilium-spire-sc

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -64,18 +64,10 @@ cluster:
   inlineManifests:
   - name: cilium-values
     contents: |
-      ---
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: cilium-values
-        namespace: kube-system
-      data:
-        values.yaml: |-
-          ${indent(10, cilium_values)}
+      ${indent(6, file("${path.module}/inline-manifests/cilium-values.yaml"))}
   - name: cilium-bootstrap
     contents: |
-      ${indent(6, cilium_install)}
+      ${indent(6, file("${path.module}/inline-manifests/cilium-install.yaml"))}
   - name: coredns-bootstrap
     contents: |
-      ${indent(6, coredns_install)}
+      ${indent(6, file("${path.module}/inline-manifests/coredns-install.yaml"))}

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -75,20 +75,6 @@ variable "nodes" {
   }
 }
 
-variable "cilium" {
-  description = "Cilium configuration"
-  type = object({
-    values  = string
-    install = string
-  })
-}
-
-variable "coredns" {
-  description = "CoreDNS configuration"
-  type = object({
-    install = string
-  })
-}
 
 # variable "storage_pool" {
 #   type        = string


### PR DESCRIPTION
## Summary
- move cilium, coredns manifests to files
- update machine config to load manifests from files
- drop unused cilium and coredns variables

## Testing
- `tofu fmt -recursive tofu`
- `tofu -chdir=tofu init -backend=false`
- `tofu -chdir=tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_68533c0a77908322975c889e5f380d3a