### PR TITLE
feat(k8s): expand immich library volume to 40Gi

### DIFF
--- a/k8s/applications/media/immich/immich-server/statefulset.yaml
+++ b/k8s/applications/media/immich/immich-server/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       storageClassName: "longhorn"
       resources:
         requests:
-          storage: 20Gi
+          storage: 40Gi
   template:
     metadata:
       labels:

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -98,3 +98,22 @@ Both pods need enough memory to process photos without crashing. A good starting
 | --------- | ----------- | -------------- | --------- | ------------ |
 | immich-server | 500m | 512Mi | 2000m | 2Gi |
 | immich-machine-learning | 200m | 1Gi | 1000m | 4Gi |
+
+### Library Storage
+
+Immich stores uploaded files on a Persistent Volume Claim named `library`. The claim
+requests 40Gi from Longhorn:
+
+```yaml
+# k8s/applications/media/immich/immich-server/statefulset.yaml
+spec:
+  volumeClaimTemplates:
+  - metadata:
+      name: library
+    spec:
+      storageClassName: longhorn
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 40Gi
+```


### PR DESCRIPTION
## Summary
- allocate more Longhorn storage for the immich library
- document the new library storage size

## Testing
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/applications/media/immich`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68556b40474083228215b1c4b06138fb