### PR TITLE
Fix Bytebot VNC routing by adding URLRewrite filter

### DIFF
--- a/k8s/applications/ai/bytebot/agent/deployment.yaml
+++ b/k8s/applications/ai/bytebot/agent/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                   name: database-cnpg-app
                   key: uri
             - name: BYTEBOT_DESKTOP_BASE_URL
-              value: "http://bytebot-desktop:9990"
+              value: "/vnc"
             - name: BYTEBOT_LLM_PROXY_URL
               value: "http://litellm.litellm.svc.cluster.local"
             - name: BYTEBOT_LLM_PROXY_API_KEY

--- a/k8s/applications/ai/bytebot/httproute.yaml
+++ b/k8s/applications/ai/bytebot/httproute.yaml
@@ -29,6 +29,12 @@ spec:
         - path:
             type: PathPrefix
             value: /vnc
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
       backendRefs:
         - name: bytebot-desktop
           port: 80

--- a/k8s/applications/ai/bytebot/ui/deployment.yaml
+++ b/k8s/applications/ai/bytebot/ui/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: BYTEBOT_AGENT_BASE_URL
               value: "http://bytebot-agent:9991"
             - name: BYTEBOT_DESKTOP_VNC_URL
-              value: "http://bytebot-desktop:9990/websockify"
+              value: "/vnc/websockify"
           resources:
             requests:
               cpu: "250m"


### PR DESCRIPTION
Fixes #1617

This PR resolves the Bytebot VNC routing issue by:

1. Adding a URLRewrite filter to the `/vnc` route in the HTTPRoute configuration to strip the prefix before forwarding to the desktop pod
2. Updating the UI's `BYTEBOT_DESKTOP_VNC_URL` to use the public gateway path (`/vnc/websockify`) instead of internal cluster DNS
3. Updating the agent's `BYTEBOT_DESKTOP_BASE_URL` to use the public gateway path (`/vnc`)

These changes ensure that:
- Requests to `/vnc/websockify` are properly stripped to `/websockify` before reaching the desktop container
- Browsers can resolve and connect to the VNC service through the public gateway instead of trying to reach internal cluster DNS names

----
Generated with [Claude Code](https://claude.ai/code)