### PR TITLE
fix(automation): link to correct home assistant folder

### DIFF
--- a/k8s/applications/automation/kustomization.yaml
+++ b/k8s/applications/automation/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
 - project.yaml
 - frigate
 - mqtt
-- haos/
+- hassio/
 - zigbee2mqtt/


### PR DESCRIPTION
## What & why
- update automation kustomization to use the existing `hassio` directory

## Validation
- `kustomize build --enable-helm k8s/applications/automation`

------
https://chatgpt.com/codex/tasks/task_e_6858244fbd948322a2c714fcba13ec7b