### PR TITLE
feat(mastodon): add hcaptcha secrets

### DIFF
--- a/k8s/applications/web/mastodon/base/externalsecret.yaml
+++ b/k8s/applications/web/mastodon/base/externalsecret.yaml
@@ -60,3 +60,9 @@ spec:
     - secretKey: S3_ENDPOINT
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: HCAPTCHA_SITE_KEY
+      remoteRef:
+        key: app-mastodon-hcaptcha-site-key
+    - secretKey: HCAPTCHA_SECRET_KEY
+      remoteRef:
+        key: app-mastodon-hcaptcha-secret-key

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -50,6 +50,19 @@ configMapGenerator:
   - SMTP_ENABLE_STARTTLS=never
 ```
 
+## Captcha
+
+New accounts must solve an hCaptcha challenge. The site and secret keys come from the same `mastodon-app-secrets` ExternalSecret:
+
+```yaml
+# k8s/applications/web/mastodon/base/externalsecret.yaml
+data:
+  - secretKey: HCAPTCHA_SITE_KEY
+    remoteRef: { key: app-mastodon-hcaptcha-site-key }
+  - secretKey: HCAPTCHA_SECRET_KEY
+    remoteRef: { key: app-mastodon-hcaptcha-secret-key }
+```
+
 ## Media Storage
 
 Attachments are stored on a Persistent Volume Claim named `mastodon-public-pvc`.


### PR DESCRIPTION
## Summary
- add hcaptcha site and secret keys to mastodon external secret
- document hcaptcha variables

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build` *(fails: docusaurus: not found)*
- `pre-commit run --files k8s/applications/web/mastodon/base/externalsecret.yaml website/docs/k8s/applications/mastodon-implementation.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6891ad6b24308322ab8438614c0f00f5