### PR TITLE
fix(sabnzbd): ensure config seed uses envsubst

### DIFF
--- a/k8s/applications/media/sabnzbd/statefulset.yaml
+++ b/k8s/applications/media/sabnzbd/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: seed-config
-          image: alpine:latest
+          image: busybox:1.37
           envFrom:
             - secretRef:
                 name: sabnzbd-secrets
@@ -35,11 +35,15 @@ spec:
             - sh
             - -c
             - |
-              set -e
+              set -euo pipefail
               echo "Seeding sabnzbd.ini to /config"
+              command -v envsubst >/dev/null || { echo "envsubst not found" >&2; exit 1; }
               envsubst < /config-template/sabnzbd.ini > /config/sabnzbd.ini
+              echo "Rendered sabnzbd.ini"
               mkdir -p /downloads/incomplete /app/data/downloads
+              echo "Prepared download directories"
               chown -R 2501:2501 /config /downloads /app/data
+              echo "Config seed complete"
           volumeMounts:
             - name: config
               mountPath: /config

--- a/website/docs/applications/sabnzbd.md
+++ b/website/docs/applications/sabnzbd.md
@@ -16,4 +16,4 @@ Credentials are stored in Bitwarden. An `ExternalSecret` pulls the API key and U
 
 ## Configuration seeding
 
-An init container renders `sabnzbd.ini` from a ConfigMap template and always copies it into the config volume, applying any updated settings on every start.
+An init container uses `envsubst` to render `sabnzbd.ini` from a ConfigMap template. The file is copied into the config volume on every start so new settings take effect without manual steps.


### PR DESCRIPTION
## Summary
- use busybox init container with `envsubst`
- log config seeding steps
- document busybox templating of `sabnzbd.ini`

## Testing
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `npm run build` *(fails: docusaurus: not found)*
- `pre-commit run --files k8s/applications/media/sabnzbd/statefulset.yaml website/docs/applications/sabnzbd.md` *(fails: certificate verify failed)*
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_689296059400832294d0ba51abe81819