### PR TITLE
feat(tofu): add support for external nodes in configuration

### DIFF
--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -60,4 +60,9 @@ nodes_config = {
       "0000:03:00.1" = { id = "10de:0fbc", subsystem_id = "10de:1097", iommu_group = 50 }
     }
   }
+  "baremetal-01" = {
+    machine_type = "worker"
+    ip           = "10.25.150.30"
+    is_external  = true
+  }
 }

--- a/tofu/talos/config-machine.tf
+++ b/tofu/talos/config-machine.tf
@@ -54,7 +54,9 @@ resource "talos_machine_configuration_apply" "this" {
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.this[each.key].machine_configuration
   lifecycle {
-    # re-run config apply if vm changes
-    replace_triggered_by = [proxmox_virtual_environment_vm.this[each.key]]
+    # External nodes will handle missing VM dependencies gracefully
+    replace_triggered_by = [
+      proxmox_virtual_environment_vm.this
+    ]
   }
 }

--- a/tofu/talos/image.tf
+++ b/tofu/talos/image.tf
@@ -49,6 +49,8 @@ locals {
       schematic_id = talos_image_factory_schematic.main[local.get_schematic_key[name]].id
       version      = lookup(node, "update", false) ? local.update_version : var.talos_image.version
     } ...
+    # External nodes manage their own images, skip factory download
+    if !lookup(node, "is_external", false)
   }
 
   image_downloads = {

--- a/tofu/talos/virtual-machines.tf
+++ b/tofu/talos/virtual-machines.tf
@@ -3,7 +3,7 @@ resource "terraform_data" "image_version" {
 }
 
 resource "proxmox_virtual_environment_vm" "this" {
-  for_each = var.nodes
+  for_each = local.internal_nodes
 
 
   node_name = each.value.host_node
@@ -118,9 +118,11 @@ resource "proxmox_virtual_environment_vm" "this" {
 }
 
 locals {
+  internal_nodes = { for k, v in var.nodes : k => v if !lookup(v, "is_external", false) }
+
   gpu_mapping_alias_prefix = "gpu"
   gpu_mappings = flatten([
-    for node_name, node_cfg in var.nodes : [
+    for node_name, node_cfg in local.internal_nodes : [
       for idx, bdf in lookup(node_cfg, "gpu_devices", []) : {
         name = "${local.gpu_mapping_alias_prefix}-${node_name}-${idx}"
         node = node_cfg.host_node


### PR DESCRIPTION
- Introduced `is_external` attribute for nodes to differentiate between internal and external nodes.
- Updated validation rules for `vm_id` and `mac_address` based on node type.
- Adjusted VM resource handling to skip factory download for external nodes.