### PR TITLE
docs(k8s): remove Bitwarden item notes

### DIFF
--- a/k8s/applications/web/babybuddy/babybuddy-external-secret.yaml
+++ b/k8s/applications/web/babybuddy/babybuddy-external-secret.yaml
@@ -14,4 +14,4 @@ spec:
   data:
     - secretKey: SECRET_KEY         # ← must be exactly SECRET_KEY
       remoteRef:
-        key: app-babybuddy-secret-key  # sample Bitwarden item ID
+        key: app-babybuddy-secret-key

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -61,10 +61,10 @@ spec:
     # --- User Emails ---
     - secretKey: ARGOCD_ADMIN_EMAIL
       remoteRef:
-        key: 'app-authentik-admin-email' # Replace with actual Bitwarden item ID
+        key: 'app-authentik-admin-email' # Replace with your admin email item key
     - secretKey: GRAFANA_VIEWER_EMAIL
       remoteRef:
-        key: 'app-authentik-admin-email' # Replace with actual Bitwarden item ID
+        key: 'app-authentik-admin-email' # Replace with your admin email item key
 
     # --- ArgoCD ---
     - secretKey: ARGOCD_CLIENT_ID


### PR DESCRIPTION
## Summary
- remove outdated Bitwarden note in Baby Buddy secret
- reword comments for admin email secrets

## Testing
- `kustomize build --enable-helm k8s/applications/web/babybuddy`
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`


------
https://chatgpt.com/codex/tasks/task_e_6853ecff390c832299c79761f13ed485