### PR TITLE
Fix Vale action config

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -12,8 +12,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: errata-ai/vale-action@v2.1.1
         with:
           files: website/docs
-          config: website/utils/vale/.vale.ini
+          vale_flags: '--config=website/utils/vale/.vale.ini'
           fail_on_error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- use `--config` flag for Vale to link the workflow to the repo config
- add checkout step and set `GITHUB_TOKEN`

## Testing
- `pre-commit run --files .github/workflows/vale.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6871905fe510832280b8ab6be1052a9e