### PR TITLE
Increase Mastodon Sidekiq resources

### DIFF
--- a/k8s/applications/web/mastodon/sidekiq-deployment.yaml
+++ b/k8s/applications/web/mastodon/sidekiq-deployment.yaml
@@ -46,11 +46,11 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "100m"
-              memory: "256Mi"
+              cpu: "200m"
+              memory: "512Mi"
             limits:
-              cpu: "500m"
-              memory: "1Gi"
+              cpu: "1000m"
+              memory: "2Gi"
           securityContext:
             runAsNonRoot: true
             runAsUser: 991

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -50,3 +50,19 @@ configMapGenerator:
       - SMTP_ENABLE_STARTTLS=never
 ```
 
+## Sidekiq Resources
+
+Sidekiq processes background jobs. A larger instance benefits from more
+CPU and memory:
+
+```yaml
+# k8s/applications/web/mastodon/sidekiq-deployment.yaml
+resources:
+  requests:
+    cpu: "200m"
+    memory: "512Mi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+```
+


### PR DESCRIPTION
## Summary
- bump Sidekiq CPU/memory limits for Mastodon
- document the new Sidekiq resource requirements

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build` *(fails: Warn `blogDir` doesn't exist, but build succeeds)*
- `pre-commit run --files website/docs/k8s/applications/mastodon-implementation.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bbe7087088322ac9b02af555f2b0c