### PR TITLE
fix(talos): pin cilium-cli version

### DIFF
--- a/tofu/talos/inline-manifests/cilium-install.yaml
+++ b/tofu/talos/inline-manifests/cilium-install.yaml
@@ -60,7 +60,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cilium-install
-        image: quay.io/cilium/cilium-cli-ci:latest
+        image: quay.io/cilium/cilium-cli:v0.18.4
         env:
         - name: KUBERNETES_SERVICE_HOST
           valueFrom:


### PR DESCRIPTION
## What & why
- pin cilium CLI bootstrap image to v0.18.4 for deterministic installs

## Validation evidence
- `tofu init -backend=false`
```
should now work.

If you ever set or change modules or backend configuration for OpenTofu,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
- `tofu validate`
```
Success! The configuration is valid.
```

## Impact radius / follow-ups
- only affects Talos bootstrap process


------
https://chatgpt.com/codex/tasks/task_e_6855de7fa1008322a0afca8b639e259f