### PR TITLE
feat: enable LiteLLM caching and health probes

### DIFF
--- a/k8s/applications/ai/litellm/configmap.yaml
+++ b/k8s/applications/ai/litellm/configmap.yaml
@@ -5,6 +5,56 @@ metadata:
   namespace: litellm
 data:
   proxy_server_config.yaml: |
+    model_list: []
+
+    litellm_settings:
+      callbacks: ["prometheus"]
+      prometheus_initialize_budget_metrics: true
+      require_auth_for_metrics_endpoint: false
+      cache: true
+      cache_params:
+        type: redis
+        host: redis.litellm.svc.kube.pc-tips.se
+        port: 6379
+        namespace: "litellm.cache"
+        mode: default_off
+        ttl: 600
+      json_logs: true
+      turn_off_message_logging: true
+      redact_user_api_key_info: true
+      enable_json_schema_validation: true
+      set_verbose: false
+
+    router_settings:
+      routing_strategy: usage-based-routing-v2
+      enable_pre_call_checks: true
+      num_retries: 3
+      retry_after: 1
+      allowed_fails: 3
+      cooldown_time: 30
+      allowed_fails_policy:
+        AuthenticationErrorAllowedFails: 3
+        TimeoutErrorAllowedFails: 6
+        RateLimitErrorAllowedFails: 10000
+        ContentPolicyViolationErrorAllowedFails: 6
+        InternalServerErrorAllowedFails: 10
+        BadRequestErrorAllowedFails: 1000
+      max_fallbacks: 3
+      enable_tag_filtering: true
+      cache_responses: true
+      redis_host: redis.litellm.svc.kube.pc-tips.se
+      redis_port: "6379"
+
     general_settings:
       store_model_in_db: true
       store_prompts_in_spend_logs: true
+      enforce_user_param: true
+      background_health_checks: true
+      health_check_interval: 300
+      health_check_details: true
+      ui_access_mode: admin_only
+      max_request_size_mb: 20
+      max_response_size_mb: 25
+      database_connection_pool_limit: 50
+      database_connection_timeout: 60
+      allow_requests_on_db_unavailable: false

--- a/k8s/applications/ai/litellm/deployment.yaml
+++ b/k8s/applications/ai/litellm/deployment.yaml
@@ -21,6 +21,7 @@ spec:
           - "/app/proxy_server_config.yaml"
         ports:
         - containerPort: 4000
+        - containerPort: 4001
         envFrom:
         - secretRef:
             name: litellm-secrets
@@ -37,10 +38,36 @@ spec:
               key: password
         - name: DATABASE_URL
           value: postgres://$(PGUSER):$(PGPASSWORD)@litellm-postgresql.litellm.svc.kube.pc-tips.se:5432/litellm
+        - name: SEPARATE_HEALTH_APP
+          value: "1"
+        - name: SEPARATE_HEALTH_PORT
+          value: "4001"
         volumeMounts:
         - name: litellm-config
           mountPath: /app/proxy_server_config.yaml
           subPath: proxy_server_config.yaml
+        livenessProbe:
+          httpGet:
+            path: /health/liveliness
+            port: 4001
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 2
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health/readiness
+            port: 4001
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+        startupProbe:
+          httpGet:
+            path: /health/liveliness
+            port: 4001
+          failureThreshold: 30
+          periodSeconds: 2
 
       volumes:
         - name: litellm-config

--- a/k8s/applications/ai/litellm/kustomization.yaml
+++ b/k8s/applications/ai/litellm/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - litellm-secrets.yaml
 - configmap.yaml
 - deployment.yaml
+- redis.yaml
 - svc.yaml
 - database.yaml

--- a/k8s/applications/ai/litellm/redis.yaml
+++ b/k8s/applications/ai/litellm/redis.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: litellm
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2.5-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+          args:
+            - "--save"
+            - ""
+            - "--appendonly"
+            - "no"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 6379
+            periodSeconds: 2
+            failureThreshold: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: litellm
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP

--- a/website/docs/k8s/applications/ai/litellm.md
+++ b/website/docs/k8s/applications/ai/litellm.md
@@ -1,8 +1,8 @@
 ---
-title: 'LiteLLM Prompt Storage'
+title: 'LiteLLM Proxy Configuration'
 ---
 
-LiteLLM can persist request and response data to PostgreSQL for later review. The deployment mounts a proxy configuration file that enables prompt logging.
+LiteLLM reads its settings from a ConfigMap. The file enables database logging, Redis caching, and Prometheus metrics. A lightweight Redis Service runs in cluster for caching and router state. It has no persistence or auth.
 
 ## Configuration
 
@@ -10,9 +10,19 @@ LiteLLM can persist request and response data to PostgreSQL for later review. Th
 # k8s/applications/ai/litellm/configmap.yaml
 data:
   proxy_server_config.yaml: |
+    litellm_settings:
+      callbacks: ["prometheus"]
+      cache: true
+      cache_params:
+        type: redis
+        host: redis.litellm.svc.kube.pc-tips.se
+        port: 6379
+    router_settings:
+      redis_host: redis.litellm.svc.kube.pc-tips.se
+      redis_port: "6379"
     general_settings:
       store_model_in_db: true
       store_prompts_in_spend_logs: true
 ```
 
-The Deployment mounts this file at `/app/proxy_server_config.yaml` to activate the settings.
+The Deployment mounts this file at `/app/proxy_server_config.yaml`. Probes call `/health/readiness` and `/health/liveliness` on port `4001`. Prometheus scrapes metrics from `/metrics`.


### PR DESCRIPTION
## Summary
- enable Redis caching and Prometheus metrics in LiteLLM config
- add separate health app, probes, and Redis wiring to LiteLLM deployment
- bundle ephemeral Redis Deployment and Service for cache and router state
- document LiteLLM proxy configuration

## Testing
- `kustomize build --enable-helm k8s/applications/ai/litellm`
- `vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/ai/litellm.md`
- `pre-commit run --files k8s/applications/ai/litellm/kustomization.yaml k8s/applications/ai/litellm/redis.yaml website/docs/k8s/applications/ai/litellm.md` *(fails: Missing Authority Key Identifier)*

------
https://chatgpt.com/codex/tasks/task_e_68af8d4783108322a6a0a04b7769e187