### PR TITLE
feat(talos): add image version sentinel

### DIFF
--- a/tofu/talos/version-sentinel.tf
+++ b/tofu/talos/version-sentinel.tf
@@ -1,0 +1,6 @@
+resource "terraform_data" "image_version" {
+  # Tracks the intended Talos image version. Bumping
+  # `var.talos_image.update_version` forces a VM replacement
+  # through `replace_triggered_by` in the VM resource.
+  input = var.talos_image.update_version
+}

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -64,8 +64,16 @@ resource "proxmox_virtual_environment_vm" "this" {
     ignore_changes = [
       vga,                            # Ignore VGA changes (these are computed)
       network_device[0].disconnected, # Ignore network disconnected state
-      # Add any other attributes causing issues
+      disk[0].file_id,                # Decouple VM from minor base-image hash changes
     ]
+
+    # Replace the VM deliberately when the wanted Talos image version changes
+    replace_triggered_by = [
+      terraform_data.image_version
+    ]
+
+    # Ensure the new VM is up before the old one is destroyed
+    create_before_destroy = true
   }
   boot_order = ["scsi0"]
 

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -299,6 +299,9 @@ talos_image = {
 
 Change these version strings to match the Talos release you want to use.
 
+Changing `update_version` forces a VM replacement. OpenTofu keeps the new
+machine running before the old one is removed so you don't lose capacity.
+
 ### 3. Deployment Steps
 
 1. Load your SSH key for Proxmox access:

--- a/website/docs/tofu/upgrade-talos.md
+++ b/website/docs/tofu/upgrade-talos.md
@@ -34,6 +34,9 @@ image = {
 }
 ```
 
+When you bump `update_version`, the VM is recreated. OpenTofu creates the
+replacement before destroying the old VM.
+
 > **Note:** You may commit and push this change if you're using GitOps automation, or run it locally via CLI if applying manually.
 
 ### Start Upgrade
@@ -73,6 +76,9 @@ image = {
   update_version  = "<see https://github.com/siderolabs/talos/releases>"
   schematic       = file("${path.module}/talos/image/schematic.yaml")
 }
+
+OpenTofu will roll out new VMs when this version changes, ensuring the
+replacement is running before the original is removed.
 
 # Update the cluster Talos version
 cluster = {


### PR DESCRIPTION
## Summary
- track the desired Talos image version with a `terraform_data` resource
- update VM lifecycle rules to ignore disk file hashes
- replace VMs when the target image version changes and create the new VM before removing the old one
- document how `update_version` triggers VM replacement

## Testing
- `tofu validate`
- `tofu init`
- `tofu plan -input=false`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6854094753988322bf264b80e006f1be