### PR TITLE
fix(ci): lint only changed docs

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -6,9 +6,9 @@ name: Vale Documentation Lint
 
 on:
   pull_request:
-    paths: [ 'website/docs/**' ]
+    paths: [ 'website/docs/**/*.md' ]
   push:
-    paths: [ 'website/docs/**' ]
+    paths: [ 'website/docs/**/*.md' ]
 
 jobs:
   docs_lint:
@@ -17,11 +17,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed Markdown files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files: website/docs/**/*.md
+          separator: ,
 
       - name: Run Vale with reviewdog
+        if: steps.changed.outputs.any_changed == 'true'
         uses: errata-ai/vale-action@v2.1.1
         with:
-          files: website/docs
+          files: ${{ steps.changed.outputs.all_changed_files }}
+          separator: ,
           vale_flags: '--config=website/utils/vale/.vale.ini'
           reporter: github-pr-review   # inline PR comments
           level: warning              # INFO is non-blocking

--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -40,6 +40,13 @@ This page explains how GitHub Actions, Renovate, and Dependabot keep this homela
   - `packages: write` (upload images)
 - **Build context:** Uses `.dockerignore` files within each image directory to keep uploads minimal.
 
+### Documentation Lint (`vale.yaml`)
+
+- **File:** `.github/workflows/vale.yaml`
+- **Purpose:** Lints Markdown files in `website/docs` using [Vale](https://vale.sh/).
+- **When triggered:** Only when `.md` files change under `website/docs/`.
+- **How it works:** The workflow runs Vale only on the Markdown files that changed in the PR.
+
 ### Validation & CI (Implied Workflows)
 
 - **What:** While specific workflow YAMLs for all validation steps aren't detailed here, CI jobs automatically lint and validate configurations.


### PR DESCRIPTION
## Summary
- update Vale workflow to use tj-actions/changed-files so only changed docs are linted
- document Vale workflow behavior

## Testing
- `npm run build`
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*
- `pre-commit run --files .github/workflows/vale.yaml website/docs/github/github-configuration.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887d955aeb48322aea5dde589d7d70e