### PR TITLE
fix(pre-commit): add document start

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/errata-ai/vale
     rev: v3.12.0


### PR DESCRIPTION
## Summary
- fix pre-commit config by adding missing YAML document start

## Testing
- `npm run build`
- `pre-commit run vale --all-files` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*


------
https://chatgpt.com/codex/tasks/task_e_68960a153c308322815622ef48c681f0