### PR TITLE
fix(mastodon): provision vm.max_map_count via tofu

### DIFF
--- a/tofu/nodes.auto.tfvars
+++ b/tofu/nodes.auto.tfvars
@@ -23,18 +23,21 @@ nodes_config = {
     ip           = "10.25.150.21"
     mac_address  = "bc:24:11:64:5b:cb"
     vm_id        = 8201
+    sysctls      = { vm.max_map_count = "262144" }
   }
   "work-01" = {
     machine_type = "worker"
     ip           = "10.25.150.22"
     mac_address  = "bc:24:11:c9:22:c3"
     vm_id        = 8202
+    sysctls      = { vm.max_map_count = "262144" }
   }
   "work-02" = {
     machine_type = "worker"
     ip           = "10.25.150.23"
     mac_address  = "bc:24:11:6f:20:03"
     vm_id        = 8203
+    sysctls      = { vm.max_map_count = "262144" }
     disks = {
       longhorn = {
         device      = "/dev/sdb"
@@ -55,6 +58,7 @@ nodes_config = {
     igpu               = true
     gpu_node_exclusive = true
     gpu_devices        = ["0000:03:00.0", "0000:03:00.1"]
+    sysctls            = { vm.max_map_count = "262144" }
     gpu_device_meta = {
       "0000:03:00.0" = { id = "10de:13ba", subsystem_id = "10de:1097", iommu_group = 50 }
       "0000:03:00.1" = { id = "10de:0fbc", subsystem_id = "10de:1097", iommu_group = 50 }
@@ -64,5 +68,6 @@ nodes_config = {
     machine_type = "worker"
     ip           = "10.25.150.30"
     is_external  = true
+    sysctls      = { vm.max_map_count = "262144" }
   }
 }

--- a/tofu/talos/config-machine.tf
+++ b/tofu/talos/config-machine.tf
@@ -31,6 +31,7 @@ data "talos_machine_configuration" "this" {
         cluster            = var.cluster
         cluster_domain     = var.cluster_domain
         disks              = each.value.disks
+        sysctls            = lookup(each.value, "sysctls", {})
         igpu               = each.value.igpu
         gpu_node_exclusive = lookup(each.value, "gpu_node_exclusive", false)
         vip                = var.network.vip

--- a/tofu/talos/machine-config/worker.yaml.tftpl
+++ b/tofu/talos/machine-config/worker.yaml.tftpl
@@ -28,9 +28,11 @@ machine:
   %{ endif }
   sysctls:
     vm.nr_hugepages: "1024"
+%{ if sysctls is defined and length(sysctls) > 0 ~}
 %{ for name, value in sysctls ~}
     ${name}: "${value}"
 %{ endfor ~}
+%{ endif ~}
   kernel:
     modules: # These modules will be loaded on all worker nodes
       - name: nvme_tcp # NVMe over TCP, generally useful for storage

--- a/tofu/talos/machine-config/worker.yaml.tftpl
+++ b/tofu/talos/machine-config/worker.yaml.tftpl
@@ -28,6 +28,9 @@ machine:
   %{ endif }
   sysctls:
     vm.nr_hugepages: "1024"
+%{ for name, value in sysctls ~}
+    ${name}: "${value}"
+%{ endfor ~}
   kernel:
     modules: # These modules will be loaded on all worker nodes
       - name: nvme_tcp # NVMe over TCP, generally useful for storage

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -59,6 +59,7 @@ variable "nodes_config" {
       mountpoint  = optional(string)
       unit_number = optional(number)
     }))),
+    sysctls     = optional(map(string), {}),
     gpu_devices = optional(list(string), []),
     #   map keyed by the same BDF strings you list in `gpu_devices`
     gpu_device_meta = optional(


### PR DESCRIPTION
## Summary
- restore Mastodon's Elasticsearch deployment sysctl block
- manage `vm.max_map_count` through Tofu node provisioning

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `kustomize build --enable-helm k8s/applications/web/mastodon/elasticsearch`
- `cd tofu && tofu fmt`
- `cd tofu && tofu validate`
- `cd website && npm run build` *(fails: docusaurus: not found)*
- `cd website && pre-commit run vale --all-files` *(fails: SSL certificate verify failed)*
- `pre-commit run --files k8s/applications/web/mastodon/elasticsearch/es-deployment.yaml tofu/talos/machine-config/worker.yaml.tftpl tofu/talos/config-machine.tf tofu/variables.tf tofu/nodes.auto.tfvars website/docs/k8s/applications/mastodon-implementation.md` *(fails: SSL certificate verify failed for Vale)*

------
https://chatgpt.com/codex/tasks/task_e_68911e1716fc8322ac1158f9ca1c7740