### PR TITLE
feat(hassio): enable OIDC login via Authentik

### DIFF
--- a/k8s/applications/automation/hassio/configuration.yaml
+++ b/k8s/applications/automation/hassio/configuration.yaml
@@ -24,6 +24,15 @@ auth_header:
   username_header: X-ak-hass-user
   debug: true
 
+openid:
+  client_id: !secret ha_oidc_client_id
+  client_secret: !secret ha_oidc_client_secret
+  configure_url: "https://sso.pc-tips.se/application/o/home-assistant/.well-known/openid-configuration"
+  username_field: preferred_username
+  scope: "openid profile email"
+  block_login: false
+  openid_text: "Login with OpenID / OAuth2"
+
 automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-home-assistant.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-home-assistant.yaml
@@ -18,6 +18,7 @@ entries:
       meta_launch_url: https://pc-tips.se
       icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/home-assistant.png
       policy_engine_mode: any
+      provider: !KeyOf provider-homeassistant
 
   - model: authentik_policies.policybinding
     identifiers:
@@ -25,6 +26,53 @@ entries:
       group: !Find [authentik_core.group, [name, "Home Assistant Users"]]
     attrs:
       order: 1
+
+  - id: provider-homeassistant
+    model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: k8s.pc-tips.se/automation/home-assistant
+    attrs:
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-authorization-implicit-consent"],
+        ]
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, "authentik Self-signed Certificate"],
+        ]
+      invalidation_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-invalidation-flow"],
+        ]
+
+      client_type: confidential
+      client_id: !Env HOMEASSISTANT_CLIENT_ID
+      client_secret: !Env HOMEASSISTANT_CLIENT_SECRET
+      redirect_uris:
+        - url: https://hassio.pc-tips.se/auth/openid/callback
+          matching_mode: strict
+
+      access_code_validity: minutes=1
+      access_token_validity: minutes=5
+      refresh_token_validity: days=30
+
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "authentik default OAuth Mapping: OpenID 'openid'"],
+          ]
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "authentik default OAuth Mapping: OpenID 'profile'"],
+          ]
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "OAuth mapping: OpenID 'email' with mailPrimaryAddress"],
+          ]
 
   - id: provider-zigbee2mqtt
     model: authentik_providers_oauth2.oauth2provider

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -161,6 +161,13 @@ spec:
     - secretKey: OPENWEBUI_CLIENT_SECRET
       remoteRef:
         key: 'app-openwebui-oauth-client-secret'
+    # --- Home Assistant ---
+    - secretKey: HOMEASSISTANT_CLIENT_ID
+      remoteRef:
+        key: 'app-hassio-oauth-client-id'
+    - secretKey: HOMEASSISTANT_CLIENT_SECRET
+      remoteRef:
+        key: 'app-hassio-oauth-client-secret'
     # --- Karakeep ---
     - secretKey: KARAKEEP_CLIENT_ID
       remoteRef:

--- a/website/docs/applications/home-assistant.md
+++ b/website/docs/applications/home-assistant.md
@@ -8,3 +8,9 @@ Home Assistant is an open-source home automation platform that focuses on local 
 ## Important considerations
 
 - **Pod Security Context:** The container now adds `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` so Home Assistant can discover devices on the local network.
+
+## Authentication
+
+Home Assistant authenticates via Authentik using OpenID Connect. Credentials are
+pulled from Bitwarden and a provider is defined in the Authentik blueprints. The
+login page now shows a "Login with OpenID / OAuth2" option.


### PR DESCRIPTION
## Summary
- add OIDC provider to Home Assistant blueprint
- fetch OIDC credentials for Home Assistant
- configure Home Assistant with OpenID integration
- document OpenID authentication

## Validation
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik/extra`
- `kustomize build --enable-helm k8s/applications/automation/hassio`
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cf2370c708322b321a7c73decc4bf