### PR TITLE
refactor: scope Mastodon env config per component

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -4,79 +4,66 @@ kind: Kustomization
 namespace: mastodon
 
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-core-env
     literals:
-      # --- Base Mastodon Config ---
       - RAILS_ENV=production
       - NODE_ENV=production
       - TZ=Europe/Stockholm
+      - SINGLE_USER_MODE=false
+      - DEFAULT_LOCALE=en
+      - MASTODON_USE_LIBVIPS=true
+      - RAILS_LOG_TO_STDOUT=true
+      - PREPARED_STATEMENTS=false
+  - name: mastodon-db-env
+    literals:
       - DB_HOST=mastodon-postgresql-pooler
       - DB_PORT=5432
       - DB_NAME=mastodon
       - DB_SSLMODE=verify-ca
       - DB_SSLROOTCERT=/opt/mastodon/.postgresql/root.crt
+      - DB_POOL=15
+      - REPLICA_DB_HOST=mastodon-postgresql-repl
+      - REPLICA_DB_PORT=5432
+      - REPLICA_DB_NAME=mastodon
+      - REPLICA_PREPARED_STATEMENTS=false
+      - REPLICA_DB_TASKS=false
+      - DATABASE_TIMEOUT=60
+      - STREAMING_DATABASE_TIMEOUT=10
+  - name: mastodon-cache-env
+    literals:
       - REDIS_HOST=mastodon-redis-master
       - REDIS_PORT=6379
       - REDIS_URL=redis://mastodon-redis-master:6379/0
       - SIDEKIQ_REDIS_URL=redis://mastodon-redis-master:6379/1
       - CACHE_REDIS_URL=redis://mastodon-redis-master:6379/2
       - STREAMING_REDIS_URL=redis://mastodon-redis-master:6379/3
-      # --- Caching Optimizations ---
       - QUERY_CACHE_REDIS_URL=redis://mastodon-redis-master:6379/4
-      # --- Elasticsearch ---
+      - SIDEKIQ_CONCURRENCY=15
+  - name: mastodon-search-env
+    literals:
       - ES_ENABLED=false
       - ES_HOST=release-name-elasticsearch
       - ES_PORT=9200
       - ES_PRESET=
-      # --- Read Replica ---
-      - REPLICA_DB_HOST=mastodon-postgresql-repl
-      - REPLICA_DB_PORT=5432
-      - REPLICA_DB_NAME=mastodon
-      - REPLICA_PREPARED_STATEMENTS=false
-      - REPLICA_DB_TASKS=false
-      # --- Database Query Optimizations ---
-      - DATABASE_TIMEOUT=60
-      - STREAMING_DATABASE_TIMEOUT=10
-      # --- Prometheus ---
+  - name: mastodon-metrics-env
+    literals:
       - MASTODON_PROMETHEUS_EXPORTER_ENABLED=true
       - MASTODON_PROMETHEUS_EXPORTER_LOCAL=true
-      - SINGLE_USER_MODE=false
-      - RAILS_LOG_TO_STDOUT=true
-      - PREPARED_STATEMENTS=false
-      - DB_POOL=15
-      # --- Performance Optimizations ---
-      #- FEED_PRELOAD_LIMIT=100
-      #- LOCAL_TIMELINE_LIMIT=1000
-      #- TIMELINE_PRELOAD_CACHE_SIZE=10000
-      # --- Federation & Privacy ---
+  - name: mastodon-features-env
+    literals:
       - FETCH_REPLIES_ENABLED=true
       - IP_RETENTION_PERIOD=15552000
-      # --- Performance  ---
-      - MASTODON_USE_LIBVIPS=true
-      # --- Admin Performance ---
-      #- DISABLE_ADMIN_ANALYTICS=true
-      #- ADMIN_ANALYTICS_CACHE_TTL=3600
-      # --- Locale  ---
-      - DEFAULT_LOCALE=en
-      #- FORCE_DEFAULT_LOCALE=true
-      # --- SMTP  ---
-      - SMTP_DELIVERY_METHOD=smtp
-      - SMTP_AUTH_METHOD=login
-      - SMTP_SSL=true
-      - SMTP_TLS=false
-      - SMTP_ENABLE_STARTTLS_AUTO=false
-      # --- Web Specific ---
+  - name: mastodon-network-env
+    literals:
       - PORT=3000
       - BIND=0.0.0.0
       - RAILS_SERVE_STATIC_FILES=true
       - WEB_CONCURRENCY=2
       - MAX_THREADS=5
       - STREAMING_API_BASE_URL=wss://goingdark.social
