### PR TITLE
refactor(config): centralize cluster configuration into variables

### DIFF
--- a/tofu/config.auto.tfvars
+++ b/tofu/config.auto.tfvars
@@ -1,0 +1,30 @@
+// tofu/config.tfvars.example
+
+cluster_name   = "talos"
+cluster_domain = "kube.pc-tips.se"
+
+# Network settings
+# All nodes must be on the same L2 network
+network = {
+  gateway     = "10.25.150.1"
+  vip         = "10.25.150.10" # Control plane Virtual IP
+  cidr_prefix = 24
+  dns_servers = ["10.25.150.1"]
+  bridge      = "vmbr0"
+  vlan_id     = 150
+}
+
+# Proxmox settings
+proxmox_cluster = "host3"
+
+# Software versions
+versions = {
+  talos      = "v1.10.3"
+  kubernetes = "1.33.2"
+}
+
+# OIDC settings (optional)
+oidc = {
+  issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
+  client_id  = "kubectl"
+}

--- a/tofu/locals.tf
+++ b/tofu/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  cluster_domain = "kube.pc-tips.se"
-}

--- a/tofu/talos/config-machine.tf
+++ b/tofu/talos/config-machine.tf
@@ -18,6 +18,8 @@ data "talos_machine_configuration" "this" {
       cilium_values   = var.cilium.values
       cilium_install  = var.cilium.install
       coredns_install = var.coredns.install
+      oidc            = var.oidc
+      vip             = var.network.vip
     })
   ] : concat(
     [
@@ -31,6 +33,7 @@ data "talos_machine_configuration" "this" {
         disks              = each.value.disks
         igpu               = each.value.igpu
         gpu_node_exclusive = lookup(each.value, "gpu_node_exclusive", false)
+        vip                = var.network.vip
       })
     ],
     # This conditionally adds the GPU patches

--- a/tofu/talos/inline-manifests/coredns-install.yaml.tftpl
+++ b/tofu/talos/inline-manifests/coredns-install.yaml.tftpl
@@ -31,14 +31,14 @@ data:
         prometheus :9153
 
         # Kubernetes service domain
