### PR TITLE
fix(k8s): set minio endpoint for logical backups

### DIFF
--- a/k8s/applications/media/immich/immich-server/minio-externalsecret.yaml
+++ b/k8s/applications/media/immich/immich-server/minio-externalsecret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml
+++ b/k8s/applications/web/mastodon/postgres/minio-externalsecret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/infrastructure/auth/authentik/minio-externalsecret.yaml
+++ b/k8s/infrastructure/auth/authentik/minio-externalsecret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/infrastructure/database/postgresql/externalsecret.yaml
+++ b/k8s/infrastructure/database/postgresql/externalsecret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/infrastructure/database/postgresql/values.yaml
+++ b/k8s/infrastructure/database/postgresql/values.yaml
@@ -381,7 +381,7 @@ configLogicalBackup:
   # S3 region of bucket
   logical_backup_s3_region: "us-west-1"
   # S3 endpoint url when not using AWS
-  logical_backup_s3_endpoint: ""
+  logical_backup_s3_endpoint: "https://truenas.pc-tips.se:9000"
   # S3 Secret Access Key
   logical_backup_s3_secret_access_key: ""
   # S3 server side encryption

--- a/k8s/infrastructure/storage/longhorn/externalsecret.yaml
+++ b/k8s/infrastructure/storage/longhorn/externalsecret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: AWS_ENDPOINTS
       remoteRef:
         key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/website/docs/infrastructure/database/postgres-backup.md
+++ b/website/docs/infrastructure/database/postgres-backup.md
@@ -4,10 +4,10 @@ title: PostgreSQL Backups
 description: Logical backups using the Zalando operator and Minio storage
 ---
 
-# PostgreSQL Operator Backup Configuration
+# Postgres operator backup configuration
 
-The Zalando Postgres operator schedules `pg_dumpall` to run via a Kubernetes CronJob. Backups write to the `postgres` bucket on the cluster's Minio instance.
+The Zalando Postgres operator schedules `pg_dumpall` with a Kubernetes CronJob. Backups write to the `postgres` bucket on the cluster's Minio instance.
 
-Credentials come from the `ExternalSecret` named `longhorn-minio-credentials`. This secret is shared with Longhorn so the same Minio user manages all backups.
+The `longhorn-minio-credentials` ExternalSecret supplies credentials. Longhorn uses this secret too, so one Minio user handles every backup. It must also expose `LOGICAL_BACKUP_S3_ENDPOINT` so the job points at Minio.
 
-The default schedule stores a dump every night at 03:00 UTC. Adjust `logical_backup_schedule` in `values.yaml` if needed.
+Set `logical_backup_s3_endpoint` in `values.yaml` to the same URL. The default schedule stores a dump every night at 03:00 Coordinated Universal Time. Adjust `logical_backup_schedule` if needed.

--- a/website/docs/infrastructure/database/postgres-backup.md
+++ b/website/docs/infrastructure/database/postgres-backup.md
@@ -10,4 +10,4 @@ The Zalando Postgres operator schedules `pg_dumpall` with a Kubernetes CronJob. 
 
 The `longhorn-minio-credentials` ExternalSecret supplies credentials. Longhorn uses this secret too, so one Minio user handles every backup. It must also expose `LOGICAL_BACKUP_S3_ENDPOINT` so the job points at Minio.
 
-Set `logical_backup_s3_endpoint` in `values.yaml` to the same URL. The default schedule stores a dump every night at 03:00 Coordinated Universal Time. Adjust `logical_backup_schedule` if needed.
+Set `logical_backup_s3_endpoint` in `values.yaml` to the Minio S3 endpoint URL (the value of `LOGICAL_BACKUP_S3_ENDPOINT` exposed by the `longhorn-minio-credentials` secret). The default schedule stores a dump every night at 03:00 Coordinated Universal Time. Adjust `logical_backup_schedule` if needed.


### PR DESCRIPTION
## Summary
- specify Minio endpoint for Postgres logical backups
- expose `LOGICAL_BACKUP_S3_ENDPOINT` in shared Minio secrets
- document backup endpoint configuration

## Testing
- `kustomize build --enable-helm k8s/infrastructure/database/postgresql`
- `kustomize build --enable-helm k8s/infrastructure/storage/longhorn`
- `kustomize build --enable-helm k8s/applications/web/mastodon/postgres`
- `kustomize build --enable-helm k8s/applications/media/immich/immich-server`
- `kustomize build --enable-helm k8s/infrastructure/auth/authentik`
- `vale --config=website/utils/vale/.vale.ini website/docs/infrastructure/database/postgres-backup.md`


------
https://chatgpt.com/codex/tasks/task_e_6898762f9d288322a8b4a568ff234c02