-      # --- Streaming Specific ---
       - STREAMING_PORT=4000
-      # --- Sidekiq Specific ---
-      - SIDEKIQ_CONCURRENCY=15
-      # --- S3 NON-SECRET Configuration ---
+  - name: mastodon-storage-env
+    literals:
       - S3_ENABLED=true
       - S3_BUCKET=mastodata
       - S3_ALIAS_HOST=cdn.goingdark.social
@@ -84,6 +71,13 @@ configMapGenerator:
       - S3_REGION=us-west-1
       - S3_PERMISSION=public-read
       - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
+  - name: mastodon-smtp-env
+    literals:
+      - SMTP_DELIVERY_METHOD=smtp
+      - SMTP_AUTH_METHOD=login
+      - SMTP_SSL=true
+      - SMTP_TLS=false
+      - SMTP_ENABLE_STARTTLS_AUTO=false
 
 resources:
   - namespace.yaml

--- a/k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml
+++ b/k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml
@@ -33,7 +33,21 @@ spec:
             - secretRef:
                 name: mastodon-db-url
             - configMapRef:
-                name: mastodon-env
+                name: mastodon-core-env
+            - configMapRef:
+                name: mastodon-db-env
+            - configMapRef:
+                name: mastodon-cache-env
+            - configMapRef:
+                name: mastodon-search-env
+            - configMapRef:
+                name: mastodon-metrics-env
+            - configMapRef:
+                name: mastodon-features-env
+            - configMapRef:
+                name: mastodon-storage-env
+            - configMapRef:
+                name: mastodon-smtp-env
           env:
             - name: DB_SSLMODE
               value: verify-ca

--- a/k8s/applications/web/mastodon/streaming/streaming-deployment.yaml
+++ b/k8s/applications/web/mastodon/streaming/streaming-deployment.yaml
@@ -34,7 +34,13 @@ spec:
             - secretRef:
                 name: mastodon-db-url
             - configMapRef:
-                name: mastodon-env
+                name: mastodon-core-env
+            - configMapRef:
+                name: mastodon-db-env
+            - configMapRef:
+                name: mastodon-cache-env
+            - configMapRef:
+                name: mastodon-network-env
           volumeMounts:
             - name: db-ca
               mountPath: /opt/mastodon/.postgresql/root.crt

--- a/k8s/applications/web/mastodon/web/migrate-job.yaml
+++ b/k8s/applications/web/mastodon/web/migrate-job.yaml
@@ -20,7 +20,21 @@ spec:
             - secretRef:
                 name: mastodon-db-url
             - configMapRef:
-                name: mastodon-env
+                name: mastodon-core-env
+            - configMapRef:
+                name: mastodon-db-env
+            - configMapRef:
+                name: mastodon-cache-env
+            - configMapRef:
+                name: mastodon-search-env
+            - configMapRef:
+                name: mastodon-metrics-env
+            - configMapRef:
+                name: mastodon-features-env
+            - configMapRef:
+                name: mastodon-storage-env
+            - configMapRef:
+                name: mastodon-smtp-env
           volumeMounts:
             - name: db-ca
               mountPath: /opt/mastodon/.postgresql/root.crt

--- a/k8s/applications/web/mastodon/web/web-deployment.yaml
+++ b/k8s/applications/web/mastodon/web/web-deployment.yaml
@@ -37,7 +37,23 @@ spec:
             - secretRef:
                 name: mastodon-db-url
             - configMapRef:
