### PR TITLE
Add implicit TLS flags for Mastodon mailer

### DIFF
--- a/k8s/applications/web/mastodon/kustomization.yaml
+++ b/k8s/applications/web/mastodon/kustomization.yaml
@@ -38,6 +38,12 @@ configMapGenerator:
     # ─── locale ─────────────────────────────────────────────────────
     - DEFAULT_LOCALE=en
     - FORCE_DEFAULT_LOCALE=true
+    - SMTP_DELIVERY_METHOD=smtp
+    - SMTP_AUTH_METHOD=login
+    - SMTP_SSL=true
+    - SMTP_TLS=false
+    - SMTP_ENABLE_STARTTLS_AUTO=false
+    - SMTP_ENABLE_STARTTLS=never
 
 - name: mastodon-web-env
   literals:

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -35,3 +35,18 @@ data:
     remoteRef: { key: app-mastodon-smtp-from-address }
 ```
 
+Rails is configured to use implicit TLS on port 465 and to avoid STARTTLS:
+
+```yaml
+# k8s/applications/web/mastodon/kustomization.yaml
+configMapGenerator:
+  - name: mastodon-common-env
+    literals:
+      - SMTP_DELIVERY_METHOD=smtp
+      - SMTP_AUTH_METHOD=login
+      - SMTP_SSL=true
+      - SMTP_TLS=false
+      - SMTP_ENABLE_STARTTLS_AUTO=false
+      - SMTP_ENABLE_STARTTLS=never
+```
+


### PR DESCRIPTION
## Summary
- configure Mastodon to use implicit TLS and disable STARTTLS
- document the mailer configuration

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bb2dc42bc8322bcf00533deb43460