### PR TITLE
fix(mastodon): disable s3 acls for r2

### DIFF
--- a/k8s/applications/web/mastodon/base/kustomization.yaml
+++ b/k8s/applications/web/mastodon/base/kustomization.yaml
@@ -70,7 +70,7 @@ configMapGenerator:
       - S3_ALIAS_HOST=cdn.goingdark.social
       - S3_PROTOCOL=https
       - S3_REGION=auto
-      - S3_PERMISSION=public-read
+      - S3_PERMISSION=
       - EXTRA_MEDIA_HOSTS=https://cdn.goingdark.social
   - name: mastodon-smtp-env
     literals:

--- a/website/docs/k8s/applications/mastodon/r2-acl.md
+++ b/website/docs/k8s/applications/mastodon/r2-acl.md
@@ -1,0 +1,34 @@
+---
+title: Mastodon Cloudflare R2 access control
+---
+This document covers access control list (ACL) errors when Mastodon uses Cloudflare R2 for object storage.
+
+### R2 rejects access control lists
+
+*   **Problem:** Mastodon tries to set a `public-read` access control list and R2 returns an error.
+*   **Rationale:** R2 speaks the S3 API but ignores access control lists.
+*   **Fix:** Leave `S3_PERMISSION` blank so Mastodon skips ACL calls.
+
+**Key configuration change:**
+
+```yaml
+- S3_PERMISSION=
+```
+
+### Best practices
+
+*   Leave `S3_PERMISSION` unset when the object store doesn't support access control lists.
+
+### Checking your work
+
+To validate your changes, run the following commands:
+
+```shell
+kustomize build applications/web/mastodon/
+npm run build
+```
+
+### See also
+
+*   [Mastodon Kustomization](https://github.com/theepicsaxguy/homelab/blob/main/k8s/applications/web/mastodon/kustomization.yaml)
+

--- a/website/utils/vale/styles/Project/provider-words.txt
+++ b/website/utils/vale/styles/Project/provider-words.txt
@@ -26,3 +26,6 @@ VPC
 xpkg.crossplane.io
 Whoami
 Unrar
+R2
+ACL
+ACLs


### PR DESCRIPTION
## Summary
- leave `S3_PERMISSION` empty when using Cloudflare R2
- document R2 ACL behavior and allow terms in Vale dictionary

## Testing
- `pre-commit run --files k8s/applications/web/mastodon/base/kustomization.yaml website/docs/k8s/applications/mastodon/r2-acl.md website/utils/vale/styles/Project/provider-words.txt` *(failed: URLError: certificate verify failed)*
- `SKIP=vale pre-commit run --files k8s/applications/web/mastodon/base/kustomization.yaml website/docs/k8s/applications/mastodon/r2-acl.md website/utils/vale/styles/Project/provider-words.txt`
- `vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/mastodon/r2-acl.md`
- `kustomize build --enable-helm k8s/applications/web/mastodon`


------
https://chatgpt.com/codex/tasks/task_e_6899ae305d848322bc31eaf1023148a3