### PR TITLE
fix(mastodon): add backup credentials secret

### DIFF
--- a/k8s/applications/media/immich/immich-server/kustomization.yaml
+++ b/k8s/applications/media/immich/immich-server/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: immich
 resources:
   - immich-config-external-secret.yaml
   - externalsecret.yaml
+  - minio-externalsecret.yaml
   - database.yaml
   - zalando-k8s-store.yaml
   - serviceaccount.yaml

--- a/k8s/applications/media/immich/immich-server/minio-externalsecret.yaml
+++ b/k8s/applications/media/immich/immich-server/minio-externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: immich
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/applications/web/mastodon/postgres/kustomization.yaml
+++ b/k8s/applications/web/mastodon/postgres/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - postgresql-server-cert.yaml
   - mastodon-postgresql-ca.yaml
   - externalsecret.yaml
+  - minio-externalsecret.yaml

--- a/k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml
+++ b/k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: mastodon
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/infrastructure/auth/authentik/kustomization.yaml
+++ b/k8s/infrastructure/auth/authentik/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - database.yaml
 - httproute.yaml
 - outpost-externalsecret.yaml
+- minio-externalsecret.yaml
 - referencegrant.yaml
 - extra
 generatorOptions:

--- a/k8s/infrastructure/auth/authentik/minio-externalsecret.yaml
+++ b/k8s/infrastructure/auth/authentik/minio-externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: auth
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/website/docs/infrastructure/auth/authentik-setup.md
+++ b/website/docs/infrastructure/auth/authentik-setup.md
@@ -58,6 +58,17 @@ Two sample accounts are bootstrapped via Authentik blueprints to show how group 
 
 Passwords and emails come from ExternalSecrets entries referenced in `authentik-blueprint-secrets`.
 
+## Database Backups
+
+The database backups upload to MinIO with credentials managed by an ExternalSecret:
+
+```yaml
+# k8s/infrastructure/auth/authentik/minio-externalsecret.yaml
+spec:
+  target:
+    name: longhorn-minio-credentials
+```
+
 ## Configuration Guide
 
 ### 1. Protecting a New Application

--- a/website/docs/k8s/applications/immich-implementation.md
+++ b/website/docs/k8s/applications/immich-implementation.md
@@ -119,3 +119,14 @@ spec:
         requests:
           storage: 40Gi
 ```
+
+### Backups
+
+Database backups use MinIO credentials from an ExternalSecret:
+
+```yaml
+# k8s/applications/media/immich/immich-server/minio-externalsecret.yaml
+spec:
+  target:
+    name: longhorn-minio-credentials
+```

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -102,6 +102,17 @@ configMapGenerator:
       - REPLICA_DB_TASKS=false
 ```
 
+## Backups
+
+The PostgreSQL operator uploads backups to MinIO with credentials sourced from an ExternalSecret:
+
+```yaml
+# k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml
+spec:
+  target:
+    name: longhorn-minio-credentials
+```
+
 ## Metrics
 
 Prometheus metrics expose runtime information for scraping:


### PR DESCRIPTION
## Summary
- add ExternalSecret for MinIO backup credentials in Mastodon, Immich, and Authentik namespaces
- document backup credential configuration

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/postgres | rg -n longhorn-minio-credentials`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server | rg -n longhorn-minio-credentials`
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik | rg -n longhorn-minio-credentials`
- `npm run build` *(fails: docusaurus: not found)*
- `pre-commit run vale --all-files` *(fails: certificate verify failed)*
- `pre-commit run --files k8s/applications/media/immich/immich-server/minio-externalsecret.yaml k8s/applications/media/immich/immich-server/kustomization.yaml k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml k8s/applications/web/mastodon/postgres/kustomization.yaml k8s/infrastructure/auth/authentik/minio-externalsecret.yaml k8s/infrastructure/auth/authentik/kustomization.yaml website/docs/k8s/applications/mastodon-implementation.md website/docs/k8s/applications/immich-implementation.md website/docs/infrastructure/auth/authentik-setup.md` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_689592d303a08322a1d9b252633c1f9c