### PR TITLE
feat(k8s)!: introduce cluster-domain templated YAML sources and OpenTofu automation

### DIFF
--- a/k8s/applications/automation/frigate/values.yaml.tftpl
+++ b/k8s/applications/automation/frigate/values.yaml.tftpl
@@ -67,7 +67,7 @@ config: |
     # logs:
 
   mqtt:
-      host: mosquitto.mqtt.svc.kube.pc-tips.se
+      host: mosquitto.mqtt.svc.${cluster_domain}
       port: 1883
       topic_prefix: frigate
       client_id: frigate

--- a/k8s/applications/automation/zigbee2mqtt/config/configuration.yaml.tftpl
+++ b/k8s/applications/automation/zigbee2mqtt/config/configuration.yaml.tftpl
@@ -1,6 +1,6 @@
 version: 4
 mqtt:
-  server: mqtt://mosquitto.mqtt.svc.kube.pc-tips.se:1883
+  server: mqtt://mosquitto.mqtt.svc.${cluster_domain}:1883
   base_topic: zigbee2mqtt
 serial:
   port: tcp://10.0.10.160:20108

--- a/k8s/infrastructure/controllers/argocd/argocd-tls.yaml.tftpl
+++ b/k8s/infrastructure/controllers/argocd/argocd-tls.yaml.tftpl
@@ -15,7 +15,7 @@ spec:
     - argocd-server
     - argocd-server.argocd
     - argocd-server.argocd.svc
-    - argocd-server.argocd.svc.kube.pc-tips.se
+    - argocd-server.argocd.svc.${cluster_domain}
   usages:
     - server auth
     - client auth
@@ -41,7 +41,7 @@ spec:
     - argocd-repo-server
     - argocd-repo-server.argocd
     - argocd-repo-server.argocd.svc
-    - argocd-repo-server.argocd.svc.kube.pc-tips.se
+    - argocd-repo-server.argocd.svc.${cluster_domain}
   usages:
     - server auth
     - client auth
@@ -67,7 +67,7 @@ spec:
     - argocd-application-controller
     - argocd-application-controller.argocd
     - argocd-application-controller.argocd.svc
-    - argocd-application-controller.argocd.svc.kube.pc-tips.se
+    - argocd-application-controller.argocd.svc.${cluster_domain}
   usages:
     - server auth
     - client auth

--- a/k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml.tftpl
+++ b/k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml.tftpl
@@ -20,8 +20,8 @@ spec:
     organizations:
       - external-secrets.io
   dnsNames:
-    - external-secrets-bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
-    - bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
+    - external-secrets-bitwarden-sdk-server.external-secrets.svc.${cluster_domain}
+    - bitwarden-sdk-server.external-secrets.svc.${cluster_domain}
     - localhost
   ipAddresses:
     - 127.0.0.1

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml.tftpl
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml.tftpl
@@ -6,8 +6,8 @@ metadata:
 spec:
   secretName: bitwarden-tls-certs
   dnsNames:
-    - bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
-    - external-secrets-bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se
+    - bitwarden-sdk-server.external-secrets.svc.${cluster_domain}
+    - external-secrets-bitwarden-sdk-server.external-secrets.svc.${cluster_domain}
     - localhost
   ipAddresses:
     - 127.0.0.1

--- a/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml.tftpl
+++ b/k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml.tftpl
@@ -13,7 +13,7 @@ spec:
             key: token
             name: bitwarden-access-token
             namespace: external-secrets
-      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.kube.pc-tips.se:9998
+      bitwardenServerSDKURL: https://bitwarden-sdk-server.external-secrets.svc.${cluster_domain}:9998
       caProvider:
         type: Secret
         name: bitwarden-tls-certs

--- a/k8s/infrastructure/database/postgresql/values.yaml.tftpl
+++ b/k8s/infrastructure/database/postgresql/values.yaml.tftpl
@@ -99,7 +99,7 @@ configKubernetes:
   # - "SYS_NICE"
 
   # default DNS domain of K8s cluster where operator is running
-  cluster_domain: kube.pc-tips.se
+  cluster_domain: ${cluster_domain}
   # additional labels assigned to the cluster objects
   cluster_labels:
     application: spilo

--- a/k8s/infrastructure/deployment/kubechecks/values.yaml.tftpl
+++ b/k8s/infrastructure/deployment/kubechecks/values.yaml.tftpl
@@ -47,7 +47,7 @@ deployment:
     - name: KUBECHECKS_ARGOCD_API_INSECURE
       value: "true"
     - name: KUBECHECKS_ARGOCD_API_SERVER_ADDR
-      value: "argocd-server.argocd.svc.kube.pc-tips.se"
+      value: "argocd-server.argocd.svc.${cluster_domain}"
     - name: KUBECHECKS_ARGOCD_API_PLAINTEXT
       value: "true"
     - name: KUBECHECKS_ARGOCD_REPOSITORY_INSECURE

--- a/k8s/infrastructure/network/cilium/values.yaml.tftpl
+++ b/k8s/infrastructure/network/cilium/values.yaml.tftpl
@@ -89,7 +89,7 @@ envoy:
 
 hubble:
   peerService:
