### PR TITLE
fix: avoid tagging latest in PR builds

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -91,7 +91,16 @@ jobs:
         run: |
           REVISION_TAG="${{ steps.image-tags.outputs.image_version }}-$(echo ${{ github.sha }} | cut -c1-7)"
           echo "revision_tag=$REVISION_TAG" >> $GITHUB_OUTPUT
-
+      - name: Set image tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.revision.outputs.revision_tag }}"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            TAGS="$TAGS\nghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest"
+            TAGS="$TAGS\nghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.image-tags.outputs.base_tag }}"
+            TAGS="$TAGS\nghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.image-tags.outputs.image_version }}"
+          fi
+          printf 'tags<<EOF\n%s\nEOF\n' "$TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -105,8 +114,4 @@ jobs:
           platforms: linux/amd64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.image-tags.outputs.base_tag }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.image-tags.outputs.image_version }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.revision.outputs.revision_tag }}
+          tags: ${{ steps.tags.outputs.tags }}

--- a/website/docs/github/github-configuration.md
+++ b/website/docs/github/github-configuration.md
@@ -36,11 +36,12 @@ This page explains how GitHub Actions, Renovate, and Dependabot keep this homela
 - **File:** `.github/workflows/image-build.yaml`
 - **Purpose:** Detects Dockerfiles and pushes updated images to GHCR.
 - **When triggered:** Pushes to `main`, tags matching `*-*`, and pull requests that change files under `images/`.
+- **Tags:** Pull requests publish a revision tag. Merges and tag pushes also publish `latest` and version tags.
 - **Permissions:**
   - `contents: read` (clone the repository)
   - `packages: write` (upload images)
 - **Build context:** Uses `.dockerignore` files within each image directory to keep uploads minimal.
- - **Labels:** Each `Dockerfile` defines `org.opencontainers.image.description` to clarify the image contents.
+- **Labels:** Each `Dockerfile` defines `org.opencontainers.image.description` to clarify the image contents.
 
 ### Documentation Lint (`vale.yaml`)
 


### PR DESCRIPTION
## Summary
- stop tagging image builds as `latest` for pull requests
- note tag behavior in GitHub workflow docs

## Testing
- `vale --config=website/utils/vale/.vale.ini website/docs/github/github-configuration.md`

------
https://chatgpt.com/codex/tasks/task_e_689b466309d48322bc1740e1442027ec