### PR TITLE
docs(k8s): update repository URL in argocd guide

### DIFF
--- a/website/docs/infrastructure/controllers/argocd-gitops.md
+++ b/website/docs/infrastructure/controllers/argocd-gitops.md
@@ -79,7 +79,7 @@ spec:
   project: infrastructure
   source:
     path: k8s/infrastructure/network/cilium
-    repoURL: https://github.com/pc-cdn/homelab.git
+    repoURL: https://github.com/theepicsaxguy/homelab.git
     targetRevision: main
   destination:
     namespace: network
@@ -103,7 +103,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: https://github.com/pc-cdn/homelab.git
+        repoURL: https://github.com/theepicsaxguy/homelab.git
         revision: HEAD
         directories:
           - path: k8s/applications/media/*
@@ -114,7 +114,7 @@ spec:
       project: applications
       source:
         path: '{{path}}'
-        repoURL: https://github.com/pc-cdn/homelab.git
+        repoURL: https://github.com/theepicsaxguy/homelab.git
       destination:
         namespace: media
         server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- update the Git repository URL in the Argo CD docs

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853ebc57e188322a4b3e7739e2dc9b6