### PR TITLE
fix(k8s): align home-assistant ports and capabilities

### DIFF
--- a/k8s/applications/automation/hassio/statefulset.yaml
+++ b/k8s/applications/automation/hassio/statefulset.yaml
@@ -59,7 +59,12 @@ spec:
             memory: "1Gi"
           limits:
             memory: "3Gi"
-        securityContext: {}
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN     # allows interface promiscuous mode & multicast group joins
+              - NET_RAW       # allows open/listen on raw sockets (ARP, SSDP, mDNS, etc.)
+              - NET_BROADCAST # allows sending broadcast packets
         volumeMounts:
         - mountPath: /config
           name: home-assistant

--- a/k8s/applications/automation/hassio/svc.yaml
+++ b/k8s/applications/automation/hassio/svc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: 8123
     protocol: TCP
     targetPort: http
   selector:

--- a/website/docs/applications/home-assistant.md
+++ b/website/docs/applications/home-assistant.md
@@ -7,4 +7,4 @@ Home Assistant is an open-source home automation platform that focuses on local 
 
 ## Important considerations
 
-- **Pod Security Context:** The Home Assistant pod's security context has been configured to drop all capabilities and does not include `NET_RAW`. This adheres to the `baseline:latest` PodSecurity policy.
+- **Pod Security Context:** The container now adds `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` so Home Assistant can discover devices on the local network.


### PR DESCRIPTION
## Summary
- allow Home Assistant L2 discovery with NET_ADMIN/NET_RAW/NET_BROADCAST
- expose Home Assistant on 8123 to match HTTPRoute
- update docs for new capabilities

## Validation
- `kustomize build --enable-helm k8s/applications/automation/hassio`
- `kustomize build --enable-helm k8s/applications/automation`
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68624a8695b4832285bc97cb6ce9ae18