### PR TITLE
refactor(tofu): centralize output file resources

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -74,6 +74,25 @@ module "talos" {
   nodes = local.nodes_with_upgrade
 }
 
+resource "local_file" "machine_configs" {
+  for_each        = module.talos.machine_config
+  content         = each.value.machine_configuration
+  filename        = "output/talos-machine-config-${each.key}.yaml"
+  file_permission = "0600"
+}
+
+resource "local_file" "talos_config" {
+  content         = module.talos.client_configuration.talos_config
+  filename        = "output/talos-config.yaml"
+  file_permission = "0600"
+}
+
+resource "local_file" "kube_config" {
+  content         = module.talos.kube_config.kubeconfig_raw
+  filename        = "output/kube-config.yaml"
+  file_permission = "0600"
+}
+
 output "upgrade_info" {
   value = {
     state = {

--- a/tofu/output.tf
+++ b/tofu/output.tf
@@ -1,22 +1,3 @@
-resource "local_file" "machine_configs" {
-  for_each        = module.talos.machine_config
-  content         = each.value.machine_configuration
-  filename        = "output/talos-machine-config-${each.key}.yaml"
-  file_permission = "0600"
-}
-
-resource "local_file" "talos_config" {
-  content         = module.talos.client_configuration.talos_config
-  filename        = "output/talos-config.yaml"
-  file_permission = "0600"
-}
-
-resource "local_file" "kube_config" {
-  content         = module.talos.kube_config.kubeconfig_raw
-  filename        = "output/kube-config.yaml"
-  file_permission = "0600"
-}
-
 output "kube_config" {
   value     = module.talos.kube_config.kubeconfig_raw
   sensitive = true

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -49,10 +49,10 @@ Worker Nodes:
 
 ```
 /tofu/
-├── main.tf           # Core configuration
+├── main.tf           # Core configuration and file generation
 ├── nodes.auto.tfvars # Node definitions
 ├── variables.tf      # Input variables
-├── output.tf         # Generated outputs (kubeconfig, etc.)
+├── output.tf         # Output values only
 ├── providers.tf      # Provider configs (Proxmox, Talos)
 ├── terraform.tfvars  # Variable definitions
 ├── talos_image.auto.tfvars  # Talos image settings


### PR DESCRIPTION
## Summary
- move `local_file` resources from `output.tf` to `main.tf`
- keep only output blocks in `output.tf`
- update docs to match layout

## Testing
- `tofu validate`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853517a3efc83229a67a6a2061945c7