-    clusterDomain: kube.pc-tips.se
+    clusterDomain: ${cluster_domain}
   enabled: true
   relay:
     enabled: true

--- a/k8s/infrastructure/network/cloudflared/config.yaml.tftpl
+++ b/k8s/infrastructure/network/cloudflared/config.yaml.tftpl
@@ -9,15 +9,15 @@ warp-routing:
 ingress:
 
   - hostname: ittools.pc-tips.se
-    service: https://cilium-gateway-external.gateway.svc.kube.pc-tips.se:443
+    service: https://cilium-gateway-external.gateway.svc.${cluster_domain}:443
   - hostname: argocd.pc-tips.se
-    service: https://cilium-gateway-external.gateway.svc.kube.pc-tips.se:443
+    service: https://cilium-gateway-external.gateway.svc.${cluster_domain}:443
   - hostname: "*.pc-tips.se"
-    service: https://cilium-gateway-external.gateway.svc.kube.pc-tips.se:443
+    service: https://cilium-gateway-external.gateway.svc.${cluster_domain}:443
     originRequest:
       originServerName: "*.pc-tips.se"
   - hostname: pc-tips.se
-    service: https://cilium-gateway-external.gateway.svc.kube.pc-tips.se:443
+    service: https://cilium-gateway-external.gateway.svc.${cluster_domain}:443
     originRequest:
       originServerName: pc-tips.se
   - service: http_status:404

--- a/k8s/infrastructure/network/coredns/configmap.yaml.tftpl
+++ b/k8s/infrastructure/network/coredns/configmap.yaml.tftpl
@@ -17,7 +17,7 @@ data:
         prometheus :9153
 
         # Kubernetes service domain
