### PR TITLE
fix(sabnzbd): overwrite config during init

### DIFF
--- a/k8s/applications/media/sabnzbd/statefulset.yaml
+++ b/k8s/applications/media/sabnzbd/statefulset.yaml
@@ -37,9 +37,7 @@ spec:
             - |
               set -e
               echo "Seeding sabnzbd.ini to /config"
-              if [ ! -f /config/sabnzbd.ini ]; then
-                envsubst < /config-template/sabnzbd.ini > /config/sabnzbd.ini
-              fi
+              envsubst < /config-template/sabnzbd.ini > /config/sabnzbd.ini
               mkdir -p /downloads/incomplete /app/data/downloads
               chown -R 2501:2501 /config /downloads /app/data
           volumeMounts:

--- a/website/docs/applications/sabnzbd.md
+++ b/website/docs/applications/sabnzbd.md
@@ -16,4 +16,4 @@ Credentials are stored in Bitwarden. An `ExternalSecret` pulls the API key and U
 
 ## Configuration seeding
 
-An init container renders `sabnzbd.ini` from a ConfigMap template, substituting secrets into the file before copying it. If the file already exists, the container skips seeding.
+An init container renders `sabnzbd.ini` from a ConfigMap template and always copies it into the config volume, applying any updated settings on every start.


### PR DESCRIPTION
## Summary
- overwrite sabnzbd config on every startup to ensure host whitelist and other settings apply
- document the always-seeded config behavior

## Testing
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `npm install`
- `npm run build` (website)
- `pre-commit run --files k8s/applications/media/sabnzbd/statefulset.yaml website/docs/applications/sabnzbd.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68928f6748d8832287a188cd765627d5