### PR TITLE
feat(openwebui): merge oauth accounts by email

### DIFF
--- a/k8s/applications/ai/openwebui/webui-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/webui-statefulset.yaml
@@ -84,6 +84,8 @@ spec:
               value: 'https://chat.pc-tips.se/oauth/oidc/callback'
             - name: ENABLE_OAUTH_SIGNUP
               value: 'true'
+            - name: OAUTH_MERGE_ACCOUNTS_BY_EMAIL
+              value: 'true'
           tty: true
           livenessProbe:
             httpGet:

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -114,8 +114,7 @@ I use NFS for shared media files:
 
 ## OpenWebUI Notes
 
-OpenWebUI provides a chat interface backed by local AI models. The deployment integrates with Authentik using OIDC. The
-`OLLAMA_BASE_URL` variable is intentionally omitted because the Ollama stack is not managed in this repository.
+OpenWebUI provides a chat interface backed by local AI models. The deployment integrates with Authentik using OIDC and merges accounts by email so users can sign in with any provider. The `OLLAMA_BASE_URL` variable is intentionally omitted because the Ollama stack is not managed in this repository.
 
 Chrome and Ollama define both liveness and readiness probes so Kubernetes can restart them if they crash and only route traffic when each pod is ready.
 Mosquitto and Unrar use similar probes. Pedro Bot relies on PersistentVolumeClaims for logs and data, and Jellyfin and Unrar can run on any available node.


### PR DESCRIPTION
## Summary
- allow OpenWebUI OAuth accounts to merge by email
- note new OAuth behaviour in application docs

## Testing
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c73fae8588322a985efcd60576d78