### PR TITLE
Increase Mastodon PVC to 50Gi

### DIFF
--- a/k8s/applications/web/mastodon/pvc-public.yaml
+++ b/k8s/applications/web/mastodon/pvc-public.yaml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 30Gi
+      storage: 50Gi
   storageClassName: longhorn

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -53,7 +53,7 @@ configMapGenerator:
 ## Media Storage
 
 Attachments are stored on a Persistent Volume Claim named `mastodon-public-pvc`.
-The claim requests 30Gi from Longhorn:
+The claim now requests 50Gi from Longhorn:
 
 ```yaml
 # k8s/applications/web/mastodon/pvc-public.yaml
@@ -61,7 +61,7 @@ spec:
   accessModes: [ "ReadWriteMany" ]
   resources:
     requests:
-      storage: 30Gi
+      storage: 50Gi
   storageClassName: longhorn
 ```
 


### PR DESCRIPTION
## Summary
- bump `mastodon-public-pvc` to 50Gi
- document the larger media storage claim

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `kustomize build --enable-helm k8s/applications/web`
- `npm run build`
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d414ebea88322a168248946eaa3c5