### PR TITLE
feat(images): add dockerignore for spilo17-vchord

### DIFF
--- a/images/spilo17-vchord/.dockerignore
+++ b/images/spilo17-vchord/.dockerignore
@@ -1,0 +1,3 @@
+.git
+*.md
+**/node_modules

--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -38,6 +38,7 @@ This page explains how GitHub Actions, Dependabot, and pre-commit hooks keep thi
 - **Permissions:**
   - `contents: read` (clone the repository)
   - `packages: write` (upload images)
+- **Build context:** Uses `.dockerignore` files within each image directory to keep uploads minimal.
 
 ### Validation & CI (Implied Workflows)
 


### PR DESCRIPTION
## Summary
- exclude junk files from the spilo17-vchord build context
- document that Docker workflows rely on `.dockerignore`

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853e0e39cc08322a09486861113cf70