### PR TITLE
fix(k8s): update hassio statefulset security context

### DIFF
--- a/k8s/applications/automation/hassio/statefulset.yaml
+++ b/k8s/applications/automation/hassio/statefulset.yaml
@@ -16,16 +16,10 @@ spec:
       labels:
         app: home-assistant
     spec:
-      # --- START OF CHANGE ---
-      # Add this security context to run the pod as a specific non-root user
-      # and ensure the volume permissions are set correctly.
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
-      # --- END OF CHANGE ---
       containers:
       - name: home-assistant
         image: homeassistant/home-assistant:2025.6.1
@@ -54,22 +48,14 @@ spec:
           name: media-volume
         - name: data-volume
           mountPath: /data
-        # --- START OF CHANGE ---
-        # The container-level securityContext can now be simplified or removed,
-        # but we'll keep it for defense-in-depth.
-        # The pod-level context already enforces runAsNonRoot implicitly
-        # by setting runAsUser.
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
-          # This runAsNonRoot: true is now correctly satisfied by the pod-level securityContext
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
-        # --- END OF CHANGE ---
   volumeClaimTemplates:
   - metadata:
       name: config

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -135,7 +135,9 @@ Home Assistant runs as a StatefulSet. Configuration, media, and data paths each
 use their own persistent volume created through `volumeClaimTemplates`. It
 connects to the shared `mosquitto` service in the `mqtt` namespace—configure the
 integration to use `mosquitto.mqtt.svc.cluster.local` and your Bitwarden
-credentials. The BlueZ sidecar now drops all capabilities and runs
+credentials. The main container starts as `root` so its init system can run, but
+Kubernetes sets the volume group to `1000` so Home Assistant can drop
+privileges. The BlueZ sidecar now drops all capabilities and runs
 unprivileged, reducing risk.
 
 Need help? Check the application examples in `/k8s/applications/` for reference implementations.


### PR DESCRIPTION
## What & Why
- let the Home Assistant container start as root to allow s6-overlay to run
- document how Kubernetes sets `fsGroup` so the app can drop privileges

## Validation Evidence
- `kustomize build --enable-helm k8s/applications/automation/hassio`
```
metadata:
  name: haos
  namespace: home-assistant
...
```
- `npm install` succeeded though reported some advisories
- `npm run typecheck` completed without errors
- `npm run lint` failed: `Missing script: "lint"`


------
https://chatgpt.com/codex/tasks/task_e_68580c326c24832283af9a2afe6ae806