### PR TITLE
fix(tofu): ignore null node overrides

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -13,7 +13,7 @@ locals {
         local.node_defaults[config.machine_type],
         error("machine_type '${config.machine_type}' has no defaults")
       ),
-      config,
+      { for k, v in config : k => v if v != null },
       {
         update = var.upgrade_control.enabled && name == local.current_upgrade_node
       }


### PR DESCRIPTION
## Summary
- ensure optional values don't null out defaults

## Testing
- `tofu fmt -recursive tofu`
- `tofu -chdir=tofu validate`
- `tofu -chdir=tofu plan -var-file=terraform.tfvars.Example`

------
https://chatgpt.com/codex/tasks/task_e_6853f443ea788322b8d58f7f29bd3593