-        kubernetes cluster.local kube.pc-tips.se in-addr.arpa ip6.arpa {
+        kubernetes cluster.local ${cluster_domain} in-addr.arpa ip6.arpa {
             pods insecure
             ttl 30
             fallthrough
         }
 
         # Forwarding to external DNS servers for non-cluster queries
-        forward . 10.25.150.1 1.1.1.1 8.8.8.8 {
+        forward . ${dns_forwarders} {
             policy sequential
         }
 

--- a/tofu/talos/machine-config/control-plane.yaml.tftpl
+++ b/tofu/talos/machine-config/control-plane.yaml.tftpl
@@ -1,6 +1,6 @@
 machine:
   certSANs:
-    - ${cluster.vip}     # The VIP
+    - ${vip}
     - ${node_ip}      # The node's own IP
     - ${cluster.endpoint}
 
@@ -31,7 +31,7 @@ machine:
       - interface: eth0
         dhcp: true
         vip:
-          ip: ${cluster.vip}
+          ip: ${vip}
 
   nodeLabels:
     topology.kubernetes.io/region: ${cluster_name}
@@ -43,11 +43,13 @@ cluster:
   allowSchedulingOnControlPlanes: false
   clusterName: ${cluster_domain}
   apiServer:
+%{ if oidc != null }
     extraArgs:
-      oidc-issuer-url: https://sso.${cluster_domain}/application/o/kubectl/
-      oidc-client-id: kubectl
+      oidc-issuer-url: ${oidc.issuer_url}
+      oidc-client-id: ${oidc.client_id}
       oidc-username-claim: preferred_username
       oidc-groups-claim: groups
+%{ endif }
   network:
     dnsDomain: ${cluster_domain}
     cni:

--- a/tofu/talos/machine-config/worker.yaml.tftpl
+++ b/tofu/talos/machine-config/worker.yaml.tftpl
@@ -1,6 +1,6 @@
 machine:
   certSANs:
-    - ${cluster.vip}
+    - ${vip}
     - ${node_ip}
     - ${cluster.endpoint}
 

--- a/tofu/talos/variables.tf
+++ b/tofu/talos/variables.tf
@@ -16,8 +16,7 @@ variable "cluster" {
   type = object({
     name               = string
     endpoint           = string
-    gateway            = string
-    vip                = string
+    # gateway and vip are now in var.network
     talos_version      = string
     proxmox_cluster    = string
     kubernetes_version = optional(string, "1.32.0")
@@ -27,6 +26,27 @@ variable "cluster" {
 variable "cluster_domain" {
   description = "Internal cluster domain"
   type        = string
+}
+
+variable "network" {
+  description = "Network configuration for the cluster."
+  type = object({
+    gateway     = string
+    vip         = string
+    cidr_prefix = number
+    dns_servers = list(string)
+    bridge      = string
+    vlan_id     = number
+  })
+}
+
+variable "oidc" {
+  description = "Optional OIDC provider configuration."
+  type = object({
+    issuer_url = string
+    client_id  = string
+  })
+  default = null
 }
 
 variable "proxmox_datastore" {

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -40,8 +40,8 @@ resource "proxmox_virtual_environment_vm" "this" {
 
 
   network_device {
-    bridge      = lookup(each.value, "network_bridge", "vmbr0")
-    vlan_id     = lookup(each.value, "network_vlan_id", 150)
+    bridge      = lookup(each.value, "network_bridge", var.network.bridge)
+    vlan_id     = lookup(each.value, "network_vlan_id", var.network.vlan_id)
     mac_address = each.value.mac_address
   }
 
@@ -93,12 +93,12 @@ resource "proxmox_virtual_environment_vm" "this" {
     datastore_id = each.value.datastore_id
     dns {
       domain  = var.cluster_domain
-      servers = lookup(each.value, "dns_servers", ["10.25.150.1"])
+      servers = lookup(each.value, "dns_servers", var.network.dns_servers)
     }
     ip_config {
       ipv4 {
-        address = "${each.value.ip}/24"
-        gateway = var.cluster.gateway
+        address = "${each.value.ip}/${var.network.cidr_prefix}"
+        gateway = var.network.gateway
       }
     }
   }

--- a/tofu/terraform.tfvars.example
+++ b/tofu/terraform.tfvars.example
@@ -1,0 +1,9 @@
+proxmox = {
+  name         = "node" # Name of the Proxmox node
+  cluster_name = "node" # Must match the Proxmox cluster name
+  endpoint     = "https://node.example.com:8006"
+  insecure     = false
+  username     = "root"
+  api_token    = "root@pam!secret"
+}
+# The Proxmox API token format is: <username>@<realm>!<name>=<token>

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -133,3 +133,47 @@ variable "proxmox_datastore" {
   default     = "velocity"
 }
 
+variable "cluster_name" {
+  description = "The name of the Talos cluster."
+  type        = string
+}
+
+variable "cluster_domain" {
+  description = "The domain for the cluster (e.g., kube.example.com)."
+  type        = string
+}
+
+variable "network" {
+  description = "Network configuration for the cluster."
+  type = object({
+    gateway     = string
+    vip         = string
+    cidr_prefix = number
+    dns_servers = list(string)
+    bridge      = string
+    vlan_id     = number
+  })
+}
+
+variable "proxmox_cluster" {
+  description = "The name of the Proxmox cluster."
+  type        = string
+}
+
+variable "versions" {
+  description = "Software versions for the cluster components."
+  type = object({
+    talos      = string
+    kubernetes = string
+  })
+}
+
+variable "oidc" {
+  description = "Optional OIDC provider configuration for Kubernetes API server."
+  type = object({
+    issuer_url = string
+    client_id  = string
+  })
+  default = null # Make it optional
+}
+

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -42,7 +42,35 @@ If you fork it, search for these domains and replace them with your own.
    ```
 
 2. **Configure cluster variables:**
-   Edit or create the `config.auto.tfvars` file to define your cluster nodes:
+
+- Configure the proxmox environment and cluster settings in the `tofu` directory
+  - Copy the `terraform.tfvars.example` file to `terraform.tfvars`:
+  - Edit or create the `config.auto.tfvars` file to define your cluster nodes:
+
+    ```bash
+    cp tofu/terraform.tfvars.example tofu/terraform.tfvars
+    ```
+
+  - Edit the `tofu/terraform.tfvars` file to match your Proxmox setup and cluster details:
+
+    ```hcl
+    // tofu/terraform.tfvars example
+
+   proxmox = {
+   name         = "node" # Name of the Proxmox node
+   cluster_name = "node" # Must match the Proxmox cluster name
+   endpoint     = "<https://node.example.com:8006>"
+   insecure     = false
+   username     = "root"
+   api_token    = "root@pam!secret"
+   }
+
+   ```
+
+   :::info
+   Use secure storage for secrets, like 1Password or Bitwarden, and avoid committing sensitive files. For more information, see the [Argo CD Secrets Management](<https://argo-cd.readthedocs.io>
+
+  - Edit or create the `config.auto.tfvars` file to define your cluster nodes:
 
    ```hcl
    // tofu/config.auto.tfvars example
@@ -53,12 +81,12 @@ If you fork it, search for these domains and replace them with your own.
    # Network settings
    # All nodes must be on the same L2 network
    network = {
-     gateway     = "10.25.150.1"
-     vip         = "10.25.150.10" # Control plane Virtual IP
-     cidr_prefix = 24
-     dns_servers = ["10.25.150.1"]
-     bridge      = "vmbr0"
-     vlan_id     = 150
+   gateway     = "10.25.150.1"
+   vip         = "10.25.150.10" # Control plane Virtual IP
+   cidr_prefix = 24
+   dns_servers = ["10.25.150.1"]
+   bridge      = "vmbr0"
+   vlan_id     = 150
    }
 
    # Proxmox settings
@@ -66,14 +94,14 @@ If you fork it, search for these domains and replace them with your own.
 
    # Software versions
    versions = {
-     talos      = "v1.10.3"
-     kubernetes = "1.33.2"
+   talos      = "v1.10.3"
+   kubernetes = "1.33.2"
    }
 
    # OIDC settings (optional)
    oidc = {
-     issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
-     client_id  = "kubectl"
+   issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
+   client_id  = "kubectl"
    }
    ```
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -136,47 +136,6 @@ If you fork it, search for these domains and replace them with your own.
    chmod 600 ~/.talos/config ~/.kube/config
    ```
 
-## Bootstrap and verify ArgoCD
-
-6. **Check or install ArgoCD:**
-   ArgoCD is usually installed automatically. To verify or re-apply manually:
-
-   ```bash
-   kubectl get pods -n argocd
-   # If ArgoCD pods aren't running, install with:
-   kubectl apply -k k8s/infrastructure/controllers/argocd
-   ```
-
-7. **Monitor ApplicationSet synchronization:**
-   Use the ArgoCD CLI to confirm apps are recognized and syncing.
-
-   ```bash
-   argocd app list
-   ```
-
-## Verify the setup
-
-1. **Check node and service health:**
-
-   ```bash
-   talosctl health --talosconfig ~/.talos/config --nodes <control-plane-IP>
-   ```
-
-   All checks should report `healthy`.
-
-2. **Confirm apps are synced in ArgoCD UI:**
-   All applications should show *Synced / Healthy* status.
-
-3. **Inspect ArgoCD logs (optional troubleshooting):**
-
-   ```bash
-   kubectl logs -n argocd deployment/argocd-server
-   ```
-
-   Look for messages indicating healthy reconciliation.
-
----
-
 ## Pro tips and troubleshooting
 
 - **To recreate a node (e.g., after resizing a disk):**

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -42,13 +42,39 @@ If you fork it, search for these domains and replace them with your own.
    ```
 
 2. **Configure cluster variables:**
-   Edit or create the `terraform.tfvars` file to define your cluster nodes:
+   Edit or create the `config.auto.tfvars` file to define your cluster nodes:
 
    ```hcl
-   # terraform.tfvars
-   cluster_name     = "homelab"
-   controlplane_ips = ["10.25.150.10", "10.25.150.11", "10.25.150.12"]
-   worker_ips       = ["10.25.150.20", "10.25.150.21"]
+   // tofu/config.auto.tfvars example
+
+   cluster_name   = "talos"
+   cluster_domain = "kube.pc-tips.se"
+
+   # Network settings
+   # All nodes must be on the same L2 network
+   network = {
+     gateway     = "10.25.150.1"
+     vip         = "10.25.150.10" # Control plane Virtual IP
+     cidr_prefix = 24
+     dns_servers = ["10.25.150.1"]
+     bridge      = "vmbr0"
+     vlan_id     = 150
+   }
+
+   # Proxmox settings
+   proxmox_cluster = "host3"
+
+   # Software versions
+   versions = {
+     talos      = "v1.10.3"
+     kubernetes = "1.33.2"
+   }
+
+   # OIDC settings (optional)
+   oidc = {
+     issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
+     client_id  = "kubectl"
+   }
    ```
 
    :::info

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -89,22 +89,7 @@ For a deeper technical guide or troubleshooting steps, see [Getting Started](./g
    chmod 600 ~/.talos/config ~/.kube/config
    ```
 
-## Verify
-
-1. **Check that Talos nodes are healthy:**
-
-   ```bash
-   talosctl health --talosconfig ~/.talos/config --nodes <control-plane-IP>
-   ```
-
-2. **Confirm apps are syncing (ArgoCD):**
-
-   ```bash
-   argocd app list
-   ```
-
-   All applications should be `Healthy` and `Synced`.
-   For any issues, see [troubleshooting in the full guide](./getting-started.md).
+   For more details see [troubleshooting in the full guide](./getting-started.md).
 
 ---
 That's it! Your cluster and GitOps stack are live.

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -28,44 +28,15 @@ For a deeper technical guide or troubleshooting steps, see [Getting Started](./g
    cd homelab
    ```
 
-2. **Create your cluster variable file (`config.auto.tfvars`):**
+2. **Create your configuration files:**
 
-   ```hcl
-   // tofu/config.auto.tfvars example
-
-   cluster_name   = "talos"
-   cluster_domain = "kube.pc-tips.se"
-
-   # Network settings
-   # All nodes must be on the same L2 network
-   network = {
-     gateway     = "10.25.150.1"
-     vip         = "10.25.150.10" # Control plane Virtual IP
-     cidr_prefix = 24
-     dns_servers = ["10.25.150.1"]
-     bridge      = "vmbr0"
-     vlan_id     = 150
-   }
-
-   # Proxmox settings
-   proxmox_cluster = "host3"
-
-   # Software versions
-   versions = {
-     talos      = "v1.10.3"
-     kubernetes = "1.33.2"
-   }
-
-   # OIDC settings (optional)
-   oidc = {
-     issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
-     client_id  = "kubectl"
-   }
+   First, create your sensitive credentials file from the example.
+   ```bash
+   cp tofu/terraform.tfvars.example tofu/terraform.tfvars
    ```
+   Now, **edit `tofu/terraform.tfvars`** with your Proxmox API details.
 
-   :::info
-   Customize IPs and hostnames as needed for your lab environment.
-   :::
+   Next, **edit `tofu/config.auto.tfvars`** to match your network settings (like IP addresses and domain names). The defaults are a good starting point.
 
 3. **Initialize SSH agent and OpenTofu:**
 

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -28,13 +28,39 @@ For a deeper technical guide or troubleshooting steps, see [Getting Started](./g
    cd homelab
    ```
 
-2. **Create your cluster variable file (`terraform.tfvars`):**
+2. **Create your cluster variable file (`config.auto.tfvars`):**
 
    ```hcl
-   # terraform.tfvars
-   cluster_name     = "homelab"
-   controlplane_ips = ["10.25.150.10", "10.25.150.11", "10.25.150.12"]
-   worker_ips       = ["10.25.150.20", "10.25.150.21"]
+   // tofu/config.auto.tfvars example
+
+   cluster_name   = "talos"
+   cluster_domain = "kube.pc-tips.se"
+
+   # Network settings
+   # All nodes must be on the same L2 network
+   network = {
+     gateway     = "10.25.150.1"
+     vip         = "10.25.150.10" # Control plane Virtual IP
+     cidr_prefix = 24
+     dns_servers = ["10.25.150.1"]
+     bridge      = "vmbr0"
+     vlan_id     = 150
+   }
+
+   # Proxmox settings
+   proxmox_cluster = "host3"
+
+   # Software versions
+   versions = {
+     talos      = "v1.10.3"
+     kubernetes = "1.33.2"
+   }
+
+   # OIDC settings (optional)
+   oidc = {
+     issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
+     client_id  = "kubectl"
+   }
    ```
 
    :::info


### PR DESCRIPTION
Refactor the Terraform configuration to improve maintainability and reusability by centralizing cluster-specific settings into a single `config.auto.tfvars` file. Update the codebase to utilize these variables, replacing hardcoded values across multiple files. This change enhances the clarity and flexibility of network and OIDC configurations.