### PR TITLE
refactor(tofu): stabilize image downloads

### DIFF
--- a/tofu/talos/image.tf
+++ b/tofu/talos/image.tf
@@ -29,10 +29,15 @@ locals {
     name => "${node.host_node}_${lookup(node, "update", false) ? local.update_image_id : local.image_id}"
   }
 
+  image_download_key = {
+    for name, node in var.nodes :
+    name => "${node.host_node}_${lookup(node, "update", false)}"
+  }
+
   image_downloads = {
     for key, nodes in {
       for name, node in var.nodes :
-      local.image_key[name] => node...
+      local.image_download_key[name] => node...
       } : key => {
       host_node = nodes[0].host_node
       version   = lookup(nodes[0], "update", false) ? local.update_version : local.version

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -42,7 +42,7 @@ resource "proxmox_virtual_environment_vm" "this" {
     file_format  = "raw"
     size         = 40
     file_id = proxmox_virtual_environment_download_file.this[
-      local.image_key[each.key]
+      local.image_download_key[each.key]
     ].id
   }
 

--- a/website/docs/disaster/disaster-recovery.md
+++ b/website/docs/disaster/disaster-recovery.md
@@ -36,11 +36,7 @@ Rebuild your cluster infrastructure using OpenTofu:
 ```bash
 # Clean up existing resources
 tofu destroy
-
-# Apply image factory configurations first
-tofu apply -target=module.talos.talos_image_factory_schematic.this -target=module.talos.talos_image_factory_schematic.updated
-
-# Deploy the complete infrastructure
+# Deploy the infrastructure
 tofu apply
 ```
 

--- a/website/docs/getting-started/detailed-setup.md
+++ b/website/docs/getting-started/detailed-setup.md
@@ -79,13 +79,7 @@ Preview the changes that will be applied:
 tofu plan
 ```
 
-First, generate the Talos image schematics:
-
-```console
-tofu apply -target=module.talos.talos_image_factory_schematic.this -target=module.talos.talos_image_factory_schematic.updated
-```
-
-Then apply the full configuration to deploy your cluster:
+Deploy the configuration to build your cluster:
 
 ```console
 tofu apply


### PR DESCRIPTION
## Summary
- build image download keys only from node info
- use the new keys when creating VMs
- drop outdated `-target` guidance from docs

## Testing
- `tofu init -upgrade`
- `tofu validate`
- `npm run typecheck`
- `kustomize build --enable-helm k8s/infrastructure`

------
https://chatgpt.com/codex/tasks/task_e_6853e0dddb908322857217b7288ede29