### PR TITLE
fix(mastodon): run migrations via job

### DIFF
--- a/k8s/applications/web/mastodon/web/kustomization.yaml
+++ b/k8s/applications/web/mastodon/web/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - web-deployment.yaml
+  - migrate-job.yaml
   - svc.yaml
+  - web-deployment.yaml

--- a/k8s/applications/web/mastodon/web/migrate-job.yaml
+++ b/k8s/applications/web/mastodon/web/migrate-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mastodon-migrate
+  namespace: mastodon
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+spec:
+  template:
+    spec:
+      serviceAccountName: mastodon-eso-reader
+      containers:
+        - name: migrate
+          image: ghcr.io/glitch-soc/mastodon:v4.4.3
+          command:
+            - /bin/bash
+            - -c
+            - bundle exec rails db:migrate
+          envFrom:
+            - secretRef: { name: mastodon-app-secrets }
+            - secretRef: { name: mastodon-db-url }
+            - configMapRef: { name: mastodon-env }
+      restartPolicy: OnFailure

--- a/k8s/applications/web/mastodon/web/web-deployment.yaml
+++ b/k8s/applications/web/mastodon/web/web-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           image: ghcr.io/glitch-soc/mastodon:v4.4.3
-          command: ["/bin/bash", "-c", "bundle exec rails db:migrate && bundle exec puma -C config/puma.rb"]
+          command: ["/bin/bash", "-c", "bundle exec puma -C config/puma.rb"]
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## Summary
- run Mastodon migrations via pre-install job
- start web pods without db:migrate
- document DB_SSLMODE and migration flow

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/web`
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `npm install`
- `npm run build`
- `pre-commit run --files k8s/applications/web/mastodon/web/web-deployment.yaml k8s/applications/web/mastodon/web/kustomization.yaml k8s/applications/web/mastodon/web/migrate-job.yaml website/docs/k8s/applications/mastodon-implementation.md` *(fails: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_6893e4d6cac083229abcda68bff0b8b5