### PR TITLE
fix(ci): consolidate Vale comments into single check

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -35,9 +35,9 @@ jobs:
           files: ${{ steps.changed.outputs.all_changed_files }}
           separator: ','
           vale_flags: '--config=website/utils/vale/.vale.ini'
-          reporter: github-pr-review   # inline PR comments
-          level: warning              # INFO is non-blocking
-          fail_on_error: true         # fail on WARN or ERR only
-          filter_mode: file           # lint entire file when it changes
+          reporter: github-pr-check
+          level: warning
+          fail_on_error: true
+          filter_mode: file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -45,7 +45,7 @@ This page explains how GitHub Actions, Renovate, and Dependabot keep this homela
 - **File:** `.github/workflows/vale.yaml`
 - **Purpose:** Lints Markdown files in `website/docs` using [Vale](https://vale.sh/).
 - **When triggered:** Only when `.md` files change under `website/docs/`.
-- **How it works:** The workflow runs Vale only on the Markdown files that changed in the PR.
+- **How it works:** The workflow lints only the changed Markdown files and posts the results as a single pull request check.
 
 ### Validation & CI (Implied Workflows)
 


### PR DESCRIPTION
## Summary
- adjust vale workflow to post a single consolidated check
- document vale job behavior

## Testing
- `npm install`
- `npm run build`
- `pre-commit run vale --all-files` *(fails: URLError: certificate verify failed)*
- `pre-commit run --files .github/workflows/vale.yaml website/docs/github/github-configuration.md` *(fails: URLError: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68964fc621ac83228b928cfbe2bd5b74