### PR TITLE
fix(sabnzbd): install cherrypy runtime dependency

### DIFF
--- a/images/sabnzbd/Dockerfile
+++ b/images/sabnzbd/Dockerfile
@@ -52,7 +52,7 @@ RUN python3 -m venv $VENV \
  && $VENV/bin/pip install --upgrade pip setuptools wheel \
  && git clone --depth 1 --branch "$SAB_VERSION" \
         https://github.com/sabnzbd/sabnzbd.git /app/sabnzbd \
- && $VENV/bin/pip install --no-cache-dir -r /app/sabnzbd/requirements.txt \
+ && $VENV/bin/pip install --no-cache-dir -r /app/sabnzbd/requirements.txt cherrypy \
  && mkdir /defaults \
  && $VENV/bin/python -m sabnzbd --config-file /defaults/sabnzbd.ini \
       --server 127.0.0.1:9 || true

--- a/website/docs/k8s/applications/sabnzbd-implementation.md
+++ b/website/docs/k8s/applications/sabnzbd-implementation.md
@@ -6,7 +6,7 @@ SABnzbd runs as a StatefulSet and keeps its own `sabnzbd.ini`. Environment varia
 
 ## Image
 
-The image builds SABnzbd from the official release tarball in a Python 3.12 virtual environment. It runs on a distroless base as UID 2501. A default `sabnzbd.ini` is generated during the build and copied to `/config` only when that directory is empty.
+The image builds SABnzbd from the official release tarball in a Python 3.12 virtual environment. It runs on a distroless base as UID 2501. Dependencies from `requirements.txt`, including CherryPy, are installed during the build. A default `sabnzbd.ini` is generated during the build and copied to `/config` only when that directory is empty.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- ensure cherrypy gets installed when building SABnzbd image
- document SABnzbd image dependency installation

## Testing
- `pre-commit run --files images/sabnzbd/Dockerfile website/docs/k8s/applications/sabnzbd-implementation.md` *(failed: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*
- `vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/sabnzbd-implementation.md` *(command not found)*
- `docker build -t sabnzbd-test images/sabnzbd` *(failed: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68991f6f35f483229b5fe6c347e3d267