### PR TITLE
fix(k8s): mount hassio secrets file

### DIFF
--- a/k8s/applications/automation/hassio/external-secret.yaml
+++ b/k8s/applications/automation/hassio/external-secret.yaml
@@ -12,6 +12,6 @@ spec:
     name: hassio-secrets
     creationPolicy: Owner
   data:
-    - secretKey: hassio_CONFIG_MQTT_USER
+    - secretKey: secrets.yaml
       remoteRef:
         key: "app-hassio-secrets"

--- a/k8s/applications/automation/hassio/statefulset.yaml
+++ b/k8s/applications/automation/hassio/statefulset.yaml
@@ -49,6 +49,10 @@ spec:
           name: config
         - mountPath: /media
           name: media-volume
+        - name: hassio-secrets
+          mountPath: /config/secrets.yaml
+          subPath: secrets.yaml
+          readOnly: true
         - name: data-volume
           mountPath: /data
         securityContext:
@@ -65,6 +69,9 @@ spec:
       - name: ha-config
         configMap:
           name: home-assistant-config
+      - name: hassio-secrets
+        secret:
+          secretName: hassio-secrets
   volumeClaimTemplates:
   - metadata:
       name: config


### PR DESCRIPTION
## Summary
- mount Home Assistant secrets.yaml from Kubernetes secret
- update `hassio` ExternalSecret to export `secrets.yaml`

## Testing
- `kustomize build --enable-helm k8s/applications/automation/hassio`

------
https://chatgpt.com/codex/tasks/task_e_68586f3184e08322b086309e40cecf24