-                name: mastodon-env
+                name: mastodon-core-env
+            - configMapRef:
+                name: mastodon-db-env
+            - configMapRef:
+                name: mastodon-cache-env
+            - configMapRef:
+                name: mastodon-search-env
+            - configMapRef:
+                name: mastodon-metrics-env
+            - configMapRef:
+                name: mastodon-features-env
+            - configMapRef:
+                name: mastodon-network-env
+            - configMapRef:
+                name: mastodon-storage-env
+            - configMapRef:
+                name: mastodon-smtp-env
           env:
             - name: DB_SSLMODE
               value: verify-ca

--- a/website/docs/k8s/applications/mastodon-implementation.md
+++ b/website/docs/k8s/applications/mastodon-implementation.md
@@ -11,7 +11,7 @@ Rails connects to PgBouncer over TLS and validates the certificate. The CA comes
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-db-env
     literals:
       - DB_HOST=mastodon-postgresql-pooler
       - DB_SSLMODE=verify-ca
@@ -54,9 +54,11 @@ spec:
 
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-core-env
     literals:
       - PREPARED_STATEMENTS=false
+  - name: mastodon-db-env
+    literals:
       - DB_POOL=10
 ```
 
@@ -67,7 +69,7 @@ Full-text search and hashtag discovery rely on Elasticsearch. The deployment ena
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-search-env
     literals:
       - ES_ENABLED=true
       - ES_HOST=http://mastodon-es:9200
@@ -93,7 +95,7 @@ Rails sends read-only queries to the standby database when these variables are p
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-db-env
     literals:
       - REPLICA_DB_HOST=mastodon-postgresql-repl
       - REPLICA_DB_PORT=5432
@@ -120,7 +122,7 @@ Prometheus metrics expose runtime information for scraping:
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-metrics-env
     literals:
       - MASTODON_PROMETHEUS_EXPORTER_ENABLED=true
       - MASTODON_PROMETHEUS_EXPORTER_LOCAL=true
@@ -133,7 +135,7 @@ Sidekiq queues and application cache use separate Redis databases.
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-cache-env
     literals:
       - SIDEKIQ_REDIS_URL=redis://mastodon-redis-master:6379/1
       - CACHE_REDIS_URL=redis://mastodon-redis-master:6379/2
@@ -161,16 +163,15 @@ data:
 Rails is configured to use implicit TLS on port 465 and to avoid STARTTLS:
 
 ```yaml
-# k8s/applications/web/mastodon/kustomization.yaml
+# k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-common-env
+  - name: mastodon-smtp-env
     literals:
       - SMTP_DELIVERY_METHOD=smtp
       - SMTP_AUTH_METHOD=login
       - SMTP_SSL=true
       - SMTP_TLS=false
       - SMTP_ENABLE_STARTTLS_AUTO=false
-  - SMTP_ENABLE_STARTTLS=never
 ```
 
 ## Captcha
@@ -208,7 +209,7 @@ Media and static assets are served from `cdn.goingdark.social` through an intern
 ```yaml
 # k8s/applications/web/mastodon/base/kustomization.yaml
 configMapGenerator:
-  - name: mastodon-env
+  - name: mastodon-storage-env
     literals:
       - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
 ```


### PR DESCRIPTION
## Summary
- split Mastodon env vars into functional ConfigMaps
- mount only required env ConfigMaps in web, sidekiq, streaming, and migrate job
- document new env ConfigMap layout

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/base`
- `kustomize build --enable-helm k8s/applications/web/mastodon/web`
- `kustomize build --enable-helm k8s/applications/web/mastodon/sidekiq`
- `kustomize build --enable-helm k8s/applications/web/mastodon/streaming`
- `npm run build` *(failed: Warn: `blogDir` doesn't exist: "/workspace/homelab/website/blog".)*
- `pre-commit run vale --all-files` *(failed: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*
- `pre-commit run --files k8s/applications/web/mastodon/base/kustomization.yaml k8s/applications/web/mastodon/sidekiq/sidekiq-deployment.yaml k8s/applications/web/mastodon/streaming/streaming-deployment.yaml k8s/applications/web/mastodon/web/migrate-job.yaml k8s/applications/web/mastodon/web/web-deployment.yaml website/docs/k8s/applications/mastodon-implementation.md` *(failed: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*

------
https://chatgpt.com/codex/tasks/task_e_689611d21788832291fc5d513ee74b92