### PR TITLE
feat(k8s): update kibana deployment and add service account setup job

### DIFF
--- a/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
-          initialDelaySeconds: 120
+          initialDelaySeconds: 300
           periodSeconds: 10
           successThreshold: 1
           tcpSocket:
@@ -92,7 +92,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: http
-          initialDelaySeconds: 20
+          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 6

--- a/k8s/applications/web/mastodon/elasticsearch/kibana-service-account-job.yaml
+++ b/k8s/applications/web/mastodon/elasticsearch/kibana-service-account-job.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kibana-service-account-setup
+  namespace: mastodon
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "6"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-elasticsearch
+          image: curlimages/curl:8.15.0
+          command:
+            - sh
+            - -c
+            - |
+              until curl -k -u "elastic:${ELASTIC_PASSWORD}" https://elasticsearch-master:9200/_cluster/health?wait_for_status=yellow&timeout=30s; do
+                echo "Waiting for Elasticsearch to be ready..."
+                sleep 10
+              done
+          env:
+            - name: ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-credentials
+                  key: elasticsearch-password
+      containers:
+        - name: setup-kibana-token
+          image: curlimages/curl:8.15.0
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "Creating Kibana service account token via REST API..."
+
+              # Wait for Elasticsearch to be ready with authentication
+              until curl -k -u "elastic:${ELASTICSEARCH_PASSWORD}" -s https://elasticsearch-master:9200/_cluster/health; do
+                echo "Waiting for Elasticsearch..."
+                sleep 10
+              done
+
+              # Create the service account token via REST API
+              echo "Creating service account token..."
+              TOKEN_RESPONSE=$(curl -k -u "elastic:${ELASTICSEARCH_PASSWORD}" -X POST \
+                "https://elasticsearch-master:9200/_security/service/elastic/kibana/credential/token/kibana-token" \
+                -H 'Content-Type: application/json' \
+                -s)
+
+              echo "Token creation response: $TOKEN_RESPONSE"
+
+              # Extract the token value
+              TOKEN=$(echo "$TOKEN_RESPONSE" | grep -o '"value":"[^"]*"' | cut -d'"' -f4)
+
+              if [[ -n "$TOKEN" ]]; then
+                echo "Service account token created successfully"
+                echo "Token should be stored in Bitwarden under key: app-mastodon-elasticsearch-kibana-token"
+                echo "Token value: $TOKEN"
+              else
+                echo "Token creation failed or token already exists"
+                echo "Response: $TOKEN_RESPONSE"
+              fi
+          env:
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-credentials
+                  key: elasticsearch-password
+          volumeMounts:
+            - name: elasticsearch-certs
+              mountPath: /opt/bitnami/elasticsearch/config/certs
+              readOnly: true
+      volumes:
+        - name: elasticsearch-certs
+          secret:
+            secretName: mastodon-elastic-server

--- a/k8s/applications/web/mastodon/elasticsearch/kibana.yml
+++ b/k8s/applications/web/mastodon/elasticsearch/kibana.yml
@@ -10,8 +10,7 @@ data:
     server.port: 5601
     elasticsearch.hosts: ["https://elasticsearch-master:9200"]
     elasticsearch.serviceAccountToken: ${KIBANA_SERVICE_ACCOUNT_TOKEN}
-    elasticsearch.ssl.certificateAuthorities: ["/opt/bitnami/kibana/config/certs/tls.crt"]
-    elasticsearch.ssl.verificationMode: full
+    elasticsearch.ssl.verificationMode: none
     server.rewriteBasePath: false
     xpack.security.encryptionKey: ${KIBANA_ENCRYPTION_KEY}
     xpack.encryptedSavedObjects.encryptionKey: ${KIBANA_ENCRYPTION_KEY}

--- a/k8s/infrastructure/network/gateway/gw-internal.yaml
+++ b/k8s/infrastructure/network/gateway/gw-internal.yaml
@@ -39,6 +39,17 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - protocol: HTTPS
+      port: 443
+      name: https-domain-goingdark-gateway
+      hostname: "*.goingdark.social"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cert-goingdark
+      allowedRoutes:
+        namespaces:
+          from: All
 
     # Add TCP listeners for Omada device mgmt
     - protocol: TCP


### PR DESCRIPTION
- increase liveness probe initial delay to 300 seconds
- increase readiness probe initial delay to 120 seconds
- add job for setting up Kibana service account token
- update kibana configuration to disable SSL verification
- add new HTTPS listener for goingdark domain in gateway