### PR TITLE
fix(sabnzbd): set entrypoint download directories

### DIFF
--- a/k8s/applications/media/sabnzbd/kustomization.yaml
+++ b/k8s/applications/media/sabnzbd/kustomization.yaml
@@ -14,6 +14,11 @@ generatorOptions:
 configMapGenerator:
   - name: sabnzbd-env-config
     literals:
+      - PUID="2501"
+      - PGID="2501"
+      - SAB_DOWNLOAD_DIR="/app/data"
+      - SAB_INCOMPLETE_DIR="/downloads/incomplete"
+      - SAB_COMPLETE_DIR="/app/data/downloads"
       - SABNZBD__MISC__HOST_WHITELIST="sabnzbd,sabnzbd.media,sabnzbd.media.svc,sabnzbd.media.svc.cluster.local,sabnzbd.pc-tips.se"
       - SABNZBD__MISC__PORT="8080"
       - SABNZBD__MISC__DOWNLOAD_DIR="/downloads/incomplete"
@@ -27,3 +32,4 @@ configMapGenerator:
       - SABNZBD__SERVERS__NEWSNEWSHOSTINGCOM__CONNECTIONS="30"
       - SABNZBD__SERVERS__NEWSNEWSHOSTINGCOM__SSL="1"
       - SABNZBD__SERVERS__NEWSNEWSHOSTINGCOM__SSL_VERIFY="3"
+


### PR DESCRIPTION
## Summary
- set sabnzbd entrypoint env directories to writable paths

## Testing
- `kustomize build --enable-helm k8s/applications/media/sabnzbd`
- `pre-commit run --files k8s/applications/media/sabnzbd/kustomization.yaml` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*

------
https://chatgpt.com/codex/tasks/task_e_68c535928c888322ad43df357dc5930b