### PR TITLE
fix: add elasticsearch labels for mastodon

### DIFF
--- a/k8s/applications/web/mastodon/elasticsearch/service.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/service.yaml
@@ -15,6 +15,7 @@ spec:
   publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/component: master
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: elasticsearch
   type: ClusterIP
 ---
@@ -34,6 +35,7 @@ spec:
     port: 9300
   selector:
     app.kubernetes.io/component: master
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/name: elasticsearch
   sessionAffinity: None
   type: ClusterIP

--- a/k8s/applications/web/mastodon/elasticsearch/statefulset.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/statefulset.yaml
@@ -17,6 +17,10 @@ spec:
   template:
     metadata:
       annotations: null
+      labels:
+        app.kubernetes.io/component: master
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: elasticsearch
     spec:
       affinity:
         nodeAffinity: null

--- a/website/docs/k8s/applications/mastodon/elasticsearch-service.md
+++ b/website/docs/k8s/applications/mastodon/elasticsearch-service.md
@@ -2,7 +2,7 @@
 title: 'Elasticsearch service'
 ---
 
-The headless Service provides a stable Domain Name System (DNS) name for the search cluster. The `elasticsearch-master` Service listens on port 9200 for the Representational State Transfer (REST) API.
+The headless Service provides a stable Domain Name System (DNS) name for the search cluster. The `elasticsearch-master` Service listens on port 9200 for the Representational State Transfer (REST) API. It targets the master Pods using standard app labels.
 
 ```yaml
 # k8s/applications/web/mastodon/elasticsearch/service.yaml
@@ -11,4 +11,8 @@ metadata:
 spec:
   ports:
     - port: 9200
+  selector:
+    app.kubernetes.io/component: master
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: elasticsearch
 ```


### PR DESCRIPTION
## Summary
- ensure mastodon elasticsearch pods carry standard app labels
- align elasticsearch services with new labels
- document how the service targets pods

## Testing
- `kustomize build --enable-helm k8s/applications/web/mastodon/elasticsearch`
- `vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/mastodon/elasticsearch-service.md`
- `pre-commit run --files k8s/applications/web/mastodon/elasticsearch/statefulset.yaml k8s/applications/web/mastodon/elasticsearch/service.yaml website/docs/k8s/applications/mastodon/elasticsearch-service.md` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*

------
https://chatgpt.com/codex/tasks/task_e_689b410800748322bd2dec056e9243a5