### PR TITLE
fix(tofu): use schematic resource id

### DIFF
--- a/tofu/talos/image.tf
+++ b/tofu/talos/image.tf
@@ -10,14 +10,14 @@ locals {
   schematic = templatefile("${path.root}/${var.talos_image.schematic_path}", {
     needs_nvidia_extensions = local.needs_nvidia_extensions
   })
-  schematic_id = jsondecode(data.http.schematic_id.response_body)["id"]
+  schematic_id = talos_image_factory_schematic.this.id
 
   update_version        = coalesce(var.talos_image.update_version, var.talos_image.version)
   update_schematic_path = coalesce(var.talos_image.update_schematic_path, var.talos_image.schematic_path)
   update_schematic = templatefile("${path.root}/${local.update_schematic_path}", {
     needs_nvidia_extensions = local.needs_nvidia_extensions
   })
-  update_schematic_id = jsondecode(data.http.updated_schematic_id.response_body)["id"]
+  update_schematic_id = talos_image_factory_schematic.updated.id
 
   image_id        = "${local.schematic_id}_${local.version}"
   update_image_id = "${local.update_schematic_id}_${local.update_version}"
@@ -37,18 +37,7 @@ locals {
   }
 }
 
-data "http" "schematic_id" {
-  url          = "${var.talos_image.factory_url}/schematics"
-  method       = "POST"
-  request_body = local.schematic
-}
 
-# Always fetch update schematic ID
-data "http" "updated_schematic_id" {
-  url          = "${var.talos_image.factory_url}/schematics"
-  method       = "POST"
-  request_body = local.update_schematic
-}
 
 resource "talos_image_factory_schematic" "this" {
   schematic = local.schematic


### PR DESCRIPTION
## Summary
- remove redundant HTTP data blocks
- use the `talos_image_factory_schematic` resource ids directly

## Testing
- `tofu fmt -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_685351780318832281ee2690ae572efc