### PR TITLE
feat(tofu): add api load balancer

### DIFF
--- a/tofu/config.auto.tfvars
+++ b/tofu/config.auto.tfvars
@@ -1,30 +1,39 @@
-// tofu/config.tfvars.example
-
 cluster_name   = "talos"
 cluster_domain = "kube.pc-tips.se"
 
-# Network settings
-# All nodes must be on the same L2 network
 network = {
   gateway     = "10.25.150.1"
-  vip         = "10.25.150.10" # Control plane Virtual IP
+  vip         = "10.25.150.10"
+  api_lb_vip  = "10.25.150.9"
   cidr_prefix = 24
   dns_servers = ["10.25.150.1"]
   bridge      = "vmbr0"
   vlan_id     = 150
 }
 
-# Proxmox settings
 proxmox_cluster = "host3"
 
-# Software versions
 versions = {
   talos      = "v1.10.3"
   kubernetes = "1.33.2"
 }
 
-# OIDC settings (optional)
 oidc = {
   issuer_url = "https://sso.pc-tips.se/application/o/kubectl/"
   client_id  = "kubectl"
+}
+
+lb_nodes = {
+  lb-00 = {
+    host_node   = "host3"
+    ip          = "10.25.150.5"
+    mac_address = "bc:24:11:aa:aa:05"
+    vm_id       = 8005
+  }
+  lb-01 = {
+    host_node   = "host3"
+    ip          = "10.25.150.6"
+    mac_address = "bc:24:11:aa:aa:06"
+    vm_id       = 8006
+  }
 }

--- a/tofu/lb/main.tf
+++ b/tofu/lb/main.tf
@@ -1,0 +1,83 @@
+locals {
+  control_plane_ips = var.control_plane_ips
+  auth_pass         = "k8sapi"
+  haproxy_cfg = templatefile("${path.module}/templates/haproxy.cfg.tftpl", {
+    control_plane_ips = local.control_plane_ips
+    cluster_domain    = var.cluster_domain
+  })
+}
+
+resource "proxmox_virtual_environment_file" "cloudinit" {
+  for_each     = var.lb_nodes
+  content_type = "snippets"
+  node_name    = each.value.host_node
+  datastore_id = coalesce(each.value.datastore_id, "local")
+  source_raw {
+    data = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
+      haproxy_cfg = local.haproxy_cfg
+      keepalived_cfg = templatefile("${path.module}/templates/keepalived.conf.tftpl", {
+        state      = each.key == "lb-00" ? "MASTER" : "BACKUP"
+        priority   = each.key == "lb-00" ? 200 : 150
+        auth_pass  = local.auth_pass
+        api_lb_vip = var.network.api_lb_vip
+      })
+    })
+    file_name = "lb-${each.key}-cloudinit.yaml"
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "lb" {
+  for_each = var.lb_nodes
+
+  node_name   = each.value.host_node
+  name        = each.key
+  description = "K8s API HA LB"
+  tags        = ["k8s", "lb"]
+  vm_id       = each.value.vm_id
+  on_boot     = true
+
+  agent { enabled = true }
+
+  cpu {
+    cores = coalesce(each.value.cpu, 2)
+    type  = "host"
+  }
+  memory { dedicated = coalesce(each.value.ram_dedicated, 2048) }
+
+  network_device {
+    bridge      = var.network.bridge
+    vlan_id     = var.network.vlan_id
+    mac_address = each.value.mac_address
+  }
+
+  disk {
+    datastore_id = coalesce(each.value.datastore_id, var.proxmox_datastore)
+    interface    = "scsi0"
+    ssd          = true
+    size         = 8
+    file_format  = "raw"
+  }
+
+  operating_system { type = "l26" }
+
+  initialization {
+    datastore_id      = coalesce(each.value.datastore_id, var.proxmox_datastore)
+    user_data_file_id = proxmox_virtual_environment_file.cloudinit[each.key].id
+    dns {
+      domain  = var.cluster_domain
+      servers = var.network.dns_servers
+    }
+    ip_config {
+      ipv4 {
+        address = "${each.value.ip}/${var.network.cidr_prefix}"
+        gateway = var.network.gateway
+      }
+    }
+  }
+
+  boot_order = ["scsi0"]
+
+  lifecycle {
+    ignore_changes = [network_device[0].disconnected]
+  }
+}

