### PR TITLE
fix(mastodon): route replica database through pooler

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -25,7 +25,7 @@ configMapGenerator:
     - ES_PORT=9200
     - ES_PRESET=single_node_cluster
     # --- Read Replica ---
-    - REPLICA_DB_HOST=mastodon-postgresql-replicas
+    - REPLICA_DB_HOST=mastodon-postgresql-pooler
     - REPLICA_DB_PORT=5432
     - REPLICA_DB_NAME=mastodon
     - REPLICA_PREPARED_STATEMENTS=false


### PR DESCRIPTION
## Summary
- route Mastodon replica database traffic through PgBouncer

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `kustomize build --enable-helm k8s/applications/web/mastodon/postgres`
- `pre-commit run --files k8s/applications/web/mastodon/base/kustomization.yaml` *(fails: certificate verify failed: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_6893c60654888322a2a4dafe13f83270