### PR TITLE
Add Mastodon SMTP secrets

### DIFF
--- a/k8s/applications/web/mastodon/externalsecret.yaml
+++ b/k8s/applications/web/mastodon/externalsecret.yaml
@@ -28,3 +28,13 @@ spec:
       remoteRef: { key: app-mastodon-ar-deterministic }
     - secretKey: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
       remoteRef: { key: app-mastodon-ar-salt }
+    - secretKey: SMTP_SERVER
+      remoteRef: { key: app-mastodon-smtp-server }
+    - secretKey: SMTP_PORT
+      remoteRef: { key: app-mastodon-smtp-port }
+    - secretKey: SMTP_LOGIN
+      remoteRef: { key: app-mastodon-smtp-login }
+    - secretKey: SMTP_PASSWORD
+      remoteRef: { key: app-mastodon-smtp-password }
+    - secretKey: SMTP_FROM_ADDRESS
+      remoteRef: { key: app-mastodon-smtp-from-address }

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -16,3 +16,22 @@ configMapGenerator:
       - PGSSLMODE=disable
 ```
 
+## Email Configuration
+
+Mastodon sends emails through an SMTP server. The credentials and settings come from the `mastodon-app-secrets` ExternalSecret:
+
+```yaml
+# k8s/applications/web/mastodon/externalsecret.yaml
+data:
+  - secretKey: SMTP_SERVER
+    remoteRef: { key: app-mastodon-smtp-server }
+  - secretKey: SMTP_PORT
+    remoteRef: { key: app-mastodon-smtp-port }
+  - secretKey: SMTP_LOGIN
+    remoteRef: { key: app-mastodon-smtp-login }
+  - secretKey: SMTP_PASSWORD
+    remoteRef: { key: app-mastodon-smtp-password }
+  - secretKey: SMTP_FROM_ADDRESS
+    remoteRef: { key: app-mastodon-smtp-from-address }
+```
+


### PR DESCRIPTION
## Summary
- add SMTP variables to Mastodon ExternalSecret
- document email config for Mastodon

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build`
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e043a188322a02e8858a51ebd9e