--- a/tofu/lb/main.tf
+++ b/tofu/lb/main.tf
@@ -66,7 +66,7 @@ resource "proxmox_virtual_environment_vm" "lb" {
     interface    = "scsi0"
     ssd          = true
     size         = 8
-    file_format  = "raw"
+    file_format  = "qcow2"
     file_id      = proxmox_virtual_environment_download_file.ubuntu_amd64[each.value.host_node].id
   }
 

--- a/tofu/lb/providers.tf
+++ b/tofu/lb/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source = "bpg/proxmox"
+    }
+  }
+}

--- a/tofu/lb/templates/cloud-init.yaml.tftpl
+++ b/tofu/lb/templates/cloud-init.yaml.tftpl
@@ -1,0 +1,19 @@
+#cloud-config
+package_update: true
+packages:
+  - haproxy
+  - keepalived
+write_files:
+  - path: /etc/haproxy/haproxy.cfg
+    permissions: "0644"
+    owner: root:root
+    content: |
+      ${indent(6, haproxy_cfg)}
+  - path: /etc/keepalived/keepalived.conf
+    permissions: "0644"
+    owner: root:root
+    content: |
+      ${indent(6, keepalived_cfg)}
+runcmd:
+  - systemctl enable haproxy --now
+  - systemctl enable keepalived --now

--- a/tofu/lb/templates/haproxy.cfg.tftpl
+++ b/tofu/lb/templates/haproxy.cfg.tftpl
@@ -18,10 +18,12 @@ frontend fe_kubeapi
   default_backend be_kubeapi
 
 backend be_kubeapi
-  mode http
-  option httpchk GET /readyz
-  http-check expect status 200
-  default-server inter 1000ms fall 2 rise 2 check
+  mode tcp
+  option tcp-check
+  tcp-check connect ssl sni api.${cluster_domain} verify none
+  tcp-check send "GET /readyz HTTP/1.1\r\nHost: api.${cluster_domain}\r\nConnection: close\r\n\r\n"
+  tcp-check expect rstring ^HTTP/1\.[01]\ 200
+  default-server inter 1s fall 2 rise 2
 %{ for ip in control_plane_ips ~}
-  server cp-${ip} ${ip}:6443 check check-ssl verify none sni str(api.${cluster_domain})
+  server cp-${ip} ${ip}:6443 check
 %{ endfor ~}

--- a/tofu/lb/templates/haproxy.cfg.tftpl
+++ b/tofu/lb/templates/haproxy.cfg.tftpl
@@ -19,11 +19,13 @@ frontend fe_kubeapi
 
 backend be_kubeapi
   mode tcp
+  balance leastconn
   option tcp-check
+  timeout check 1s
   tcp-check connect ssl sni api.${cluster_domain} verify none
   tcp-check send "GET /readyz HTTP/1.1\r\nHost: api.${cluster_domain}\r\nConnection: close\r\n\r\n"
   tcp-check expect rstring ^HTTP/1\.[01]\ 200
-  default-server inter 1s fall 2 rise 2
+  default-server inter 1s fall 2 rise 2 maxconn 1000
 %{ for ip in control_plane_ips ~}
-  server cp-${ip} ${ip}:6443 check
+  server cp-${ip} ${ip}:6443 check slowstart 5s
 %{ endfor ~}

