### PR TITLE
fix(k8s): load haos env via configmap

### DIFF
--- a/k8s/applications/automation/haos/deployment.yaml
+++ b/k8s/applications/automation/haos/deployment.yaml
@@ -60,6 +60,9 @@ spec:
         - containerPort: 5580 # Expose container port
       - name: home-assistant
         image: homeassistant/home-assistant:2025.6.1
+        envFrom:
+        - configMapRef:
+            name: haos-env
         resources:
           requests:
             memory: "256Mi"

--- a/k8s/applications/automation/haos/kustomization.yaml
+++ b/k8s/applications/automation/haos/kustomization.yaml
@@ -12,3 +12,6 @@ configMapGenerator:
 - literals:
   - TZ=Europe/Stockholm
   name: haos-env
+
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
## What & why
- reference `haos-env` in the Home Assistant StatefulSet
- keep the ConfigMap name stable so `envFrom` resolves

## Validation evidence
- `kustomize build --enable-helm k8s/applications/automation/haos`


------
https://chatgpt.com/codex/tasks/task_e_6856dec8b5ec8322b9af580f5c57328d