### PR TITLE
chore(repo): enable esm for commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1"


### PR DESCRIPTION
## What & why
- added `type: module` so Node treats commitlint config as ESM

## Validation evidence
- `npx commitlint --version`

## Impact radius / follow-ups
- affects commit linting only; no further changes needed

------
https://chatgpt.com/codex/tasks/task_e_6855d8b045e483229eeb3f32060a27ed