### PR TITLE
feat(tofu): unify proxmox_datastore variable for Talos node configura…

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -21,8 +21,9 @@ locals {
         }
       },
       {
-        host_node = coalesce(config.host_node, nonsensitive(var.proxmox.name))
-        update    = var.upgrade_control.enabled && name == local.current_upgrade_node
+        host_node    = coalesce(config.host_node, nonsensitive(var.proxmox.name))
+        update       = var.upgrade_control.enabled && name == local.current_upgrade_node
+        datastore_id = coalesce(lookup(config, "datastore_id", null), var.proxmox_datastore)
       }
     )
   }
@@ -33,6 +34,8 @@ module "talos" {
   providers = {
     proxmox = proxmox
   }
+
+  proxmox_datastore = var.proxmox_datastore
 
   talos_image = var.talos_image
 

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -29,13 +29,18 @@ variable "cluster_domain" {
   type        = string
 }
 
+variable "proxmox_datastore" {
+  description = "Proxmox datastore to use for VM disks"
+  type        = string
+  default     = "velocity"
+}
 
 variable "nodes" {
   description = "Configuration for cluster nodes"
   type = map(object({
     host_node     = string
     machine_type  = string
-    datastore_id  = optional(string, "velocity")
+    datastore_id  = optional(string)
     ip            = string
     mac_address   = string
     vm_id         = number

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -127,3 +127,10 @@ variable "nodes_config" {
     error_message = "Every BDF in gpu_devices must exist in gpu_device_meta."
   }
 }
+
+variable "proxmox_datastore" {
+  description = "Default Proxmox datastore for all nodes"
+  type        = string
+  default     = "velocity"
+}
+


### PR DESCRIPTION
…tion

Introduce a top-level proxmox_datastore variable and refactor node and module definitions to use it consistently. Defaults to "velocity" for backward compatibility. This centralizes datastore configuration for Proxmox VMs and simplifies node definitions.