### PR TITLE
fix(ci): fetch full history for image builds

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Detect Dockerfiles
         id: detect
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- ensure image build workflow fetches full git history
- tidy workflow indentation

## Testing
- `pre-commit run --files .github/workflows/image-build.yaml` *(fails: URLError: [SSL: CERTIFICATE_VERIFY_FAILED] Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_689b63f6a7e8832297bf268026e25d71