### PR TITLE
fix(k8s): align mosquitto service selector

### DIFF
--- a/k8s/applications/automation/haos/deployment.yaml
+++ b/k8s/applications/automation/haos/deployment.yaml
@@ -219,7 +219,7 @@ metadata:
   name: mosquitto-service
 spec:
   selector:
-    app: mosquitto-service
+    app: mosquitto
   type: NodePort
   ports:
   - name: mqtt


### PR DESCRIPTION
## Summary
- fix mosquitto service selector label to match pods

## Validation
- `kustomize build --enable-helm k8s/applications/automation/haos`


------
https://chatgpt.com/codex/tasks/task_e_6856ddca02788322a51e5734d65246db