### PR TITLE
fix(kibana): enable tls for elasticsearch

### DIFF
--- a/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: KIBANA_PORT_NUMBER
           value: "5601"
         - name: KIBANA_ELASTICSEARCH_URL
-          value: http://elasticsearch:9200
+          value: https://elasticsearch:9200
         - name: KIBANA_ELASTICSEARCH_PORT_NUMBER
           value: "9200"
         - name: KIBANA_FORCE_INITSCRIPTS
@@ -45,7 +45,9 @@ spec:
         - name: KIBANA_SERVER_ENABLE_TLS
           value: "false"
         - name: KIBANA_ELASTICSEARCH_TLS_USE_PEM
-          value: "false"
+          value: "true"
+        - name: KIBANA_ELASTICSEARCH_CA_CERT_LOCATION
+          value: /opt/bitnami/kibana/config/certs/ca.crt
         - name: KIBANA_ELASTICSEARCH_TLS_VERIFICATION_MODE
           value: full
         - name: KIBANA_ELASTICSEARCH_ENABLE_TLS

--- a/k8s/applications/web/mastodon/elasticsearch/kibana.yml
+++ b/k8s/applications/web/mastodon/elasticsearch/kibana.yml
@@ -4,7 +4,7 @@ data:
     pid.file: /opt/bitnami/kibana/tmp/kibana.pid
     server.host: "0.0.0.0"
     server.port: 5601
-    elasticsearch.hosts: [http://elasticsearch:9200]
+    elasticsearch.hosts: [https://elasticsearch:9200]
     server.rewriteBasePath: false
 kind: ConfigMap
 metadata:

--- a/website/docs/k8s/applications/mastodon/elasticsearch-service.md
+++ b/website/docs/k8s/applications/mastodon/elasticsearch-service.md
@@ -2,7 +2,7 @@
 title: 'Elasticsearch service'
 ---
 
-The headless Service provides a stable Domain Name System (DNS) name for the search cluster. The `elasticsearch-master` Service listens on port 9200 for the Representational State Transfer (REST) API.
+The headless Service provides a stable Domain Name System (DNS) name for the search cluster. The `elasticsearch-master` Service listens on port 9200 for the Representational State Transfer (REST) API. Kibana connects to this endpoint over HTTPS using the `mastodon-elastic-ca` certificate.
 
 ```yaml
 # k8s/applications/web/mastodon/elasticsearch/service.yaml

--- a/website/utils/vale/styles/Project/project-words.txt
+++ b/website/utils/vale/styles/Project/project-words.txt
@@ -86,6 +86,7 @@ Internet-facing
 Jellyfin
 Jellyseerr
 K2200
+Kibana
 KCL
 Keep-alive
 Kube


### PR DESCRIPTION
## Summary
- switch Kibana to `https://elasticsearch:9200`
- document TLS connection and add Kibana to project dictionary

## Testing
- `pre-commit run --files k8s/applications/web/mastodon/elasticsearch/deployment.yaml k8s/applications/web/mastodon/elasticsearch/kibana.yml website/docs/k8s/applications/mastodon/elasticsearch-service.md website/utils/vale/styles/Project/project-words.txt` *(fails: URLError: SSL: CERTIFICATE_VERIFY_FAILED)*
- `SKIP=vale pre-commit run --files k8s/applications/web/mastodon/elasticsearch/deployment.yaml k8s/applications/web/mastodon/elasticsearch/kibana.yml website/docs/k8s/applications/mastodon/elasticsearch-service.md website/utils/vale/styles/Project/project-words.txt`
- `/tmp/vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/mastodon/elasticsearch-service.md`
- `kustomize build --enable-helm k8s/applications/web/mastodon/elasticsearch`
- `podman run --network host -d --name elasticsearch -e ELASTICSEARCH_PASSWORD=bitnami docker.io/bitnami/elasticsearch:8` *(fails: OCI runtime error: Read-only file system)*

------
https://chatgpt.com/codex/tasks/task_e_689b41115efc8322976af7c09d05b8d7