### PR TITLE
fix(k8s): render sabnzbd secrets in config

### DIFF
--- a/k8s/applications/media/sabnzbd/config/sabnzbd.ini
+++ b/k8s/applications/media/sabnzbd/config/sabnzbd.ini
@@ -1,7 +1,7 @@
 __encoding__ = utf-8
 __version__ = 19
 [misc]
-api_key =
+api_key = ${SABNZBD__MISC__API_KEY}
 host_whitelist = sabnzbd, sabnzbd.media, sabnzbd.media.svc, sabnzbd.media.svc.cluster.local, sabnzbd.pc-tips.se
 config_conversion_version = 4
 helpful_warnings = 1
@@ -34,7 +34,7 @@ https_key = server.key
 https_chain = ""
 enable_https = 0
 inet_exposure = 0
-nzb_key =
+nzb_key = ${SABNZBD__MISC__NZB_KEY}
 socks5_proxy_url = ""
 permissions = ""
 download_dir = /downloads/incomplete

--- a/k8s/applications/media/sabnzbd/statefulset.yaml
+++ b/k8s/applications/media/sabnzbd/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
       initContainers:
         - name: seed-config
           image: busybox:1.37
+          envFrom:
+            - secretRef:
+                name: sabnzbd-secrets
           command:
             - sh
             - -c
@@ -35,7 +38,7 @@ spec:
               set -e
               echo "Seeding sabnzbd.ini to /config"
               if [ ! -f /config/sabnzbd.ini ]; then
-                cp /config-template/sabnzbd.ini /config/sabnzbd.ini
+                envsubst < /config-template/sabnzbd.ini > /config/sabnzbd.ini
               fi
               mkdir -p /downloads/incomplete /app/data/downloads
               chown -R 2501:2501 /config /downloads /app/data

--- a/website/docs/applications/sabnzbd.md
+++ b/website/docs/applications/sabnzbd.md
@@ -16,4 +16,4 @@ Credentials are stored in Bitwarden. An `ExternalSecret` pulls the API key and U
 
 ## Configuration seeding
 
-An init container renders `sabnzbd.ini` from a ConfigMap template. If the file already exists, the container skips seeding.
+An init container renders `sabnzbd.ini` from a ConfigMap template, substituting secrets into the file before copying it. If the file already exists, the container skips seeding.


### PR DESCRIPTION
## Summary
- inject secret API keys into `sabnzbd.ini`
- seed config via envsubst in init container
- document config rendering

## Testing
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `npm run build`
- `pre-commit run vale --all-files` *(fails: URLError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68928609077c83229085a976d778b0a8