### PR TITLE
fix(mastodon): expose elasticsearch master service

### DIFF
--- a/k8s/applications/web/mastodon/elasticsearch/kustomization.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - kibana.yml
 - networkpolicy
 - pvc-es.yaml
+- service.yaml
 - serviceaccount.yaml
 - setup-user-job.yaml
 - statefulset.yaml

--- a/k8s/applications/web/mastodon/elasticsearch/service.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: elasticsearch-master
   namespace: mastodon
 spec:
   clusterIP: None

--- a/website/docs/k8s/applications/mastodon/elasticsearch-service.md
+++ b/website/docs/k8s/applications/mastodon/elasticsearch-service.md
@@ -1,0 +1,14 @@
+---
+title: 'Elasticsearch service'
+---
+
+The headless Service provides a stable Domain Name System (DNS) name for the search cluster. The `elasticsearch-master` Service listens on port 9200 for the Representational State Transfer (REST) API.
+
+```yaml
+# k8s/applications/web/mastodon/elasticsearch/service.yaml
+metadata:
+  name: elasticsearch-master
+spec:
+  ports:
+    - port: 9200
+```


### PR DESCRIPTION
## Summary
- add `elasticsearch-master` headless Service exposing port 9200
- include Service in Mastodon Elasticsearch kustomization
- document the headless Service name and port

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/elasticsearch`
- `vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/mastodon/elasticsearch-service.md`
- `kubectl apply --dry-run=client -k k8s/applications/web/mastodon/elasticsearch` *(fails: connection refused)*
- `pre-commit run --files k8s/applications/web/mastodon/elasticsearch/service.yaml k8s/applications/web/mastodon/elasticsearch/kustomization.yaml website/docs/k8s/applications/mastodon/elasticsearch-service.md` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_689af4a6cb8c8322bf45eb39af9f0252