### PR TITLE
feat(k8s): triple Mastodon media PVC

### DIFF
--- a/k8s/applications/web/mastodon/pvc-public.yaml
+++ b/k8s/applications/web/mastodon/pvc-public.yaml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi
+      storage: 30Gi
   storageClassName: longhorn

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -47,6 +47,21 @@ configMapGenerator:
       - SMTP_SSL=true
       - SMTP_TLS=false
       - SMTP_ENABLE_STARTTLS_AUTO=false
-      - SMTP_ENABLE_STARTTLS=never
+  - SMTP_ENABLE_STARTTLS=never
+```
+
+## Media Storage
+
+Attachments are stored on a Persistent Volume Claim named `mastodon-public-pvc`.
+The claim requests 30Gi from Longhorn:
+
+```yaml
+# k8s/applications/web/mastodon/pvc-public.yaml
+spec:
+  accessModes: [ "ReadWriteMany" ]
+  resources:
+    requests:
+      storage: 30Gi
+  storageClassName: longhorn
 ```
 


### PR DESCRIPTION
## Summary
- increase `mastodon-public-pvc` to 30Gi
- document media storage for Mastodon

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build` *(failed: pre-commit could not install Vale due to SSL certificate verification failure)*
- `pre-commit run vale --all-files` *(failed: could not install Vale)*

------
https://chatgpt.com/codex/tasks/task_e_688bc0556f60832284d44d2fb95a4aa0