### PR TITLE
docs(k8s): use kustomize build in manual bootstrap guide

### DIFF
--- a/website/docs/k8s/manual-bootstrap-guide.md
+++ b/website/docs/k8s/manual-bootstrap-guide.md
@@ -30,7 +30,7 @@ kubectl apply -k k8s/infrastructure/crds
 Install Cilium networking (must be done before other components):
 
 ```shell
-kubectl kustomize --enable-helm k8s/infrastructure/network/cilium | kubectl apply -f -
+kustomize build --enable-helm k8s/infrastructure/network/cilium | kubectl apply -f -
 
 # Wait for Cilium to be ready
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cilium -n kube-system --timeout=90s


### PR DESCRIPTION
## Summary
- update manual bootstrap docs to use `kustomize build`

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853ebe03bcc83229d66bf160c4f0b15