### PR TITLE
Adjust Open Web UI probes

### DIFF
--- a/k8s/applications/ai/openwebui/webui-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/webui-statefulset.yaml
@@ -104,7 +104,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /
@@ -112,4 +112,12 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 10
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 30

--- a/website/docs/applications/open-webui.md
+++ b/website/docs/applications/open-webui.md
@@ -1,0 +1,18 @@
+---
+title: Open Web UI
+sidebar_position: 7
+description: Chat UI for local LLMs
+---
+
+# Open Web UI
+
+Open Web UI provides a browser interface to local language models and relies on
+Authentik for single sign-on. The service runs as a StatefulSet and stores its
+data on a Longhorn volume.
+
+## Health checks
+
+Vectorizing large RAG documents can freeze the UI for several minutes. To avoid
+unnecessary pod restarts, the liveness and readiness probes now allow up to five
+minutes of failures. A startup probe with a ten minute threshold covers the
+initial launch.


### PR DESCRIPTION
## Summary
- allow longer RAG processing by increasing failure thresholds
- document Open Web UI and new health check behaviour

## Testing
- `kustomize build --enable-helm k8s/applications/ai/openwebui`
- `npm run build` *(failed: vale environment could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68875bb099c88322a507933b699023ad