-        kubernetes cluster.local kube.pc-tips.se in-addr.arpa ip6.arpa {
+        kubernetes cluster.local ${cluster_domain} in-addr.arpa ip6.arpa {
             pods insecure
             ttl 30
             fallthrough

--- a/k8s/infrastructure/network/coredns/values.yaml.tftpl
+++ b/k8s/infrastructure/network/coredns/values.yaml.tftpl
@@ -34,7 +34,7 @@ servers:
 
   # Required to query kubernetes API for data
   - name: kubernetes
-    parameters: kube.pc-tips.se in-addr.arpa ip6.arpa
+    parameters: ${cluster_domain} in-addr.arpa ip6.arpa
     configBlock: |-
       pods insecure
       fallthrough in-addr.arpa ip6.arpa
@@ -48,8 +48,8 @@ servers:
   - name: cache
     parameters: 30
     configBlock: |-
-      disable success kube.pc-tips.se
-      disable denial kube.pc-tips.se
+      disable success ${cluster_domain}
+      disable denial ${cluster_domain}
 
   - name: loop
   - name: reload

--- a/k8s/infrastructure/network/gateway/cert-pc-tips.yaml.tftpl
+++ b/k8s/infrastructure/network/gateway/cert-pc-tips.yaml.tftpl
@@ -7,7 +7,7 @@ spec:
   dnsNames:
     - "*.pc-tips.se"
     - pc-tips.se
-    - cilium-gateway-external.gateway.svc.kube.pc-tips.se
+    - cilium-gateway-external.gateway.svc.${cluster_domain}
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/tofu/k8s_yaml_templates.tf
+++ b/tofu/k8s_yaml_templates.tf
@@ -1,0 +1,168 @@
+# This file is auto-generated to render all k8s YAML templates from .yaml.tftpl to .yaml using the cluster_domain variable.
+
+# Frigate values
+
+data "template_file" "frigate_values" {
+  template = file("${path.module}/../k8s/applications/automation/frigate/values.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "frigate_values" {
+  content  = data.template_file.frigate_values.rendered
+  filename = "${path.module}/../k8s/applications/automation/frigate/values.yaml"
+}
+
+# Zigbee2MQTT config
+
+data "template_file" "zigbee2mqtt_config" {
+  template = file("${path.module}/../k8s/applications/automation/zigbee2mqtt/config/configuration.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "zigbee2mqtt_config" {
+  content  = data.template_file.zigbee2mqtt_config.rendered
+  filename = "${path.module}/../k8s/applications/automation/zigbee2mqtt/config/configuration.yaml"
+}
+
+# Cilium values
+
+data "template_file" "cilium_values" {
+  template = file("${path.module}/../k8s/infrastructure/network/cilium/values.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "cilium_values" {
+  content  = data.template_file.cilium_values.rendered
+  filename = "${path.module}/../k8s/infrastructure/network/cilium/values.yaml"
+}
+
+# CoreDNS values
+
+data "template_file" "coredns_values" {
+  template = file("${path.module}/../k8s/infrastructure/network/coredns/values.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "coredns_values" {
+  content  = data.template_file.coredns_values.rendered
+  filename = "${path.module}/../k8s/infrastructure/network/coredns/values.yaml"
+}
+
+data "template_file" "coredns_configmap" {
+  template = file("${path.module}/../k8s/infrastructure/network/coredns/configmap.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "coredns_configmap" {
+  content  = data.template_file.coredns_configmap.rendered
+  filename = "${path.module}/../k8s/infrastructure/network/coredns/configmap.yaml"
+}
+
+# Gateway cert
+
+data "template_file" "cert_pc_tips" {
+  template = file("${path.module}/../k8s/infrastructure/network/gateway/cert-pc-tips.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "cert_pc_tips" {
+  content  = data.template_file.cert_pc_tips.rendered
+  filename = "${path.module}/../k8s/infrastructure/network/gateway/cert-pc-tips.yaml"
+}
+
+# Bitwarden issuer
+
+data "template_file" "bitwarden_issuer" {
+  template = file("${path.module}/../k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "bitwarden_issuer" {
+  content  = data.template_file.bitwarden_issuer.rendered
+  filename = "${path.module}/../k8s/infrastructure/controllers/cert-manager/bitwarden-issuer.yaml"
+}
+
+# Cloudflared config
+
+data "template_file" "cloudflared_config" {
+  template = file("${path.module}/../k8s/infrastructure/network/cloudflared/config.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "cloudflared_config" {
+  content  = data.template_file.cloudflared_config.rendered
+  filename = "${path.module}/../k8s/infrastructure/network/cloudflared/config.yaml"
+}
+
+# PostgreSQL values
+
+data "template_file" "postgresql_values" {
+  template = file("${path.module}/../k8s/infrastructure/database/postgresql/values.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "postgresql_values" {
+  content  = data.template_file.postgresql_values.rendered
+  filename = "${path.module}/../k8s/infrastructure/database/postgresql/values.yaml"
+}
+
+# Bitwarden store
+
+data "template_file" "bitwarden_store" {
+  template = file("${path.module}/../k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "bitwarden_store" {
+  content  = data.template_file.bitwarden_store.rendered
+  filename = "${path.module}/../k8s/infrastructure/controllers/external-secrets/bitwarden-store.yaml"
+}
+
+# Bitwarden certificate
+
+data "template_file" "bitwarden_certificate" {
+  template = file("${path.module}/../k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "bitwarden_certificate" {
+  content  = data.template_file.bitwarden_certificate.rendered
+  filename = "${path.module}/../k8s/infrastructure/controllers/external-secrets/bitwarden-certificate.yaml"
+}
+
+# Kubechecks values
+
+data "template_file" "kubechecks_values" {
+  template = file("${path.module}/../k8s/infrastructure/deployment/kubechecks/values.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "kubechecks_values" {
+  content  = data.template_file.kubechecks_values.rendered
+  filename = "${path.module}/../k8s/infrastructure/deployment/kubechecks/values.yaml"
+}
+
+# ArgoCD TLS
+
+data "template_file" "argocd_tls" {
+  template = file("${path.module}/../k8s/infrastructure/controllers/argocd/argocd-tls.yaml.tftpl")
+  vars = {
+    cluster_domain = var.cluster_domain
+  }
+}
+resource "local_file" "argocd_tls" {
+  content  = data.template_file.argocd_tls.rendered
+  filename = "${path.module}/../k8s/infrastructure/controllers/argocd/argocd-tls.yaml"
+}

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -40,7 +40,10 @@ module "talos" {
   talos_image = var.talos_image
 
   cilium = {
-    values  = file("${path.module}/../k8s/infrastructure/network/cilium/values.yaml")
+    values  = templatefile(
+      "${path.module}/../k8s/infrastructure/network/cilium/values.yaml.tftpl",
+      { cluster_domain = var.cluster_domain }
+    )
     install = file("${path.module}/talos/inline-manifests/cilium-install.yaml")
   }
 


### PR DESCRIPTION
Builds on #1149 to remove all hardcoded `kube.pc-tips.se` values from k8s templates.

Add .tftpl source templates for core infrastructure and key apps (Cilium, CoreDNS, Frigate, Zigbee2MQTT, PostgreSQL, Bitwarden, Kubechecks, ArgoCD TLS, Cloudflared, Gateway cert) and OpenTofu logic to render all manifests with cluster_domain. Refactor Cilium values in tofu/main.tf to use new templating. Enables fully reproducible, environment-specific GitOps workflows.

BREAKING CHANGE: Any cluster-scoped YAML with an associated tftpl file must now be rendered from the .tftpl sources via OpenTofu; direct edits to rendered YAML are not supported.

---

I did not modify the documentation, as it still had hardcoded `kube.pc-tips.se` values. I suggest prior to approval/merge that the PR is checked out and tested in your environment to ensure everything works, as I need to diagnose a tofu apply issue still with the cluster:
```
╷
│ Error: failed to retrieve kubeconfig
│ 
│   with module.talos.talos_cluster_kubeconfig.this,
│   on talos/config-cluster.tf line 11, in resource "talos_cluster_kubeconfig" "this":
│   11: resource "talos_cluster_kubeconfig" "this" {
│ 
│ rpc error: code = Unavailable desc = name resolver error: produced zero addresses
╵
```

