### PR TITLE
docs(github): clarify updater tools

### DIFF
--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -1,6 +1,6 @@
 # GitHub Configuration: CI/CD and Repository Maintenance
 
-This page explains how GitHub Actions, Dependabot, and pre-commit hooks keep this homelab repository secure, up to date, and easy to maintain.
+This page explains how GitHub Actions, Renovate, and Dependabot keep this homelab repository secure, up to date, and easy to maintain.
 
 ---
 
@@ -42,7 +42,7 @@ This page explains how GitHub Actions, Dependabot, and pre-commit hooks keep thi
 
 ### Validation & CI (Implied Workflows)
 
-- **What:** While specific workflow YAMLs for all validation steps aren't detailed here, the presence of scripts like `hooks/validate-external-secrets.sh` suggests CI integration for validation. The repository aims to automatically lint and validate configurations.
+- **What:** While specific workflow YAMLs for all validation steps aren't detailed here, CI jobs automatically lint and validate configurations.
 - **Purpose:** Automatically lint and validate configurations (Kubernetes, Helm charts, scripts) on every push or PR.
 - **When triggered:**
   - Every push to `main`
@@ -51,10 +51,19 @@ This page explains how GitHub Actions, Dependabot, and pre-commit hooks keep thi
   - YAML and script linting
   - Kustomize and ArgoCD validation (typically using `kustomize build` and ArgoCD CLI tools)
   - Helm chart checks (typically using `helm lint` or `helm template`)
-  - Run `validate-external-secrets.sh` for secret validation
 - **Why:**
   - **Automation:** Prevents errors and broken configs from reaching production.
   - **Quality gate:** Fails builds if code doesn’t meet standards.
+
+---
+
+## Renovate (`renovate.json`)
+
+- **File:** `renovate.json`
+- **Purpose:** Keep dependencies current across Dockerfiles, Helm charts, Terraform, and other configs.
+- **Why use Renovate?**
+  - **Broad coverage:** Handles many ecosystem updates in one tool.
+  - **Automatic PRs:** Creates update pull requests with minimal manual work.
 
 ---
 
@@ -82,23 +91,10 @@ This page explains how GitHub Actions, Dependabot, and pre-commit hooks keep thi
 
 ---
 
-## Pre-commit Hooks (`.github/hooks/`)
-
-- **File:** `.github/hooks/validate-external-secrets.sh`
-- **Purpose:** Validate all `ExternalSecret` manifests before committing. Ensures required fields and sensible values (like `refreshInterval`).
-- **How it's used:**
-  - Integrated with a pre-commit framework (such as [pre-commit.com](https://pre-commit.com/)).
-  - Runs automatically on staged files before a commit.
-  - Aborts the commit if there are validation errors—fix errors, then try again.
-- **Why:**
-  - **Immediate feedback:** Catches errors before they ever reach the remote repo or CI.
-  - **Less noise in CI:** Fewer broken commits and wasted CI runs.
-
----
 
 ## Summary
 
-By combining GitHub Actions (automated CI), Dependabot (dependency management), and pre-commit hooks (local validation), this repo stays:
+By combining GitHub Actions (automated CI), Renovate (dependency updates), and Dependabot (security checks), this repo stays:
 
 - High quality
 - Secure

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -74,7 +74,7 @@ Local search runs entirely in the browser thanks to the `@easyops-cn/docusaurus-
 
 - [Pipeline Configuration](./github/github-configuration.md)
   - CI/CD workflow setup
-  - Dependabot settings
+  - Renovate and Dependabot settings
   - Repo maintenance
 
 ## Website Updates


### PR DESCRIPTION
## Summary
- document Renovate as the main dependency updater
- mention Renovate in CI/CD intro
- update intro index

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855d892c9888322978cca1674a3cfbe