### PR TITLE
feat(docs): add linting toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Docs Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Vale
+        uses: errata-ai/vale-action@v3
+        with:
+          files: .
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v5
+        with:
+          config: .markdownlint.yaml
+          globs: "**/*.md"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+default: true
+MD013: false
+MD024:
+  allow_different_nesting: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.7.0
+    hooks:
+      - id: vale
+        files: \.md$
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.9.2
+    hooks:
+      - id: markdownlint
+        files: \.md$

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: [
+    'remark-lint',
+    ['remark-lint-no-undefined-references']
+  ]
+};

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = styles
+MinAlertLevel = warning
+
+[*.md]
+BasedOnStyles = GitHub, Kubernetes

--- a/styles/Kubernetes/NoVague.yml
+++ b/styles/Kubernetes/NoVague.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Avoid vague terms like '%s'. Be precise."
+ignorecase: true
+nonword: true
+level: error
+tokens:
+  - sometimes
+  - might
+  - could
+  - seems

--- a/website/docs/writing-documentation/linting-toolchain.md
+++ b/website/docs/writing-documentation/linting-toolchain.md
@@ -1,0 +1,28 @@
+---
+title: Documentation linting toolchain
+---
+
+This project uses automated linting to keep the docs readable and consistent. The stack relies on open-source tools that run locally and in CI.
+
+## Local setup
+
+1. Install the **Vale** and **markdownlint** extensions in VS Code.
+2. From the repository root, bootstrap the config files:
+   ```bash
+   vale config init
+   npx markdownlint-cli2 --init
+   ```
+3. Pre-commit hooks run `vale` and `markdownlint` before every commit.
+
+## CI checks
+
+GitHub Actions validates all Markdown files on every pull request. The pipeline fails if either linter reports errors.
+
+## Files and directories
+
+- `.vale.ini` and `styles/` define prose rules.
+- `.markdownlint.yaml` controls Markdown style.
+- `.pre-commit-config.yaml` enables the hooks.
+- `.github/workflows/docs.yml` runs the checks in CI.
+
+Follow the existing [style guide](./style-guide.mdx) along with these tools. Fix warnings as you go so the CI stays green.

--- a/website/docs/writing-documentation/writing-documentation.md
+++ b/website/docs/writing-documentation/writing-documentation.md
@@ -17,8 +17,8 @@ adhere to the following guidelines.
 - Remember to use the [documentation templates](./templates/index.md) when appropriate. They are pre-structured to align
   with my style guidelines, simplify the writing process (helping to avoid the "blank page" challenge), and maintain
   consistency in document structure and headings.
-- Before submitting a PR, ensure your Markdown is well-formatted. If you have local Markdown linting tools configured,
-  please run them.
+ - Before submitting a PR, ensure your Markdown is well-formatted. Pre-commit hooks run
+   `vale` and `markdownlint` automatically, so fix any warnings before pushing.
 - For new documentation pages, ensure they are appropriately linked from relevant sections in the main documentation (e.g., `website/docs/intro.md` or other logical overview pages) so that users can discover them.
 - Place your new file in the folder that best matches its topic (e.g., `infrastructure/` or `k8s/`). The sidebar indexes each folder automatically, so you do not need to edit `sidebars.ts`.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -72,6 +72,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'writing-documentation/writing-documentation',
         'writing-documentation/style-guide',
+        'writing-documentation/linting-toolchain',
         'writing-documentation/templates/index',
       ],
     },


### PR DESCRIPTION
## What & why
- enforce markdown style and prose using Vale and markdownlint
- document the linting workflow and add it to the docs sidebar
- run checks locally with pre-commit and in CI

## Validation
- `npm install` in `website/` succeeded
- `npm run typecheck` failed with TS2339 (existing issue)
- `npm run lint` reported missing script


------
https://chatgpt.com/codex/tasks/task_e_686d0b8526b08322917c8251e0929ddb