### PR TITLE
Split gateway TLS certs by domain

### DIFF
--- a/k8s/infrastructure/network/gateway/cert-goingdark.yaml
+++ b/k8s/infrastructure/network/gateway/cert-goingdark.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-goingdark
+  namespace: gateway
+spec:
+  dnsNames:
+    - "*.goingdark.social"
+    - goingdark.social
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: cloudflare-issuer
+  secretName: cert-goingdark
+  usages:
+    - digital signature
+    - key encipherment

--- a/k8s/infrastructure/network/gateway/gw-external.yaml
+++ b/k8s/infrastructure/network/gateway/gw-external.yaml
@@ -38,7 +38,7 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: cert-pc-tips
+            name: cert-goingdark
       allowedRoutes:
         namespaces:
           from: All

--- a/k8s/infrastructure/network/gateway/gw-internal.yaml
+++ b/k8s/infrastructure/network/gateway/gw-internal.yaml
@@ -35,7 +35,7 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: cert-pc-tips
+            name: cert-goingdark
       allowedRoutes:
         namespaces:
           from: All

--- a/k8s/infrastructure/network/gateway/kustomization.yaml
+++ b/k8s/infrastructure/network/gateway/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - cert-pc-tips.yaml
+  - cert-goingdark.yaml
   - gw-external.yaml
   - gw-internal.yaml
   - gw-tls-passthrough.yaml

--- a/website/docs/k8s/infrastructure/infrastructure-management.md
+++ b/website/docs/k8s/infrastructure/infrastructure-management.md
@@ -71,6 +71,7 @@ Three gateway types:
   - Cloudflare DNS validation
   - Internal CA for cluster services
   - Automatic certificate renewal
+  - Separate certificates for pc-tips.se and goingdark.social
 
 - **External Secrets:**
   - Bitwarden integration


### PR DESCRIPTION
## Summary
- add cert-goingdark for Mastodon domain
- update gateways to use cert-goingdark
- document separate certs in infrastructure management guide

## Testing
- `kustomize build --enable-helm k8s/infrastructure/network/gateway`
- `npm run build` *(in `website`)*
- `pre-commit run vale --all-files` *(failed: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68892195edec8322858372a0454cf0ea