### PR TITLE
feat(k8s): seed sabnzbd config via ExternalSecret

### DIFF
--- a/k8s/applications/media/sabnzbd/externalsecret.yaml
+++ b/k8s/applications/media/sabnzbd/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sabnzbd-secrets
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: sabnzbd-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: SAB_API_KEY
+      remoteRef: {key: "app-sabnzbd-api-key"}
+    - secretKey: USENET_USERNAME
+      remoteRef: {key: "app-sabnzbd-usenet-username"}
+    - secretKey: USENET_PASSWORD
+      remoteRef: {key: "app-sabnzbd-usenet-password"}

--- a/k8s/applications/media/sabnzbd/kustomization.yaml
+++ b/k8s/applications/media/sabnzbd/kustomization.yaml
@@ -5,6 +5,14 @@ namespace: media
 
 resources:
   - http-route.yaml
+  - externalsecret.yaml
   - statefulset.yaml
   - svc.yaml
+
+configMapGenerator:
+  - name: sabnzbd-seed
+    options:
+      disableNameSuffixHash: true
+    files:
+      - sabnzbd.ini.tpl
 

--- a/k8s/applications/media/sabnzbd/sabnzbd.ini.tpl
+++ b/k8s/applications/media/sabnzbd/sabnzbd.ini.tpl
@@ -1,0 +1,6 @@
+host_whitelist = sabnzbd,sabnzbd.media,sabnzbd.media.svc,sabnzbd.media.svc.cluster.local,sabnzbd.pc-tips.se
+api_key        = ${SAB_API_KEY}
+username       = ${USENET_USERNAME}
+password       = ${USENET_PASSWORD}
+download_dir   = /downloads/incomplete
+complete_dir   = /app/data

--- a/k8s/applications/media/sabnzbd/statefulset.yaml
+++ b/k8s/applications/media/sabnzbd/statefulset.yaml
@@ -23,6 +23,21 @@ spec:
       labels:
         app: sabnzbd
     spec:
+      initContainers:
+        - name: seed-config
+          image: alpine:3.20
+          envFrom:
+            - secretRef: {name: sabnzbd-secrets}
+          command: ["/bin/sh","-c"]
+          args:
+            - |
+              set -e
+              if [ ! -f /config/sabnzbd.ini ]; then
+                envsubst < /seed/sabnzbd.ini.tpl > /config/sabnzbd.ini
+              fi
+          volumeMounts:
+            - {name: seed,           mountPath: /seed}
+            - {name: sabnzbd-config, mountPath: /config}
       containers:
         - name: sabnzbd
           image: ghcr.io/linuxserver/sabnzbd:4.5.1 # renovate: docker=ghcr.io/linuxserver/sabnzbd
@@ -69,6 +84,8 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 3
       volumes:
+        - name: seed
+          configMap: {name: sabnzbd-seed}
         - name: media-share
           persistentVolumeClaim:
             claimName: media-share

--- a/website/docs/applications/sabnzbd.md
+++ b/website/docs/applications/sabnzbd.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 3
+title: SABnzbd
+description: Usenet download client configuration
+---
+
+# SABnzbd
+
+SABnzbd downloads from Usenet and serves as the backend for the *arr applications.
+
+## Secret management
+
+Credentials are stored in Bitwarden. An `ExternalSecret` pulls the API key and Usenet login into a Kubernetes `Secret`.
+
+## Configuration seeding
+
+An init container renders `sabnzbd.ini` from a ConfigMap template. If the file already exists, the container skips seeding.


### PR DESCRIPTION
## Summary
- pull SABnzbd credentials from Bitwarden via ExternalSecret
- generate sabnzbd.ini from a ConfigMap template
- document the new SABnzbd setup

## Testing
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `npm install` *(in website)*
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a7a3891488322aa4f510f27b65cf4