### PR TITLE
feat(k8s): persist mosquitto data and tighten policies

### DIFF
--- a/k8s/applications/automation/hassio/namespace.yaml
+++ b/k8s/applications/automation/hassio/namespace.yaml
@@ -3,8 +3,6 @@ kind: Namespace
 metadata:
   name: home-assistant
   labels:
-      # ENFORCE privileged because this pod needs hardware access
-      pod-security.kubernetes.io/enforce: privileged
-      # AUDIT and WARN against baseline to still get feedback on best practices.
-      pod-security.kubernetes.io/audit: baseline
-      pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/k8s/applications/automation/mqtt/configmap.yaml
+++ b/k8s/applications/automation/mqtt/configmap.yaml
@@ -8,3 +8,5 @@ data:
     listener 1883
     allow_anonymous false
     password_file /mosquitto/config/password.txt
+    persistence true
+    persistence_location /mosquitto/data

--- a/k8s/applications/automation/mqtt/kustomization.yaml
+++ b/k8s/applications/automation/mqtt/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - namespace.yaml
 - configmap.yaml
 - externalsecret.yaml
-- deployment.yaml
+- statefulset.yaml
 - service.yaml
 generatorOptions:
   disableNameSuffixHash: true

--- a/k8s/applications/automation/mqtt/statefulset.yaml
+++ b/k8s/applications/automation/mqtt/statefulset.yaml
@@ -1,9 +1,12 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mosquitto
   namespace: mqtt
+  labels:
+    app: mosquitto
 spec:
+  serviceName: mosquitto
   replicas: 1
   selector:
     matchLabels:
@@ -26,6 +29,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /mosquitto/config
+            - name: data
+              mountPath: /mosquitto/data
           ports:
             - containerPort: 1883
           livenessProbe:
@@ -50,3 +55,12 @@ spec:
                   name: mosquitto-config
               - secret:
                   name: mosquitto-password
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 1Gi

--- a/k8s/applications/automation/zigbee2mqtt/config/configuration.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/config/configuration.yaml
@@ -2,8 +2,6 @@ homeassistant:
   enabled: true
 mqtt:
   server: mqtt://mosquitto:1883
-  user: addons
-  password: password
 serial:
   port: tcp://10.0.10.160:20108
   adapter: deconz

--- a/k8s/applications/automation/zigbee2mqtt/deployment.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/deployment.yaml
@@ -48,8 +48,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            # - name: zigbee-stick
-            #   mountPath: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2426266-if00
           livenessProbe:
             tcpSocket:
               port: 8080
@@ -76,8 +74,3 @@ spec:
         - name: config-template
           configMap:
             name: zigbee2mqtt-config
-        # This securely passes the host's USB device to the container without privileged mode.
-        # - name: zigbee-stick
-        #   hostPath:
-        #     path: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2426266-if00
-        #     type: CharDevice

--- a/k8s/applications/automation/zigbee2mqtt/namespace.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/namespace.yaml
@@ -3,8 +3,6 @@ kind: Namespace
 metadata:
   name: zigbee2mqtt
   labels:
-    # ENFORCE privileged because this pod needs hardware access via hostPath to /dev.
-    pod-security.kubernetes.io/enforce: privileged
-    # AUDIT and WARN against baseline to still get feedback on best practices.
+    pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: baseline
     pod-security.kubernetes.io/warn: baseline

--- a/website/docs/k8s/applications/application-management.md
+++ b/website/docs/k8s/applications/application-management.md
@@ -141,9 +141,9 @@ so Home Assistant can drop privileges. The BlueZ sidecar now drops all
 capabilities and runs unprivileged, reducing risk.
 ## Zigbee2MQTT Notes
 
-Zigbee2MQTT accesses the Zigbee adapter on the host. The container runs
-in privileged mode and mounts `/dev/ttyACM0`. Label the `zigbee2mqtt`
-namespace with `pod-security.kubernetes.io/enforce=privileged` so the pod can start.
+Zigbee2MQTT manages the Zigbee adapter without privileged mode. The
+`zigbee2mqtt` namespace is labeled `pod-security.kubernetes.io/enforce=baseline` so
+it adheres to the cluster's standard policies.
 
 
 Need help? Check the application examples in `/k8s/applications/` for reference implementations.


### PR DESCRIPTION
## What & why
- convert Mosquitto to a StatefulSet with a persistent volume
- enforce baseline Pod Security for Home Assistant and Zigbee2MQTT
- clean up Zigbee2MQTT config and remove hardcoded MQTT credentials
- document the new Zigbee2MQTT security posture

## Validation
- `kustomize build --enable-helm k8s/applications/automation/mqtt`
- `kustomize build --enable-helm k8s/applications/automation/hassio`
- `kustomize build --enable-helm k8s/applications/automation/zigbee2mqtt`
- `npm install && npm run typecheck` in `website/`
- `npm run lint` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_685fff53449c8322abee1b070da4ad62