### PR TITLE
fix(mastodon): route replica traffic through pooler

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -29,7 +29,7 @@ configMapGenerator:
       - ES_PORT=9200
       - ES_PRESET=
       # --- Read Replica ---
-      - REPLICA_DB_HOST=mastodon-postgresql-repl
+      - REPLICA_DB_HOST=mastodon-postgresql-repl-pooler
       - REPLICA_DB_PORT=5432
       - REPLICA_DB_NAME=mastodon
       - REPLICA_PREPARED_STATEMENTS=false

--- a/k8s/applications/web/mastodon/postgres/postgresql-server-cert.yaml
+++ b/k8s/applications/web/mastodon/postgres/postgresql-server-cert.yaml
@@ -16,6 +16,10 @@ spec:
     - mastodon-postgresql.mastodon.svc.kube.pc-tips.se
     - mastodon-postgresql-pooler
     - mastodon-postgresql-pooler.mastodon.svc
+    - mastodon-postgresql-repl
+    - mastodon-postgresql-repl.mastodon.svc
+    - mastodon-postgresql-repl-pooler
+    - mastodon-postgresql-repl-pooler.mastodon.svc
   duration: 2160h       # 90 days
   renewBefore: 360h     # renew 15 days before expiry
   usages:

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -95,7 +95,7 @@ Rails sends read-only queries to the standby database when these variables are p
 configMapGenerator:
   - name: mastodon-env
     literals:
-      - REPLICA_DB_HOST=mastodon-postgresql-repl
+      - REPLICA_DB_HOST=mastodon-postgresql-repl-pooler
       - REPLICA_DB_PORT=5432
       - REPLICA_DB_NAME=mastodon
       - REPLICA_PREPARED_STATEMENTS=false


### PR DESCRIPTION
## Summary
- direct read traffic to `mastodon-postgresql-repl-pooler`
- include replica pooler names in Postgres cert
- document replica pooler host

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `kustomize build --enable-helm k8s/applications/web/mastodon/postgres`
- `npm run build`
- `pre-commit run vale --all-files` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier>)*


------
https://chatgpt.com/codex/tasks/task_e_68959442e86083228379b8c4def46d18