### PR TITLE
feat: add headlessx dockerfile

### DIFF
--- a/images/headlessx/Dockerfile
+++ b/images/headlessx/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:20-slim AS website-builder
+
+WORKDIR /app/website
+
+COPY website/package*.json ./
+RUN npm ci
+
+COPY website/ ./
+RUN npm run build
+
+FROM mcr.microsoft.com/playwright:v1.56.0-noble
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN if [ -f "package-lock.json" ]; then \
+        npm ci --omit=dev; \
+    else \
+        npm install --production; \
+    fi && npm cache clean --force
+
+COPY src/ ./src/
+COPY --from=website-builder /app/website/out/ ./website/out/
+
+RUN mkdir -p logs
+RUN groupadd -r headlessx && useradd -r -g headlessx headlessx
+RUN chown -R headlessx:headlessx /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    AUTH_TOKEN="" \
+    DOMAIN=localhost \
+    SUBDOMAIN=headlessx
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD curl -f http://localhost:3000/api/health || exit 1
+
+USER headlessx
+
+CMD ["node", "src/server.js"]

--- a/website/docs/k8s/applications/headlessx.md
+++ b/website/docs/k8s/applications/headlessx.md
@@ -6,7 +6,7 @@ This service runs the modular HeadlessX browserless API behind the internal gate
 
 ## Build and Image
 
-* Build the container with `docker/Dockerfile` and push it to a registry the cluster can reach, for example `ghcr.io/theepicsaxguy/headlessx:1.2.0`.
+* Build the container with `images/headlessx/Dockerfile` and push it to a registry the cluster can reach, for example `ghcr.io/theepicsaxguy/headlessx:1.2.0`.
 * If the registry requires credentials, create an `imagePullSecret` named `headlessx-registry` in the `headlessx` namespace and add it to the Deployment before syncing.
 
 ## Namespace


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the HeadlessX image aligned with the upstream build
- update the HeadlessX deployment notes to point to the new Dockerfile location

## Testing
- vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/headlessx.md *(fails: vale not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f37e1f3d7c832283373f2efd373db2