### PR TITLE
Fix postgres backup secret

### DIFF
--- a/k8s/infrastructure/database/postgresql/externalsecret.yaml
+++ b/k8s/infrastructure/database/postgresql/externalsecret.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: minio-postgres-backup-secret
+  name: minio-longhorn-backup-secret
   namespace: postgres-operator
 spec:
   refreshInterval: "1h"
@@ -9,7 +9,7 @@ spec:
     name: bitwarden-backend
     kind: ClusterSecretStore
   target:
-    name: postgres-minio-credentials
+    name: longhorn-minio-credentials
     creationPolicy: Owner
   data:
     - secretKey: AWS_ACCESS_KEY_ID

--- a/k8s/infrastructure/database/postgresql/values.yaml
+++ b/k8s/infrastructure/database/postgresql/values.yaml
@@ -391,7 +391,7 @@ configLogicalBackup:
   # backup schedule in the cron format
   logical_backup_schedule: "0 3 * * *"
   # secret to be used as reference for env variables in cronjob
-  logical_backup_cronjob_environment_secret: "postgres-minio-credentials"
+  logical_backup_cronjob_environment_secret: "longhorn-minio-credentials"
 
 # automate creation of human users with teams API service
 configTeamsApi:

--- a/website/docs/infrastructure/database/postgres-backup.md
+++ b/website/docs/infrastructure/database/postgres-backup.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 1
+title: PostgreSQL Backups
+description: Logical backups using the Zalando operator and Minio storage
+---
+
+# PostgreSQL Operator Backup Configuration
+
+The Zalando Postgres operator schedules `pg_dumpall` to run via a Kubernetes CronJob. Backups write to the `postgres` bucket on the cluster's Minio instance.
+
+Credentials come from the `ExternalSecret` named `longhorn-minio-credentials`. This secret is shared with Longhorn so the same Minio user manages all backups.
+
+The default schedule stores a dump every night at 03:00 UTC. Adjust `logical_backup_schedule` in `values.yaml` if needed.


### PR DESCRIPTION
## Summary
- use the same Minio secret name as Longhorn
- document the postgres backup job

## Testing
- `kustomize build --enable-helm k8s/infrastructure/database/postgresql`
- `npm run build`
- `pre-commit run vale --files website/docs/infrastructure/database/postgres-backup.md` *(fails: URLError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bb76e53a48322bad3ff1aa17345b0