### PR TITLE
fix: align headlessx manifests with platform patterns

### DIFF
--- a/k8s/applications/web/headlessx/deployment.yaml
+++ b/k8s/applications/web/headlessx/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlessx
+  namespace: headlessx
+  labels:
+    app.kubernetes.io/name: headlessx
+    app.kubernetes.io/part-of: headlessx
+    app.kubernetes.io/component: service
+    app.kubernetes.io/version: "1.2.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlessx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlessx
+        app.kubernetes.io/version: "1.2.0"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: headlessx
+          image: ghcr.io/theepicsaxguy/headlessx:1.2.0 # renovate: docker=ghcr.io/theepicsaxguy/headlessx
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: es-headlessx-auth-token
+          env:
+            - name: PORT
+              value: "3000"
+            - name: NODE_ENV
+              value: production
+            - name: UV_THREADPOOL_SIZE
+              value: "128"
+            - name: NODE_OPTIONS
+              value: --max-old-space-size=4096
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: logs
+              mountPath: /app/logs
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: logs
+          persistentVolumeClaim:
+            claimName: headlessx-logs
+        - name: tmp
+          emptyDir: {}

--- a/k8s/applications/web/headlessx/headlessx-external-secret.yaml
+++ b/k8s/applications/web/headlessx/headlessx-external-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: es-headlessx-auth-token
+  namespace: headlessx
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: es-headlessx-auth-token
+    creationPolicy: Owner
+  data:
+    - secretKey: AUTH_TOKEN
+      remoteRef:
+        key: app-headlessx-auth-token

--- a/k8s/applications/web/headlessx/http-route.yaml
+++ b/k8s/applications/web/headlessx/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlessx
+  namespace: headlessx
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "headlessx.pc-tips.se"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: headlessx
+          port: 3000

--- a/k8s/applications/web/headlessx/kustomization.yaml
+++ b/k8s/applications/web/headlessx/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - headlessx-external-secret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - http-route.yaml
+  - networkpolicy.yaml

--- a/k8s/applications/web/headlessx/namespace.yaml
+++ b/k8s/applications/web/headlessx/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlessx
+  labels:
+    name: headlessx

--- a/k8s/applications/web/headlessx/networkpolicy.yaml
+++ b/k8s/applications/web/headlessx/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: headlessx
+  namespace: headlessx
+  labels:
+    app.kubernetes.io/name: headlessx
+    app.kubernetes.io/version: "1.2.0"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: headlessx
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: gateway
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to: []
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 80
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 443

--- a/k8s/applications/web/headlessx/pvc.yaml
+++ b/k8s/applications/web/headlessx/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: headlessx-logs
+  namespace: headlessx
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn

--- a/k8s/applications/web/headlessx/service.yaml
+++ b/k8s/applications/web/headlessx/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlessx
+  namespace: headlessx
+  labels:
+    app.kubernetes.io/name: headlessx
+spec:
+  selector:
+    app.kubernetes.io/name: headlessx
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/applications/web/kustomization.yaml
+++ b/k8s/applications/web/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
 - project.yaml
 - babybuddy
+- headlessx
 - mastodon

--- a/k8s/applications/web/project.yaml
+++ b/k8s/applications/web/project.yaml
@@ -13,6 +13,8 @@ spec:
       server: '*'
     - namespace: 'babybuddy'
       server: '*'
+    - namespace: 'headlessx'
+      server: '*'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/website/docs/k8s/applications/headlessx.md
+++ b/website/docs/k8s/applications/headlessx.md
@@ -1,0 +1,43 @@
+---
+title: 'HeadlessX Deployment Notes'
+---
+
+This service runs the modular HeadlessX browserless API behind the internal gateway. The manifests live in `k8s/applications/web/headlessx` and stay aligned with the original docker-compose configuration.
+
+## Build and Image
+
+* Build the container with `docker/Dockerfile` and push it to a registry the cluster can reach, for example `ghcr.io/theepicsaxguy/headlessx:1.2.0`.
+* If the registry requires credentials, create an `imagePullSecret` named `headlessx-registry` in the `headlessx` namespace and add it to the Deployment before syncing.
+
+## Namespace
+
+* Namespace: `headlessx`. No extra quota or limit range is defined here—reuse the cluster defaults.
+
+## Configuration and Secrets
+
+* Runtime knobs (`PORT`, `NODE_ENV`, `UV_THREADPOOL_SIZE`, `NODE_OPTIONS`) are set directly on the Deployment.
+* `AUTH_TOKEN` comes from `es-headlessx-auth-token`, which pulls `app-headlessx-auth-token` out of Bitwarden through External Secrets.
+
+## Storage Layout
+
+* Logs persist to `headlessx-logs`, a 10Gi Longhorn-backed PVC mounted at `/app/logs`.
+* `/tmp` uses an `emptyDir` to mimic the compose bind mount.
+
+## Deployment Highlights
+
+* Single replica Deployment with requests set to 1 CPU / 1Gi and limits to 4 CPU / 4Gi.
+* Probes hit `GET /api/health` on port 3000 with a 15s initial delay, 30s period, and 10s timeout.
+* Pod security: `runAsNonRoot`, `runAsUser`/`runAsGroup` 1000, default seccomp, no privilege escalation, and all capabilities dropped.
+## Networking
+
+* Service `headlessx` exposes port 3000 internally.
+* `HTTPRoute` binds `headlessx.pc-tips.se` to the `internal` Gateway and forwards all paths to the Service.
+* `NetworkPolicy` only permits ingress from namespaces labeled `name=gateway`, and limits egress to DNS plus outbound HTTP/HTTPS.
+* Publish `headlessx.pc-tips.se` inside the private DNS zone so the Gateway’s internal address resolves for callers.
+
+## Verification Checklist
+
+1. Wait for the Deployment to become `Available` and confirm probes stay green.
+2. `kubectl port-forward` or exec into the pod and curl `http://localhost:3000/api/health` → HTTP 200.
+3. Resolve `headlessx.pc-tips.se` from an internal network and curl through the Gateway → HTTP 200.
+4. Inspect `/app/logs` to verify log files reach the PVC. Tune retention or ship to centralized logging before the volume fills.


### PR DESCRIPTION
## Summary
- align the HeadlessX Deployment with repository conventions by sourcing secrets from an ExternalSecret and setting required runtime env vars in the pod spec
- drop the bespoke ConfigMap, LimitRange, and ResourceQuota so the namespace matches existing apps while keeping the HTTPRoute and NetworkPolicy in place
- remove the HeadlessX PodDisruptionBudget and update the operations doc to reflect the streamlined stack

## Testing
- kustomize build --enable-helm k8s/applications/web/headlessx

------
https://chatgpt.com/codex/tasks/task_e_68f36489f12c8322a0f7c2ba1019d424