### PR TITLE
refactor(tofu): remove freeze attribute from node configurations

### DIFF
--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -29,6 +29,9 @@ nodes_config = {
     ip           = "10.25.150.22"
     mac_address  = "bc:24:11:c9:22:c3"
     vm_id        = 8202
+    memory = {
+      dedicated = 12046
+    }
   }
   "work-02" = {
     machine_type = "worker"

--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -29,13 +29,11 @@ nodes_config = {
     ip           = "10.25.150.22"
     mac_address  = "bc:24:11:c9:22:c3"
     vm_id        = 8202
-    freeze       = false
   }
   "work-02" = {
     machine_type = "worker"
     ip           = "10.25.150.23"
     mac_address  = "bc:24:11:6f:20:03"
     vm_id        = 8203
-    freeze       = true
   }
 }

--- a/tofu/providers.tf
+++ b/tofu/providers.tf
@@ -32,10 +32,4 @@ provider "kubernetes" {
   client_certificate     = base64decode(module.talos.kube_config.kubernetes_client_configuration.client_certificate)
   client_key             = base64decode(module.talos.kube_config.kubernetes_client_configuration.client_key)
   cluster_ca_certificate = base64decode(module.talos.kube_config.kubernetes_client_configuration.ca_certificate)
-  config_sensitive_attrs = [
-    "host",
-    "client_certificate",
-    "client_key",
-    "cluster_ca_certificate",
-  ]
 }

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -43,7 +43,6 @@ variable "nodes" {
     ram_dedicated = number
     update        = optional(bool, false)
     igpu          = optional(bool, false)
-    freeze        = optional(bool, false)
     disks = optional(map(object({
       device      = string
       size        = string
@@ -90,19 +89,6 @@ variable "coredns" {
     install = string
   })
 }
-
-# variable "storage_pool" {
-#   type        = string
-#   description = "Default Proxmox storage pool to use for VM disks."
-# }
-
-# variable "disk_owner" {
-#   description = "Where to create the data disks VM"
-#   type = object({
-#     node_name = string
-#     vm_id     = number
-#   })
-# }
 
 
 

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -1,3 +1,7 @@
+resource "terraform_data" "image_version" {
+  input = var.talos_image.version
+}
+
 resource "proxmox_virtual_environment_vm" "this" {
   for_each = var.nodes
 
@@ -66,16 +70,12 @@ resource "proxmox_virtual_environment_vm" "this" {
     }
   }
   lifecycle {
-    ignore_changes = lookup(each.value, "freeze", false) ? [
-      vga,
-      network_device[0].disconnected,
-      disk[0].file_id,
-      ] : [
+    ignore_changes = [
       vga,
       network_device[0].disconnected,
     ]
 
-    replace_triggered_by = lookup(each.value, "freeze", false) ? [] : [
+    replace_triggered_by = [
       terraform_data.image_version
     ]
 
@@ -84,7 +84,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   boot_order = ["scsi0"]
 
   operating_system {
-    type = "l26" # Linux Kernel 2.6 - 6.X.
+    type = "l26"
   }
 
   initialization {

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -73,6 +73,7 @@ resource "proxmox_virtual_environment_vm" "this" {
     ignore_changes = [
       vga,
       network_device[0].disconnected,
+      disk[0].file_id,
     ]
 
     replace_triggered_by = [

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -49,7 +49,6 @@ variable "nodes_config" {
     mac_address   = string
     vm_id         = number
     ram_dedicated = optional(number)
-    freeze        = optional(bool, false)
   }))
 
   validation {

--- a/website/docs/tofu/opentofu-provisioning.md
+++ b/website/docs/tofu/opentofu-provisioning.md
@@ -279,7 +279,6 @@ nodes = {
     cpu           = 6
     ram_dedicated = 6144
     update        = false
-    freeze        = false
     igpu          = false
   }
   # Additional nodes...
@@ -381,12 +380,6 @@ tofu plan -target=module.talos
 # Apply updates
 tofu apply -target=module.talos
 ```
-
-#### Freeze a Node
-
-Set `freeze = true` in `tofu/nodes.auto.tfvars` to keep a node on its current
-image. Use this only as a short-term hold; clear the flag when you're ready to
-roll the node forward.
 
 ### Recovery Operations
 

--- a/website/docs/tofu/upgrade-talos.md
+++ b/website/docs/tofu/upgrade-talos.md
@@ -26,8 +26,7 @@ The upgrade sequence is automatically derived from your node configuration:
 
 Set the version to upgrade to in `main.tf` under the `talos_image` block. The
 `update_version` value only applies when `update = true` is set for a node in
-`tofu/nodes.auto.tfvars`. Nodes with `freeze = true` keep their current image
-during the rollout:
+`tofu/nodes.auto.tfvars`.
 
 ```hcl
 talos_image = {


### PR DESCRIPTION
- Removed the freeze attribute from nodes.auto.tfvars, variables.tf, and nodes_config.
- Updated documentation to reflect the removal of freeze functionality.