### PR TITLE
Fix homepage quick start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 After rebuilding my homelab one too many times, I committed to managing it entirely with GitOps. This repository is the result: a blueprint for a resilient, production-inspired Kubernetes cluster.
 
 I'm sharing it to document my own journey and to help others build a stable, maintainable homelab without repeating my mistakes.
- **[Explore the Documentation](https://homelab.orkestack.com/)** │ **[See the Architecture](https://homelab.orkestack.com/docs/architecture)** │ **[Get Started](https://homelab.orkestack.com/docs/quick-start)**
+ **[Explore the Documentation](https://homelab.orkestack.com/)** │ **[See the Architecture](https://homelab.orkestack.com/docs/architecture)** │ **[Get Started](https://homelab.orkestack.com/docs/getting-started)**
 
 ## The Stack
 
@@ -41,7 +41,7 @@ I'm sharing it to document my own journey and to help others build a stable, mai
 ## Quick Start
 
 1. Make sure you have Proxmox access with your SSH key and install `opentofu`, `talosctl`, `kubectl`, and `argocd`. A little Kubernetes and Git know-how helps.
-2. Clone this repository and follow the steps in the [Quick Start guide](https://homelab.orkestack.com/docs/quick-start).
+2. Clone this repository and follow the steps in the [Quick Start guide](https://homelab.orkestack.com/docs/getting-started).
 
 ---
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -2,7 +2,7 @@
 title: 'Getting Started: Homelab Cluster and GitOps Onboarding'
 description: Step-by-step guide to bootstrap the homelab cluster and deploy apps using GitOps.
 ---
-This guide walks you through spinning up a Kubernetes homelab: provisioning virtual machines, bootstrapping the cluster, and deploying workloads using GitOps—all in under one hour.
+This guide walks you through spinning up a Kubernetes homelab: provisioning virtual machines, bootstrapping the cluster, and deploying workloads using GitOps, all in under one hour.
 
 For a conceptual understanding of the OpenTofu setup, refer to the [OpenTofu Provisioning Concepts](/docs/tofu/provisioning-concepts.md) guide. For step-by-step instructions on provisioning your cluster, see the [OpenTofu Provisioning Task Guide](/docs/tofu/provisioning-task-guide.md).
 
@@ -11,4 +11,4 @@ For a conceptual understanding of the OpenTofu setup, refer to the [OpenTofu Pro
 Before you begin, ensure you have met the prerequisites outlined in the [OpenTofu Provisioning Task Guide](tofu/provisioning-task-guide.md).
 
 ---
-For further details on cluster architecture, networking, and recovery, see [Cluster Details](./architecture.md).
+For further details on cluster architecture, networking, and recovery, see [Cluster Details](architecture).

--- a/website/src/components/Homepage/CTASection/index.tsx
+++ b/website/src/components/Homepage/CTASection/index.tsx
@@ -10,7 +10,7 @@ export function CTASection(): JSX.Element {
         <h2 className={styles.title}>Dive In and Explore</h2>
         <div className={styles.buttons}>
           <Link
-            to="/docs/quick-start"
+            to="/docs/getting-started"
             className={styles.primaryButton}
           >
             Quick Start Guide

--- a/website/src/components/Homepage/QuickStart/index.tsx
+++ b/website/src/components/Homepage/QuickStart/index.tsx
@@ -33,7 +33,7 @@ export function QuickStart(): JSX.Element {
         <div className={styles.quickStartCta}>
           <Link
             className="button button--primary button--lg"
-            to="/docs/quick-start"
+            to="/docs/getting-started"
           >
             View Full Guide
           </Link>


### PR DESCRIPTION
## Summary
- fix broken quick-start link on homepage components
- update README quick-start links
- tweak getting-started guide formatting to satisfy Vale

## Testing
- `npm run build`
- `pre-commit run --files README.md website/src/components/Homepage/QuickStart/index.tsx website/src/components/Homepage/CTASection/index.tsx website/docs/getting-started.md`


------
https://chatgpt.com/codex/tasks/task_e_687225bea9b483229cf3c45f7ab7ff13