--- a/tofu/lb/templates/haproxy.cfg.tftpl
+++ b/tofu/lb/templates/haproxy.cfg.tftpl
@@ -1,0 +1,27 @@
+global
+  log /dev/log local0
+  log /dev/log local1 notice
+  maxconn 10000
+  daemon
+
+defaults
+  log     global
+  mode    tcp
+  option  tcplog
+  timeout connect 10s
+  timeout client  86400s
+  timeout server  86400s
+
+frontend fe_kubeapi
+  bind *:6443
+  mode tcp
+  default_backend be_kubeapi
+
+backend be_kubeapi
+  mode http
+  option httpchk GET /readyz
+  http-check expect status 200
+  default-server inter 1000ms fall 2 rise 2 check
+%{ for ip in control_plane_ips ~}
+  server cp-${ip} ${ip}:6443 check check-ssl verify none sni str(api.${cluster_domain})
+%{ endfor ~}

--- a/tofu/lb/templates/keepalived.conf.tftpl
+++ b/tofu/lb/templates/keepalived.conf.tftpl
@@ -1,0 +1,24 @@
+vrrp_script chk_haproxy {
+  script "/usr/bin/pgrep -x haproxy"
+  interval 2
+  fall 2
+  rise 2
+}
+
+vrrp_instance VI_API {
+  state ${state}
+  interface eth0
+  virtual_router_id 51
+  priority ${priority}
+  advert_int 1
+  authentication {
+    auth_type PASS
+    auth_pass ${auth_pass}
+  }
+  virtual_ipaddress {
+    ${api_lb_vip}/32 dev eth0
+  }
+  track_script {
+    chk_haproxy
+  }
+}

