### PR TITLE
Add Portkey Gateway deployment

### DIFF
--- a/k8s/applications/kustomization.yaml
+++ b/k8s/applications/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - external
 - web
 - network
+- portkey
 
 
 generatorOptions:

--- a/k8s/applications/portkey/configmap.yaml
+++ b/k8s/applications/portkey/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portkey-gateway-config
+  namespace: portkey
+data:
+  NODE_ENV: "production"
+  LOG_LEVEL: "info"
+  PORT: "8787"
+  HEALTH_CHECK_PATH: "/v1/health"

--- a/k8s/applications/portkey/deployment.yaml
+++ b/k8s/applications/portkey/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portkey-gateway
+  namespace: portkey
+  labels:
+    app.kubernetes.io/version: "1.12.1"
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: portkey-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: "1.12.1"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8787"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: default
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: portkeyai/gateway:1.12.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8787
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: portkey-gateway-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 500Mi
+          startupProbe:
+            httpGet:
+              path: /v1/health
+              port: 8787
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 10
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8787
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8787
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: var-tmp
+              mountPath: /var/tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
+        - name: var-tmp
+          emptyDir:
+            sizeLimit: 100Mi
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/k8s/applications/portkey/http-route.yaml
+++ b/k8s/applications/portkey/http-route.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: portkey-gateway
+  namespace: portkey
+  labels:
+    app.kubernetes.io/version: "1.12.1"
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - portkey.pc-tips.se
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: portkey-gateway
+          namespace: portkey
+          port: 8787
+          weight: 100
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: X-Frame-Options
+                value: DENY
+              - name: X-Content-Type-Options
+                value: nosniff
+              - name: X-XSS-Protection
+                value: "1; mode=block"
+              - name: Strict-Transport-Security
+                value: max-age=31536000; includeSubDomains

--- a/k8s/applications/portkey/kustomization.yaml
+++ b/k8s/applications/portkey/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: portkey
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+- http-route.yaml
+- servicemonitor.yaml
+- networkpolicy.yaml
+- configmap.yaml
+
+
+commonAnnotations:
+  app.kubernetes.io/version: 1.12.1
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: api-gateway
+    app.kubernetes.io/instance: portkey
+    app.kubernetes.io/name: portkey-gateway
+    app.kubernetes.io/part-of: portkey

--- a/k8s/applications/portkey/namespace.yaml
+++ b/k8s/applications/portkey/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portkey
+  labels:
+    app.kubernetes.io/name: portkey
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/k8s/applications/portkey/networkpolicy.yaml
+++ b/k8s/applications/portkey/networkpolicy.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: portkey-gateway
+  namespace: portkey
+  labels:
+    app.kubernetes.io/version: "1.12.1"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: portkey-gateway
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: gateway
+      ports:
+        - protocol: TCP
+          port: 8787
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: monitoring
+      ports:
+        - protocol: TCP
+          port: 8787
+  egress:
+    - to: []
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 443
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 80

--- a/k8s/applications/portkey/service.yaml
+++ b/k8s/applications/portkey/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: portkey-gateway
+  namespace: portkey
+  labels:
+    app.kubernetes.io/version: "1.12.1"
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  selector:
+    app.kubernetes.io/name: portkey-gateway
+  ports:
+    - name: http
+      port: 8787
+      targetPort: 8787
+      protocol: TCP
+      appProtocol: http

--- a/k8s/applications/portkey/servicemonitor.yaml
+++ b/k8s/applications/portkey/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: portkey-gateway
+  namespace: portkey
+  labels:
+    app.kubernetes.io/version: "1.12.1"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: portkey-gateway
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - portkey

--- a/website/docs/k8s/applications/portkey/portkey-gateway.md
+++ b/website/docs/k8s/applications/portkey/portkey-gateway.md
@@ -1,0 +1,29 @@
+---
+title: 'Portkey Gateway Deployment'
+---
+
+Portkey Gateway runs in the `portkey` namespace with locked down Pod Security Standard labels. The namespace manifest applies a
+restricted policy set before any other resource syncs.
+
+## Configuration
+
+The ConfigMap sets `NODE_ENV`, health check path, port, and log level so the container starts in production mode. The Deployment
+pulls `portkeyai/gateway:1.12.1`, runs it as UID and GID `1000`, and keeps the file system read-only except for temporary
+storage mounted at `/tmp` and `/var/tmp`.
+
+## Probes and Resources
+
+All three probes call `/v1/health` on port `8787`. Startup waits up to fifty seconds, readiness checks every ten seconds, and
+liveness runs on a thirty second cadence. Requests stay small (100m CPU, 256Mi memory), while limits allow brief spikes to 500m
+CPU and 512Mi memory.
+
+## Traffic Policy
+
+Gateway API traffic arrives through the shared `external` listener. The HTTPRoute forwards `portkey.pc-tips.se` traffic to the
+Service and adds strict security headers on responses. A NetworkPolicy only allows ingress from the `gateway` and `monitoring`
+namespaces and restricts egress to DNS plus HTTP and HTTPS.
+
+## Monitoring
+
+Prometheus discovers the pods through a ServiceMonitor that scrapes `/metrics` over HTTP every thirty seconds. The Deployment
+labels and annotations enable the scrape and keep version tracking in sync with the `1.12.1` release.


### PR DESCRIPTION
## Summary
- add a Portkey Gateway Kustomize base with namespace, deployment, service, HTTPRoute, ServiceMonitor, and NetworkPolicy
- wire the new application into the global applications kustomization and document the deployment under website/docs

## Testing
- kustomize build --enable-helm k8s/applications/portkey

------
https://chatgpt.com/codex/tasks/task_e_68cfb8ab10ec8322aadda3c478588328