### PR TITLE
feat(k8s): add configmap for home assistant

### DIFF
--- a/k8s/applications/automation/hassio/configmap.yaml
+++ b/k8s/applications/automation/hassio/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: home-assistant-config
+  namespace: home-assistant
+data:
+  configuration.yaml: |
+    default_config:
+
+    frontend:
+      themes: !include_dir_merge_named themes
+
+    automation: !include automations.yaml
+
+    http:
+      use_x_forwarded_for: true
+      trusted_proxies:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+  automations.yaml: ""
+  known_devices.yaml: ""

--- a/k8s/applications/automation/hassio/kustomization.yaml
+++ b/k8s/applications/automation/hassio/kustomization.yaml
@@ -6,11 +6,4 @@ resources:
 - http-route.yaml
 - statefulset.yaml
 - svc.yaml
-
-configMapGenerator:
-- literals:
-  - TZ=Europe/Stockholm
-  name: haos-env
-
-generatorOptions:
-  disableNameSuffixHash: true
+- configmap.yaml

--- a/k8s/applications/automation/hassio/statefulset.yaml
+++ b/k8s/applications/automation/hassio/statefulset.yaml
@@ -23,9 +23,9 @@ spec:
       containers:
       - name: home-assistant
         image: homeassistant/home-assistant:2025.6.1
-        envFrom:
-        - configMapRef:
-            name: haos-env
+        env:
+        - name: TZ
+          value: "Europe/Stockholm"
         resources:
           requests:
             memory: "256Mi"
@@ -42,6 +42,9 @@ spec:
             path: /
             port: 8123
         volumeMounts:
+        - mountPath: /config/configuration.yaml
+          name: ha-config
+          subPath: configuration.yaml
         - mountPath: /config
           name: config
         - mountPath: /media
@@ -56,6 +59,10 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+      - name: ha-config
+        configMap:
+          name: home-assistant-config
   volumeClaimTemplates:
   - metadata:
       name: config

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -135,9 +135,10 @@ Home Assistant runs as a StatefulSet. Configuration, media, and data paths each
 use their own persistent volume created through `volumeClaimTemplates`. It
 connects to the shared `mosquitto` service in the `mqtt` namespace—configure the
 integration to use `mosquitto.mqtt.svc.cluster.local` and your Bitwarden
-credentials. The main container starts as `root` so its init system can run, but
-Kubernetes sets the volume group to `1000` so Home Assistant can drop
-privileges. The BlueZ sidecar now drops all capabilities and runs
-unprivileged, reducing risk.
+credentials. A ConfigMap provides `configuration.yaml` so the cluster gateway can
+proxy requests using the `X-Forwarded-For` header. The main container starts as
+`root` so its init system can run, but Kubernetes sets the volume group to `1000`
+so Home Assistant can drop privileges. The BlueZ sidecar now drops all
+capabilities and runs unprivileged, reducing risk.
 
 Need help? Check the application examples in `/k8s/applications/` for reference implementations.


### PR DESCRIPTION
## What & Why
- provide `configuration.yaml` via ConfigMap so trusted proxies work
- mount the config in the StatefulSet and set TZ directly
- document how Home Assistant picks up the config

## Validation
- `kustomize build --enable-helm k8s/applications/automation/hassio`
- `npm install` *(website)*
- `npm run typecheck` *(website)*
- `npm run lint` *(failed: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858117660788322939ba4d15a57407c