### PR TITLE
fix(ci): restrict Vale workflow to Markdown docs

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -6,9 +6,9 @@ name: Vale Documentation Lint
 
 on:
   pull_request:
-    paths: [ 'website/docs/**' ]
+    paths: [ 'website/docs/**/*.md' ]
   push:
-    paths: [ 'website/docs/**' ]
+    paths: [ 'website/docs/**/*.md' ]
 
 jobs:
   docs_lint:

--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -40,6 +40,12 @@ This page explains how GitHub Actions, Renovate, and Dependabot keep this homela
   - `packages: write` (upload images)
 - **Build context:** Uses `.dockerignore` files within each image directory to keep uploads minimal.
 
+### Documentation Lint (`vale.yaml`)
+
+- **File:** `.github/workflows/vale.yaml`
+- **Purpose:** Lints Markdown files in `website/docs` using [Vale](https://vale.sh/).
+- **When triggered:** Only when `.md` files change under `website/docs/`.
+
 ### Validation & CI (Implied Workflows)
 
 - **What:** While specific workflow YAMLs for all validation steps aren't detailed here, CI jobs automatically lint and validate configurations.


### PR DESCRIPTION
## Summary
- run Vale CI check only when website docs markdown files change
- document how the Vale workflow triggers

## Testing
- `npm run build`
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*
- `pre-commit run --files .github/workflows/vale.yaml website/docs/github/github-configuration.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887d955aeb48322aea5dde589d7d70e