### PR TITLE
fix(ci): quote pattern and separator in Vale workflow

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -1,14 +1,15 @@
+---
 permissions:
   contents: read
   pull-requests: write
 
 name: Vale Documentation Lint
 
-on:
+'on':
   pull_request:
-    paths: [ 'website/docs/**/*.md' ]
+    paths: ['website/docs/**/*.md']
   push:
-    paths: [ 'website/docs/**/*.md' ]
+    paths: ['website/docs/**/*.md']
 
 jobs:
   docs_lint:
@@ -24,15 +25,15 @@ jobs:
         id: changed
         uses: tj-actions/changed-files@v46
         with:
-          files: website/docs/**/*.md
-          separator: ,
+          files: 'website/docs/**/*.md'
+          separator: ','
 
       - name: Run Vale with reviewdog
         if: steps.changed.outputs.any_changed == 'true'
         uses: errata-ai/vale-action@v2.1.1
         with:
           files: ${{ steps.changed.outputs.all_changed_files }}
-          separator: ,
+          separator: ','
           vale_flags: '--config=website/utils/vale/.vale.ini'
           reporter: github-pr-review   # inline PR comments
           level: warning              # INFO is non-blocking


### PR DESCRIPTION
## Summary
- fix YAML syntax in Vale lint workflow

## Testing
- `yamllint .github/workflows/vale.yaml`
- `pre-commit run --files .github/workflows/vale.yaml` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*

------
https://chatgpt.com/codex/tasks/task_e_6896048504048322aff3b9a8a0c05e2b