### PR TITLE
fix(k8s): update bazarr statefulset configuration and environment variables

### DIFF
--- a/k8s/applications/media/arr/bazarr/statefulset.yaml
+++ b/k8s/applications/media/arr/bazarr/statefulset.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: bazarr
     spec:
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+            claimName: media-share
       containers:
         - name: bazarr
           image: lscr.io/linuxserver/bazarr:1.5.2
@@ -23,6 +27,10 @@ spec:
             - name: http
               containerPort: 6767
               protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: common-env
+                optional: true
           env:
             - name: VPN_ENABLED
               value: 'false'
@@ -31,6 +39,8 @@ spec:
             - name: WEBUI_PORTS
               value: '6767/tcp,6767/udp'
           volumeMounts:
+            - name: media
+              mountPath: /app/data
             - name: config
               mountPath: /config
           resources:

--- a/k8s/applications/media/arr/kustomization.yaml
+++ b/k8s/applications/media/arr/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 configMapGenerator:
 - literals:
-  - TZ="Europe/Oslo"
+  - TZ="Europe/Stockholm"
   - PUID="2501"
   - PGID="2501"
   name: common-env
@@ -23,4 +23,4 @@ patches:
   - path: base/patch.yaml
     target:
       kind: StatefulSet
-      labelSelector: app in (bazarr, prowlarr, radarr, sonarr)
+      labelSelector: app in (prowlarr, radarr, sonarr)

--- a/k8s/applications/network/omada/statefulset.yaml
+++ b/k8s/applications/network/omada/statefulset.yaml
@@ -121,17 +121,22 @@ spec:
               value: Etc/UTC
             - name: SKIP_USERMOD
               value: 'true'
+          startupProbe:
+            tcpSocket:
+              port: 8088
+            periodSeconds: 30
+            failureThreshold: 60
           livenessProbe:
             tcpSocket:
               port: 8088
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 8088
-            initialDelaySeconds: 20
+            initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 3


### PR DESCRIPTION
Update the Bazarr StatefulSet configuration to include a persistent volume claim for media storage and modify environment variables. Adjust health probe settings to improve application reliability.