### PR TITLE
fix(mastodon): remove CDN_HOST override

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -56,7 +56,6 @@ configMapGenerator:
     - S3_REGION=us-west-1
     - S3_PERMISSION=public-read
     - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
-    - CDN_HOST=https://cdn.goingdark.social
 
 resources:
   - namespace.yaml

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -67,7 +67,7 @@ spec:
 
 ## Content Delivery
 
-Media and static assets are served from `cdn.goingdark.social` through an internal Nginx proxy backed by MinIO. The environment ConfigMap exposes the host to Mastodon's Content Security Policy:
+Media and static assets are served from `cdn.goingdark.social` through an internal Nginx proxy backed by MinIO. Mastodon trusts this host via the `EXTRA_MEDIA_HOSTS` variable; `CDN_HOST` stays unset so Rails keeps serving its own compiled assets:
 
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
@@ -75,7 +75,6 @@ configMapGenerator:
   - name: mastodon-env
     literals:
       - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
-      - CDN_HOST=https://cdn.goingdark.social
 ```
 
 ## Sidekiq Resources


### PR DESCRIPTION
## Summary
- restore Rails asset URLs by dropping `CDN_HOST`
- document that only `EXTRA_MEDIA_HOSTS` is set for Mastodon

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `npm install`
- `npm run build`
- `pre-commit run --files k8s/applications/web/mastodon/base/kustomization.yaml website/docs/k8s/applications/mastodon-implementation.md` *(fails: certificate verify failed installing Vale)*

------
https://chatgpt.com/codex/tasks/task_e_689137bf22a083228e8c5c54006546b0