--- a/tofu/lb/templates/keepalived.conf.tftpl
+++ b/tofu/lb/templates/keepalived.conf.tftpl
@@ -7,7 +7,7 @@ vrrp_script chk_haproxy {
 
 vrrp_instance VI_API {
   state ${state}
-  interface eth0
+  interface ens18
   virtual_router_id 51
   priority ${priority}
   advert_int 1
@@ -16,7 +16,7 @@ vrrp_instance VI_API {
     auth_pass ${auth_pass}
   }
   virtual_ipaddress {
-    ${api_lb_vip}/32 dev eth0
+    ${api_lb_vip}/32 dev ens18
   }
   track_script {
     chk_haproxy

--- a/tofu/lb/variables.tf
+++ b/tofu/lb/variables.tf
@@ -1,0 +1,45 @@
+variable "proxmox_datastore" { type = string }
+
+variable "proxmox" {
+  type = object({
+    endpoint  = string
+    insecure  = bool
+    username  = string
+    api_token = string
+    name      = string
+  })
+  sensitive = true
+}
+
+variable "cluster_domain" { type = string }
+
+variable "network" {
+  description = "Extend network object with api_lb_vip"
+  type = object({
+    gateway     = string
+    vip         = string
+    cidr_prefix = number
+    dns_servers = list(string)
+    bridge      = string
+    vlan_id     = number
+    api_lb_vip  = string
+  })
+}
+
+variable "control_plane_ips" {
+  description = "Control plane node IPs"
+  type        = list(string)
+}
+
+variable "lb_nodes" {
+  description = "Load balancer VMs"
+  type = map(object({
+    host_node    = string
+    ip           = string
+    mac_address  = string
+    vm_id        = number
+    cpu          = optional(number, 2)
+    ram_dedicated= optional(number, 2048)
+    datastore_id = optional(string)
+  }))
+}

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -73,3 +73,16 @@ module "talos" {
 
   nodes = local.nodes_with_upgrade
 }
+
+module "lb" {
+  source = "./lb"
+  providers = {
+    proxmox = proxmox
+  }
+  proxmox           = var.proxmox
+  proxmox_datastore = var.proxmox_datastore
+  cluster_domain    = var.cluster_domain
+  network           = var.network
+  control_plane_ips = [for name, n in var.nodes_config : n.ip if n.machine_type == "controlplane"]
+  lb_nodes          = var.lb_nodes
+}

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -170,6 +170,7 @@ variable "network" {
   type = object({
     gateway     = string
     vip         = string
+    api_lb_vip  = string
     cidr_prefix = number
     dns_servers = list(string)
     bridge      = string
@@ -197,5 +198,18 @@ variable "oidc" {
     client_id  = string
   })
   default = null # Make it optional
+}
+
+variable "lb_nodes" {
+  description = "Load balancer VMs"
+  type = map(object({
+    host_node     = string
+    ip            = string
+    mac_address   = string
+    vm_id         = number
+    cpu           = optional(number)
+    ram_dedicated = optional(number)
+    datastore_id  = optional(string)
+  }))
 }
 

--- a/website/docs/tofu/api-load-balancer.md
+++ b/website/docs/tofu/api-load-balancer.md
@@ -4,7 +4,7 @@ title: API load balancer
 
 # API load balancer
 
-Two small VMs run `HAProxy` and `Keepalived`. OpenTofu provisions them with Proxmox `cloud-init`. `HAProxy` checks `/readyz` on each control plane node over HTTPS and routes only to nodes that respond. `Keepalived` advertises a virtual IP used by the DNS record `api.<cluster-domain>`.
+Two small VMs run `HAProxy` and `Keepalived`. OpenTofu downloads an Ubuntu 24.04 cloud image and configures the VMs with Proxmox `cloud-init`. `HAProxy` checks `/readyz` on each control plane node over HTTPS and routes only to nodes that respond. `Keepalived` advertises a virtual IP used by the Domain Name System (DNS) record `api.<cluster-domain>`.
 
 ## Configuration
 
@@ -31,7 +31,7 @@ lb_nodes = {
 }
 ```
 
-Create a DNS A record `api.<cluster-domain>` pointing at `api_lb_vip`.
+Create a Domain Name System (DNS) A record `api.<cluster-domain>` pointing at `api_lb_vip`.
 
 ## Verification
 

--- a/website/docs/tofu/api-load-balancer.md
+++ b/website/docs/tofu/api-load-balancer.md
@@ -1,0 +1,44 @@
+---
+title: API load balancer
+---
+
+# API load balancer
+
+Two small VMs run `HAProxy` and `Keepalived`. OpenTofu provisions them with Proxmox `cloud-init`. `HAProxy` checks `/readyz` on each control plane node over HTTPS and routes only to nodes that respond. `Keepalived` advertises a virtual IP used by the DNS record `api.<cluster-domain>`.
+
+## Configuration
+
+Add the virtual IP and load balancer nodes in `config.auto.tfvars`.
+
+```hcl
+network = {
+  api_lb_vip = "10.25.150.9"
+}
+
+lb_nodes = {
+  lb-00 = {
+    host_node   = "host3"
+    ip          = "10.25.150.5"
+    mac_address = "bc:24:11:aa:aa:05"
+    vm_id       = 8005
+  }
+  lb-01 = {
+    host_node   = "host3"
+    ip          = "10.25.150.6"
+    mac_address = "bc:24:11:aa:aa:06"
+    vm_id       = 8006
+  }
+}
+```
+
+Create a DNS A record `api.<cluster-domain>` pointing at `api_lb_vip`.
+
+## Verification
+
+After planning the infrastructure, verify the API responds.
+
+```shell
+curl -k "https://api.<cluster-domain>:6443/readyz"
+```
+
+The command prints `ok` when the API is ready.


### PR DESCRIPTION
## Summary
- provision HAProxy and Keepalived VMs for the Kubernetes API
- expose API load balancer settings in variables and config
- document configuration and verification steps

## Testing
- `tofu init`
- `tofu validate`
- `vale --config=website/utils/vale/.vale.ini website/docs/tofu/api-load-balancer.md`
- `pre-commit run --all-files` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c6cff11b08322948e7d7880b1fa8f