### PR TITLE
feat(k8s): configure GPU node runtime and taints

### DIFF
--- a/k8s/infrastructure/controllers/nvidia-device-plugin/device-plugin/values.yaml
+++ b/k8s/infrastructure/controllers/nvidia-device-plugin/device-plugin/values.yaml
@@ -8,3 +8,4 @@ gfd:
   enabled: true                 # auto-label GPU features
 timeSlicing:
   enabled: false
+runtimeClassName: nvidia

--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -53,6 +53,7 @@ nodes_config = {
     ram_dedicated = 4168
     datastore_id  = "rpool2"
     igpu          = true
+    gpu_node_exclusive = true
     gpu_devices   = ["0000:03:00.0", "0000:03:00.1"]
     gpu_device_meta = {
       "0000:03:00.0" = {

--- a/tofu/talos/machine-config/worker.yaml.tftpl
+++ b/tofu/talos/machine-config/worker.yaml.tftpl
@@ -22,10 +22,19 @@ machine:
           - rw
 %{ endfor }
 %{ endif }
-    %{ if igpu && gpu_node_exclusive }
+  %{ if igpu && gpu_node_exclusive }
   nodeTaints:
-    gpu: "true:NoSchedule"
-%{ endif }
+    - key: "gpu"
+      value: "true"
+      effect: "NoSchedule"
+  %{ endif }
+  runtime:
+    name: containerd
+    config:
+      defaultRuntimeName: nvidia
+      runtimes:
+        - name: nvidia
+          path: nvidia-container-runtime
   sysctls:
     vm.nr_hugepages: "1024"
   kernel:

--- a/website/docs/infrastructure/controllers/gpu-support.md
+++ b/website/docs/infrastructure/controllers/gpu-support.md
@@ -21,5 +21,7 @@ Key components and configurations:
 *   **NVIDIA Device Plugin**: Deployed via a Helm chart, it allows Kubernetes to expose NVIDIA GPUs as a schedulable resource.
 *   **RuntimeClass `nvidia`**: A `RuntimeClass` named `nvidia` is created to enable pods to utilize the NVIDIA container runtime, which is necessary for GPU acceleration.
 *   **Kustomization**: The `nvidia-gpu` components are included in the controllers `kustomization.yaml` under `k8s/infrastructure/controllers/nvidia-gpu/`.
+*   **Containerd Runtime Configuration**: Worker nodes load the `nvidia-container-runtime` so GPU workloads can run without extra Pod tweaks.
+*   **GPU Node Taint**: The GPU worker can be marked with a `gpu=true:NoSchedule` taint, reserving it for GPU-aware pods.
 
 This setup ensures that GPU-enabled nodes are properly identified and that applications requiring GPU resources can be scheduled and executed efficiently within the Kubernetes cluster.

--- a/website/docs/tofu/gpu-passthrough.md
+++ b/website/docs/tofu/gpu-passthrough.md
@@ -186,7 +186,7 @@ dynamic "hostpci" {
 
 ### 5. Talos Machine Configuration (`worker.yaml.tftpl`)
 
-The Talos machine configuration template (`tofu/talos/machine-config/worker.yaml.tftpl`) needs to include the `nodeTaints` field under the `machine.kubelet` block to apply node taints. Previously, `taints` was incorrectly placed directly under `machine`, leading to YAML unmarshalling errors. The correct placement, as per Talos documentation, is under `machine.kubelet`.
+The Talos machine configuration template (`tofu/talos/machine-config/worker.yaml.tftpl`) must include a `nodeTaints` section in the `machine` block. Earlier versions placed `taints` elsewhere, which caused YAML unmarshalling errors.
 
 ```yaml
 machine:
@@ -195,8 +195,17 @@ machine:
 %{ if igpu && gpu_node_exclusive ~}
 { endif }
   nodeTaints:
-    gpu: "true:NoSchedule"
+    - key: "gpu"
+      value: "true"
+      effect: "NoSchedule"
 %{ endif ~}
+  runtime:
+    name: containerd
+    config:
+      defaultRuntimeName: nvidia
+      runtimes:
+        - name: nvidia
+          path: nvidia-container-runtime
   kernel:
     modules: # These modules will be loaded on all worker nodes
       - name: nvme_tcp # NVMe over TCP, generally useful for storage


### PR DESCRIPTION
## Summary
- configure worker runtime to use nvidia-container-runtime
- taint GPU node via variable
- set runtimeClassName for nvidia device plugin
- document GPU taint and runtime requirements

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*
- `tofu validate`
- `kustomize build --enable-helm k8s/infrastructure/controllers/nvidia-device-plugin`

------
https://chatgpt.com/codex/tasks/task_e_685fc7f9cb04832280e147f8fe7e7b54