### PR TITLE
sabnzbd: store config in subdirectory

### DIFF
--- a/images/sabnzbd/Dockerfile
+++ b/images/sabnzbd/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=build /defaults           /defaults
 COPY entrypoint.py                    /entrypoint.py
 
 USER 2501:2501
-ENV PATH="/venv/bin:$PATH" PYTHONPATH="/app"
+ENV PATH="/venv/bin:$PATH" PYTHONPATH="/app" CONFIG_DIR="/config/sabnzbd"
 VOLUME ["/config", "/downloads/incomplete", "/app/data"]
 EXPOSE 8080
 ENTRYPOINT ["python", "/entrypoint.py"]

--- a/images/sabnzbd/entrypoint.py
+++ b/images/sabnzbd/entrypoint.py
@@ -2,7 +2,10 @@ import os
 import shutil
 import sys
 
-config_dir = os.environ.get("CONFIG_DIR", "/config/sabnzbd")
+config_dir = os.environ.get("CONFIG_DIR")
+if config_dir is None:
+    print("Error: CONFIG_DIR environment variable is not set.", file=sys.stderr)
+    sys.exit(1)
 config = os.path.join(config_dir, "sabnzbd.ini")
 default = "/defaults/sabnzbd.ini"
 

--- a/images/sabnzbd/entrypoint.py
+++ b/images/sabnzbd/entrypoint.py
@@ -2,14 +2,13 @@ import os
 import shutil
 import sys
 
-config = '/config/sabnzbd.ini'
-default = '/defaults/sabnzbd.ini'
+config_dir = os.environ.get("CONFIG_DIR", "/config/sabnzbd")
+config = os.path.join(config_dir, "sabnzbd.ini")
+default = "/defaults/sabnzbd.ini"
 
-# If PVC is empty, seed with current SAB defaults
 if not os.path.exists(config):
-    os.makedirs(os.path.dirname(config), exist_ok=True)
+    os.makedirs(config_dir, exist_ok=True)
     shutil.copy(default, config)
 
-# Change to SABnzbd directory and run SABnzbd
-os.chdir('/app/sabnzbd')
-os.execv(sys.executable, [sys.executable, '-m', 'sabnzbd', '--config-file', config])
+os.chdir("/app/sabnzbd")
+os.execv(sys.executable, [sys.executable, "-m", "sabnzbd", "--config-file", config])

--- a/website/docs/applications/sabnzbd.md
+++ b/website/docs/applications/sabnzbd.md
@@ -17,3 +17,7 @@ Credentials are stored in Bitwarden. An `ExternalSecret` pulls the API key and U
 ## Configuration seeding
 
 An init container uses `envsubst` to render `sabnzbd.ini` from a ConfigMap template. The file is copied into the config volume on every start so new settings take effect without manual steps.
+
+## Persistent data
+
+The image stores its configuration under `/config/sabnzbd` to keep system directories like `lost+found` out of the SABnzbd search path. This avoids permission warnings when the PVC already contains `lost+found`.


### PR DESCRIPTION
## Summary
- store sabnzbd config under /config/sabnzbd inside the image
- document sabnzbd config path and rationale

## Testing
- `pre-commit run --files images/sabnzbd/entrypoint.py images/sabnzbd/Dockerfile website/docs/applications/sabnzbd.md` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*
- `vale --config=website/utils/vale/.vale.ini website/docs/applications/sabnzbd.md`
- `docker build -t sabnzbd-test images/sabnzbd` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_689a6fabe2488322ad8dbfddedab543b