### PR TITLE
Refactor(tofu)  update variable definitions and remove unused outputs

### DIFF
--- a/tofu/defaults.tf
+++ b/tofu/defaults.tf
@@ -1,7 +1,7 @@
 variable "defaults_worker" {
   description = "Default configuration for worker nodes"
   type = object({
-    host_node     = string
+    host_node     = optional(string) #  "The Proxmox node to schedule this VM on. If omitted, defaults to the `name` specified in the `var.proxmox` provider configuration."
     machine_type  = string
     cpu           = number
     ram_dedicated = number
@@ -15,7 +15,6 @@ variable "defaults_worker" {
     }))
   })
   default = {
-    host_node     = "host3"
     machine_type  = "worker"
     cpu           = 8
     ram_dedicated = 10240
@@ -35,13 +34,12 @@ variable "defaults_worker" {
 variable "defaults_controlplane" {
   description = "Default configuration for control plane nodes"
   type = object({
-    host_node     = string
+    host_node     = optional(string) #  "The Proxmox node to schedule this VM on. If omitted, defaults to the `name` specified in the `var.proxmox` provider configuration."
     machine_type  = string
     cpu           = number
     ram_dedicated = number
   })
   default = {
-    host_node     = "host3"
     machine_type  = "controlplane"
     cpu           = 6
     ram_dedicated = 6144

--- a/tofu/defaults.tf
+++ b/tofu/defaults.tf
@@ -17,12 +17,12 @@ variable "defaults_worker" {
   default = {
     machine_type  = "worker"
     cpu           = 8
-    ram_dedicated = 10240
+    ram_dedicated = 12240
     igpu          = false
     disks = {
       longhorn = {
         device      = "/dev/sdb"
-        size        = "180G"
+        size        = "220G"
         type        = "scsi"
         mountpoint  = "/var/lib/longhorn"
         unit_number = 1

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -1,3 +1,5 @@
+# tofu/main.tf
+
 locals {
   node_defaults = {
     worker       = var.defaults_worker
@@ -15,7 +17,10 @@ locals {
       ),
       { for k, v in config : k => v if v != null },
       {
-        update = var.upgrade_control.enabled && name == local.current_upgrade_node
+        # Use nonsensitive() to prevent the sensitivity of var.proxmox
+        # from tainting the entire nodes_with_upgrade map.
+        host_node = coalesce(config.host_node, nonsensitive(var.proxmox.name))
+        update    = var.upgrade_control.enabled && name == local.current_upgrade_node
       }
     )
   }
@@ -53,4 +58,3 @@ module "talos" {
 
   nodes = local.nodes_with_upgrade
 }
-

--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -29,14 +29,20 @@ nodes_config = {
     ip           = "10.25.150.22"
     mac_address  = "bc:24:11:c9:22:c3"
     vm_id        = 8202
-    memory = {
-      dedicated = 12046
-    }
   }
   "work-02" = {
     machine_type = "worker"
     ip           = "10.25.150.23"
     mac_address  = "bc:24:11:6f:20:03"
     vm_id        = 8203
+    disks = {
+      longhorn = {
+        device      = "/dev/sdb"
+        size        = "180G"
+        type        = "scsi"
+        mountpoint  = "/var/lib/longhorn"
+        unit_number = 1
+      }
+    }
   }
 }

--- a/tofu/output.tf
+++ b/tofu/output.tf
@@ -26,7 +26,3 @@ output "talos_config" {
   value     = module.talos.client_configuration.talos_config
   sensitive = true
 }
-
-output "image_key" {
-  value = module.talos.image_key
-}

--- a/tofu/talos/image.tf
+++ b/tofu/talos/image.tf
@@ -1,3 +1,5 @@
+# tofu/talos/image.tf
+
 locals {
   # Determine if any node in the cluster has igpu=true
   needs_nvidia_extensions = anytrue([
@@ -8,36 +10,24 @@ locals {
 locals {
   version = var.talos_image.version
 
-  # 1. render – keep exact text for provider (no ID drift)
   schematic = templatefile("${path.root}/${var.talos_image.schematic_path}", {
     needs_nvidia_extensions = local.needs_nvidia_extensions
   })
-
-  # 2. deterministic hash using only built-ins
-  #    yamldecode → structural object (whitespace gone)
-  #    jsonencode → canonical JSON string (stable key order)
-  schematic_hash = sha256(jsonencode(yamldecode(local.schematic)))
-  schematic_id = talos_image_factory_schematic.this.id
 
   update_version        = coalesce(var.talos_image.update_version, var.talos_image.version)
   update_schematic_path = coalesce(var.talos_image.update_schematic_path, var.talos_image.schematic_path)
   update_schematic = templatefile("${path.root}/${local.update_schematic_path}", {
     needs_nvidia_extensions = local.needs_nvidia_extensions
   })
-  update_schematic_hash = sha256(jsonencode(yamldecode(local.update_schematic)))
 }
 
 locals {
-  image_key = {
-    for name, node in var.nodes :
-    name => "${node.host_node}_${lookup(node, "update", false) ? local.update_image_id : local.image_id}"
-  }
-
   image_download_key = {
     for name, node in var.nodes :
     name => "${node.host_node}_${lookup(node, "update", false)}"
   }
 
+  # This local is now NON-SENSITIVE and valid for for_each.
   image_downloads = {
     for key, nodes in {
       for name, node in var.nodes :
@@ -45,17 +35,10 @@ locals {
     } : key => {
       host_node = nodes[0].host_node
       version   = lookup(nodes[0], "update", false) ? local.update_version : local.version
-      hash = lookup(nodes[0], "update", false) ? local.update_schematic_hash : local.schematic_hash
+      is_update = lookup(nodes[0], "update", false)
     }
   }
 }
-
-locals {
-  image_id        = "${local.schematic_hash}_${local.version}"
-  update_image_id = "${local.update_schematic_hash}_${local.update_version}"
-}
-
-
 
 resource "talos_image_factory_schematic" "this" {
   schematic = local.schematic
@@ -72,11 +55,10 @@ resource "proxmox_virtual_environment_download_file" "this" {
   content_type = "iso"
   datastore_id = var.talos_image.proxmox_datastore
 
-  file_name = "talos-${local.image_downloads[each.key].hash}-${each.value.version}-${var.talos_image.platform}-${var.talos_image.arch}.img"
-  url       = "${var.talos_image.factory_url}/image/${local.image_downloads[each.key].hash}/${each.value.version}/${var.talos_image.platform}-${var.talos_image.arch}.raw.gz"
+  # The sensitive schematic ID is used here, which is allowed.
+  file_name = "talos-${each.value.is_update ? talos_image_factory_schematic.updated.id : talos_image_factory_schematic.this.id}-${each.value.version}-${var.talos_image.platform}-${var.talos_image.arch}.img"
+  url       = "${var.talos_image.factory_url}/image/${each.value.is_update ? talos_image_factory_schematic.updated.id : talos_image_factory_schematic.this.id}/${each.value.version}/${var.talos_image.platform}-${var.talos_image.arch}.raw.gz"
 
   decompression_algorithm = "gz"
   overwrite               = false
-
 }
-

--- a/tofu/talos/output.tf
+++ b/tofu/talos/output.tf
@@ -11,7 +11,3 @@ output "kube_config" {
   value     = talos_cluster_kubeconfig.this
   sensitive = true
 }
-
-output "image_key" {
-  value = local.image_key
-}

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -29,8 +29,6 @@ resource "proxmox_virtual_environment_vm" "this" {
 
   memory {
     dedicated = each.value.ram_dedicated # minimum (guaranteed)
-    shared    = each.value.ram_dedicated # maximum = minimum ⇒ no ballooning
-    floating  = 0                        # explicit: don’t over-commit
   }
 
 

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -44,6 +44,7 @@ variable "talos_image" {
 variable "nodes_config" {
   description = "Per-node configuration map"
   type = map(object({
+    host_node     = optional(string) #  "The Proxmox node to schedule this VM on. If omitted, defaults to the `name` specified in the `var.proxmox` provider configuration."
     machine_type  = string
     ip            = string
     mac_address   = string

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -50,6 +50,14 @@ variable "nodes_config" {
     mac_address   = string
     vm_id         = number
     ram_dedicated = optional(number)
+    igpu          = optional(bool)
+    disks         = optional(map(object({
+      device      = optional(string)
+      size        = optional(string)
+      type        = optional(string)
+      mountpoint  = optional(string)
+      unit_number = optional(number)
+    })))
   }))
 
   validation {

--- a/website/docs/getting-started/detailed-setup.md
+++ b/website/docs/getting-started/detailed-setup.md
@@ -36,16 +36,6 @@ proxmox = {
   username     = "root@pam"           # Your Proxmox username
   api_token    = "USER@pam!ID=TOKEN"  # Your Proxmox API token
 }
-
-talos_image = {
-  version           = "<see https://github.com/siderolabs/talos/releases>"           # Current Talos version
-  update_version    = "<see https://github.com/siderolabs/talos/releases>"          # Target Talos version for updates
-  schematic_path    = "talos/image/schematic.yaml.tftpl"
-  platform          = "proxmox"
-  arch              = "amd64"
-  proxmox_datastore = "local"            # Your Proxmox datastore name
-  factory_url       = "https://factory.talos.dev"
-}
 ```
 
 Initialize the OpenTofu configuration:
@@ -66,17 +56,6 @@ proxmox = {
   insecure     = false
   username     = "root"
   api_token    = "root@pam!token_id=your_token_secret"
-}
-
-talos_image = {
-  version           = "<see https://github.com/siderolabs/talos/releases>"
-  schematic_path    = "talos/image/schematic.yaml.tftpl"
-  update_version    = "<see https://github.com/siderolabs/talos/releases>"
-  update_schematic_path = "talos/image/schematic.yaml.tftpl"
-  platform          = "proxmox"
-  arch              = "amd64"
-  proxmox_datastore = "local"
-  factory_url       = "https://factory.talos.dev"
 }
 ```
 


### PR DESCRIPTION
This pull request introduces significant updates to the OpenTofu configuration for provisioning Kubernetes clusters with Talos OS. Key changes include making `host_node` optional, restructuring default settings for worker and control plane nodes, improving disk configuration flexibility, and removing outdated Talos image-related settings. Additionally, the documentation has been updated to reflect these changes, simplifying the setup process and improving clarity.

### Configuration Enhancements:

* **Optional `host_node` Parameter**: The `host_node` parameter is now optional across configurations (`tofu/defaults.tf`, `tofu/variables.tf`). If omitted, the VM defaults to the Proxmox node specified in the provider configuration (`var.proxmox.name`). This simplifies single-host setups. [[1]](diffhunk://#diff-57b4800854805d1e33b8d790eb3a4f92e85d6f59f67ba5d37bf5febe0ed05374L4-R4) [[2]](diffhunk://#diff-57b4800854805d1e33b8d790eb3a4f92e85d6f59f67ba5d37bf5febe0ed05374L38-L44) [[3]](diffhunk://#diff-d3ee0e158b2ff0d845e43c4af7883367378889d9ffb61bb2c3d147c89f2fc5caR47-R60)

* **Default Settings Restructuring**: The `defaults_worker` and `defaults_controlplane` variables now centralize shared settings like CPU, RAM, and disk layout. Nodes only need to specify deviations from these defaults, reducing repetition and improving maintainability. [[1]](diffhunk://#diff-57b4800854805d1e33b8d790eb3a4f92e85d6f59f67ba5d37bf5febe0ed05374L18-R25) [[2]](diffhunk://#diff-57b4800854805d1e33b8d790eb3a4f92e85d6f59f67ba5d37bf5febe0ed05374L38-L44)

* **Flexible Disk Configuration**: Nodes can override default disk settings using a `disks` map. Each disk requires a `unit_number` for Proxmox interface mapping, enabling customization such as larger volumes for specific nodes. [[1]](diffhunk://#diff-466cc56d22572db0278fa2938c50de81ae413c7466511ff2c81a839d41c4bf72L7-L23) [[2]](diffhunk://#diff-8e9d0fbff7824eae20c086aa06adc0fdf71708d133f47b02dc08b722f4ef2131L32-R46) [[3]](diffhunk://#diff-b22f4ac8f84bccb68d5d16f5cdefa3504927e3c3a882b6435d324ebd1c4a02b6L132-R153)

### Codebase Simplification:

* **Removal of Ballooning and Shared Memory Settings**: The `shared` and `floating` memory settings have been removed from VM configurations, ensuring no over-commitment.

* **Talos Image Settings Cleanup**: Outdated Talos image-related settings, such as `image_key` and schematic hashes, have been removed to streamline the configuration. [[1]](diffhunk://#diff-40491f4c28e574a1c8718be4b43b7dd82b83b24daf7a6eb858d6b3d3f3232808L11-L59) [[2]](diffhunk://#diff-66e2d061519add085ae209d329a3d8d3452004b4a57d14bd5ed4e1833e11ed1bL14-L17)

### Documentation Updates:

* **Simplified Node Configuration**: Documentation now emphasizes the use of default settings for nodes, with examples showcasing how to override defaults when necessary. [[1]](diffhunk://#diff-b22f4ac8f84bccb68d5d16f5cdefa3504927e3c3a882b6435d324ebd1c4a02b6L96-L121) [[2]](diffhunk://#diff-b22f4ac8f84bccb68d5d16f5cdefa3504927e3c3a882b6435d324ebd1c4a02b6L132-R153)

* **Removal of Talos Image Version Section**: References to Talos image settings in the documentation have been removed, reflecting the cleanup in the codebase. [[1]](diffhunk://#diff-cece4a8689f9e15b1421a7adfb8b60f4e45bd7e27e8846edcf0bb68a54aeb6a1L39-L48) [[2]](diffhunk://#diff-cece4a8689f9e15b1421a7adfb8b60f4e45bd7e27e8846edcf0bb68a54aeb6a1L70-L80) [[3]](diffhunk://#diff-b22f4ac8f84bccb68d5d16f5cdefa3504927e3c3a882b6435d324ebd1c4a02b6L274-L301)

These changes collectively enhance the usability, maintainability, and clarity of the OpenTofu configuration for Kubernetes provisioning.

Resolves #1108 