### PR TITLE
fix(mastodon): include bucket in proxy and allow CDN hosts

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -55,6 +55,8 @@ configMapGenerator:
     - S3_PROTOCOL=https
     - S3_REGION=us-west-1
     - S3_PERMISSION=public-read
+    - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
+    - CDN_HOST=https://cdn.goingdark.social
 
 resources:
   - namespace.yaml

--- a/k8s/applications/web/mastodon/networking/httproute-s3.yaml
+++ b/k8s/applications/web/mastodon/networking/httproute-s3.yaml
@@ -16,7 +16,6 @@ spec:
         - path:
             type: PathPrefix
             value: /
-          method: GET
       backendRefs:
         - name: mastodon-s3-proxy-internal-svc
           port: 80

--- a/k8s/applications/web/mastodon/proxy/nginx-proxy.yaml
+++ b/k8s/applications/web/mastodon/proxy/nginx-proxy.yaml
@@ -23,7 +23,8 @@ data:
       }
 
       # Variable to force DNS re-resolution
-      set $s3_backend 'https://truenas.pc-tips.se:9000';
+      # Path-style for MinIO: include the bucket from S3_BUCKET=mastodata
+      set $s3_backend 'https://truenas.pc-tips.se:9000/mastodata';
 
             location @s3 {
         limit_except GET {

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -65,6 +65,19 @@ spec:
   storageClassName: longhorn
 ```
 
+## Content Delivery
+
+Media and static assets are served from `cdn.goingdark.social` through an internal Nginx proxy backed by MinIO. The environment ConfigMap exposes the host to Mastodon's Content Security Policy:
+
+```yaml
+# k8s/applications/web/mastodon/base/kustomization.yaml
+configMapGenerator:
+  - name: mastodon-env
+    literals:
+      - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
+      - CDN_HOST=https://cdn.goingdark.social
+```
+
 ## Sidekiq Resources
 
 Sidekiq processes background jobs. A larger instance benefits from more


### PR DESCRIPTION
## Summary
- include Mastodon bucket path in S3 proxy
- expose CDN host to Mastodon and allow HEAD on CDN route
- document CDN and CSP configuration

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/proxy`
- `kustomize build --enable-helm k8s/applications/web/mastodon/networking`
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `npm run build` in `website/`
- `pre-commit run --files website/docs/k8s/applications/mastodon-implementation.md` *(fails: URLError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68912acaf2388322afa41af3f0f56e3a