### PR TITLE
feat(k8s): allow zigbee2mqtt privileged

### DIFF
--- a/k8s/applications/automation/zigbee2mqtt/namespace.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: zigbee2mqtt
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -140,5 +140,11 @@ proxy requests using the `X-Forwarded-For` header. The main container starts as
 `root` so its init system can run, but Kubernetes sets the volume group to `1000`
 so Home Assistant can drop privileges. The BlueZ sidecar now drops all
 capabilities and runs unprivileged, reducing risk.
+## Zigbee2MQTT Notes
+
+Zigbee2MQTT accesses the Zigbee adapter on the host. The container runs
+in privileged mode and mounts `/dev/ttyACM0`. Label the `zigbee2mqtt`
+namespace with `pod-security.kubernetes.io/enforce=privileged` so the pod can start.
+
 
 Need help? Check the application examples in `/k8s/applications/` for reference implementations.


### PR DESCRIPTION
## Summary
- allow zigbee2mqtt namespace to run privileged pods
- document the requirement in the application management guide

## Validation
- `kustomize build --enable-helm k8s/applications/automation/zigbee2mqtt`
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685823eab4888322ba6c174172b703ac