### PR TITLE
fix(kibana): add missing template labels

### DIFF
--- a/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
@@ -13,10 +13,13 @@ spec:
   strategy:
     type: RollingUpdate
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: kibana
     spec:
       affinity:
-        nodeAffinity: null
-        podAffinity: null
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -47,7 +50,6 @@ spec:
           value: full
         - name: KIBANA_ELASTICSEARCH_ENABLE_TLS
           value: "true"
-        envFrom: null
         image: docker.io/bitnami/kibana:9.1.0-debian-12-r0
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -92,7 +94,6 @@ spec:
           runAsGroup: 1001
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -154,7 +155,6 @@ spec:
           runAsGroup: 1001
           runAsNonRoot: true
           runAsUser: 1001
-          seLinuxOptions: {}
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
@@ -164,8 +164,6 @@ spec:
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
-        supplementalGroups: []
-        sysctls: []
       serviceAccountName: kibana
       volumes:
       - emptyDir: {}


### PR DESCRIPTION
## Summary
- add template labels to match selector for Kibana deployment
- drop unused configuration

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/elasticsearch`
- `pre-commit run --files k8s/applications/web/mastodon/elasticsearch/deployment.yaml` *(fails: URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_689a4ae13d908322b7c0da848b3ccba0