### PR TITLE
chore(mastodon): update to v4.4.3

### DIFF
--- a/k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml
+++ b/k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: Always
       containers:
         - name: sidekiq
-          image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+          image: ghcr.io/glitch-soc/mastodon:v4.4.3
           args:
           - bundle
           - exec

--- a/k8s/applications/web/mastodon/streaming/streaming-deployment.yaml
+++ b/k8s/applications/web/mastodon/streaming/streaming-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: streaming
-          image: ghcr.io/glitch-soc/mastodon-streaming:nightly.2025-07-31
+          image: ghcr.io/glitch-soc/mastodon-streaming:v4.4.3
           command: ["node", "./streaming/index.js"]
           ports:
             - name: streaming

--- a/k8s/applications/web/mastodon/web/web-deployment.yaml
+++ b/k8s/applications/web/mastodon/web/web-deployment.yaml
@@ -26,7 +26,7 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-          image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+          image: ghcr.io/glitch-soc/mastodon:v4.4.3
           command: ["/bin/bash", "-c", "bundle exec rails db:migrate && bundle exec puma -C config/puma.rb"]
           ports:
             - name: http

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -109,16 +109,16 @@ resources:
 ## Container Images
 
 This deployment uses the Glitch-soc variant of Mastodon for additional features.
-All components reference the `nightly.2025-07-31` tag:
+All components reference the `v4.4.3` tag:
 
 ```yaml
 # k8s/applications/web/mastodon/web-deployment.yaml
-image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+image: ghcr.io/glitch-soc/mastodon:v4.4.3
 
 # k8s/applications/web/mastodon/sidekiq-deployment.yaml
-image: ghcr.io/glitch-soc/mastodon:nightly.2025-07-31
+image: ghcr.io/glitch-soc/mastodon:v4.4.3
 
 # k8s/applications/web/mastodon/streaming-deployment.yaml
-image: ghcr.io/glitch-soc/mastodon-streaming:nightly.2025-07-31
+image: ghcr.io/glitch-soc/mastodon-streaming:v4.4.3
 ```
 


### PR DESCRIPTION
## Summary
- update Mastodon containers to v4.4.3
- document new Mastodon image tag

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/web`
- `kustomize build --enable-helm k8s/applications/web/mastodon/sidekiq`
- `kustomize build --enable-helm k8s/applications/web/mastodon/streaming`
- `npm install`
- `npm run build`
- `pre-commit run --files k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml k8s/applications/web/mastodon/streaming/streaming-deployment.yaml k8s/applications/web/mastodon/web/web-deployment.yaml website/docs/k8s/applications/mastodon-implementation.md` *(fails: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_68934dea7e2483229d53389f348d69bd