### PR TITLE
fix(talos): ensure unique image downloads

### DIFF
--- a/tofu/talos/image.tf
+++ b/tofu/talos/image.tf
@@ -25,7 +25,7 @@ locals {
 
 locals {
   image_downloads = {
-    for node in var.nodes : "${node.host_node}_${node.update ? local.update_image_id : local.image_id}" => {
+    for name, node in var.nodes : "${name}_${node.update ? "update" : "base"}" => {
       host_node = node.host_node
       version   = node.update ? local.update_version : local.version
       schematic = node.update ? talos_image_factory_schematic.updated.id : talos_image_factory_schematic.this.id

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -42,7 +42,7 @@ resource "proxmox_virtual_environment_vm" "this" {
     file_format  = "raw"
     size         = 40
     file_id = proxmox_virtual_environment_download_file.this[
-      "${each.value.host_node}_${each.value.update == true ? local.update_image_id : local.image_id}"
+      "${each.key}_${each.value.update == true ? "update" : "base"}"
     ].id
   }
 


### PR DESCRIPTION
## Summary
- ensure Talos image download keys include node name to avoid duplicates

## Testing
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_68535462de408322a4adc36b82a50697