### PR TITLE
fix(mastodon): label namespace for baseline podsecurity

### DIFF
--- a/k8s/applications/web/mastodon/base/namespace.yaml
+++ b/k8s/applications/web/mastodon/base/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mastodon
+  labels:
+    podsecurity.kubernetes.io/enforce: baseline
+    podsecurity.kubernetes.io/enforce-version: latest

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -50,6 +50,17 @@ configMapGenerator:
       - ES_PRESET=single_node_cluster
 ```
 
+The pod raises `vm.max_map_count` to `262144`. Kubernetes blocks that sysctl under the `restricted` PodSecurity profile, so the namespace uses the `baseline` policy instead:
+
+```yaml
+# k8s/applications/web/mastodon/base/namespace.yaml
+metadata:
+  name: mastodon
+  labels:
+    podsecurity.kubernetes.io/enforce: baseline
+    podsecurity.kubernetes.io/enforce-version: latest
+```
+
 ## Read replica
 
 Rails sends read-only queries to the standby database when these variables are present:


### PR DESCRIPTION
## Summary
- allow vm.max_map_count by enforcing PodSecurity baseline in mastodon namespace
- document why mastodon opts into baseline profile

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `kustomize build --enable-helm k8s/applications/web/mastodon`
- `npm run build` (from `website/`)
- `pre-commit run --files k8s/applications/web/mastodon/base/namespace.yaml website/docs/k8s/applications/mastodon-implementation.md` *(fails: certificate verify failed)*
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_6893bcdd030c8322bfcb09e1c61169de