### PR TITLE
Update Mastodon images

### DIFF
--- a/k8s/applications/web/mastodon/sidekiq-deployment.yaml
+++ b/k8s/applications/web/mastodon/sidekiq-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: Always
       containers:
         - name: sidekiq
-          image: ghcr.io/mastodon/mastodon:v4.4.2
+          image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
           args:
           - bundle
           - exec

--- a/k8s/applications/web/mastodon/streaming-deployment.yaml
+++ b/k8s/applications/web/mastodon/streaming-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: streaming
-          image: ghcr.io/mastodon/mastodon-streaming:v4.4.2
+          image: ghcr.io/glitch-soc/mastodon-streaming:nightly.2025-07-31
           command: ["node", "./streaming/index.js"]
           ports:
             - name: streaming

--- a/k8s/applications/web/mastodon/web-deployment.yaml
+++ b/k8s/applications/web/mastodon/web-deployment.yaml
@@ -26,7 +26,7 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/mastodon/mastodon:nightly.2025-07-31
+          image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
           command: ["/bin/bash", "-c", "bundle exec rails db:migrate && bundle exec puma -C config/puma.rb"]
           ports:
             - name: http

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -81,3 +81,19 @@ resources:
     memory: "2Gi"
 ```
 
+## Container Images
+
+This deployment uses the Glitch-soc variant of Mastodon for additional features.
+All components reference the `nightly.2025-07-31` tag:
+
+```yaml
+# k8s/applications/web/mastodon/web-deployment.yaml
+image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+
+# k8s/applications/web/mastodon/sidekiq-deployment.yaml
+image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+
+# k8s/applications/web/mastodon/streaming-deployment.yaml
+image: ghcr.io/glitch-soc/mastodon-streaming:nightly.2025-07-31
+```
+


### PR DESCRIPTION
## Summary
- update Mastodon deployments to use glitch-soc images
- document container image choice

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build` *(fails: Warn: `blogDir` doesn't exist but build succeeds)*
- `pre-commit run vale --all-files` *(fails: URLError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bd7b950c4832297ddcf7083d3d353