### PR TITLE
feat(auth): configure kubectl oidc via authentik

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-kubernetes.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-kubernetes.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable-file
+# prettier-ignore-start
+# eslint-disable
+---
+version: 1
+metadata:
+  name: Apps - Kubernetes
+entries:
+  - id: kubectl-users-group
+    model: authentik_core.group
+    identifiers:
+      name: Kubectl Users
+    attrs:
+      name: Kubectl Users
+  - id: kubectl_provider
+    model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: k8s.pc-tips.se/kubectl
+    attrs:
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-authorization-implicit-consent"],
+        ]
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, "authentik Self-signed Certificate"],
+        ]
+      invalidation_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-invalidation-flow"],
+        ]
+      client_type: confidential
+      client_id: !Env KUBECTL_CLIENT_ID
+      client_secret: !Env KUBECTL_CLIENT_SECRET
+      redirect_uris:
+        - url: http://localhost:8000
+          matching_mode: exact
+      access_code_validity: minutes=1
+      access_token_validity: minutes=5
+      refresh_token_validity: days=30
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
+  - id: kubectl_application
+    model: authentik_core.application
+    identifiers:
+      slug: kubectl
+    attrs:
+      name: Kubernetes API
+      group: Infrastructure
+      description: Cluster access via kubectl
+      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/kubernetes.png
+      provider: !KeyOf kubectl_provider
+      policy_engine_mode: any
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf kubectl_application
+      group: !Find [authentik_core.group, [name, "Kubectl Users"]]
+    attrs:
+      order: 1

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
@@ -73,3 +73,9 @@ entries:
       name: Karakeep Users
     attrs:
       name: Karakeep Users
+  - id: kubectl-users
+    model: authentik_core.group
+    identifiers:
+      name: Kubectl Users
+    attrs:
+      name: Kubectl Users

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/users.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/users.yaml
@@ -30,6 +30,7 @@ entries:
         - !Find [authentik_core.group, [name, "Media Users"]]
         - !Find [authentik_core.group, [name, "Open WebUI Users"]]
         - !Find [authentik_core.group, [name, "Karakeep Users"]]
+        - !Find [authentik_core.group, [name, "Kubectl Users"]]
 
   - id: user-standard
     model: authentik_core.user
@@ -50,3 +51,4 @@ entries:
         - !Find [authentik_core.group, [name, "Media Users"]]
         - !Find [authentik_core.group, [name, "Open WebUI Users"]]
         - !Find [authentik_core.group, [name, "Karakeep Users"]]
+        - !Find [authentik_core.group, [name, "Kubectl Users"]]

--- a/k8s/infrastructure/auth/authentik/extra/kustomization.yml
+++ b/k8s/infrastructure/auth/authentik/extra/kustomization.yml
@@ -19,6 +19,7 @@ configMapGenerator:
       - ./blueprints/apps-media.yaml
       - ./blueprints/apps-openwebui.yaml
       - ./blueprints/apps-karakeep.yaml
+      - ./blueprints/apps-kubernetes.yaml
       - ./blueprints/groups.yaml
       - ./blueprints/users.yaml
       - ./blueprints/brands.yaml

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -43,13 +43,11 @@ cluster:
   allowSchedulingOnControlPlanes: false
   clusterName: ${cluster_domain}
   apiServer:
-    # extraArgs:
-    #   oidc-issuer-url: https://authelia.${cluster_domain}
-    #   oidc-client-id: kubectl
-    #   oidc-username-claim: preferred_username
-    #   oidc-username-prefix: 'authelia:'
-    #   oidc-groups-claim: groups
-    #   oidc-groups-prefix: 'authelia:'
+    extraArgs:
+      oidc-issuer-url: https://sso.${cluster_domain}/application/o/kubectl/
+      oidc-client-id: kubectl
+      oidc-username-claim: preferred_username
+      oidc-groups-claim: groups
   network:
     dnsDomain: ${cluster_domain}
     cni:

--- a/website/docs/infrastructure/auth/authentik-setup.md
+++ b/website/docs/infrastructure/auth/authentik-setup.md
@@ -34,6 +34,21 @@ graph LR
     C -.-> F[Authentik Server]
 ```
 
+## Kubernetes API Authentication
+
+Cluster logins go through Authentik using a dedicated OAuth2 provider:
+
+```yaml
+apiServer:
+  extraArgs:
+    oidc-issuer-url: https://sso.your.domain.tld/application/o/kubectl/
+    oidc-client-id: kubectl
+    oidc-username-claim: preferred_username
+    oidc-groups-claim: groups
+```
+
+Add your users to the **Kubectl Users** group in Authentik to grant access.
+
 ## Blueprint Users
 
 Two sample accounts are bootstrapped via Authentik blueprints to show how group membership controls access:


### PR DESCRIPTION
## Summary
- create kubectl provider blueprint
- add Kubectl Users group and assign it to sample users
- enable OIDC in Talos control plane
- document Kubernetes API auth with Authentik

## Testing
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`
- `kustomize build --enable-helm k8s/infrastructure/auth`
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: Missing script 'lint')*
- `tofu fmt`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_685bea517e5c832283d114aee49e9186