### PR TITLE
docs: refresh HeadlessX runtime image documentation

### DIFF
--- a/website/docs/k8s/applications/headlessx.md
+++ b/website/docs/k8s/applications/headlessx.md
@@ -2,47 +2,47 @@
 title: 'HeadlessX Deployment Notes'
 ---
 
-This service runs the modular HeadlessX browserless API behind the internal gateway. The manifests live in `k8s/applications/web/headlessx` and stay aligned with the original docker-compose configuration.
+This service runs the modular HeadlessX API behind the internal gateway. The manifests live in `k8s/applications/web/headlessx` and stay aligned with the original Docker Compose configuration.
 
-## Build and Image
+## Build and image
 
 * The Dockerfile at `images/headlessx/Dockerfile` builds HeadlessX from source using the upstream repository at `https://github.com/saifyxpro/HeadlessX`.
-* The build uses a three-stage Dockerfile pattern matching the official HeadlessX Dockerfile:
+* The build uses a three stage Dockerfile pattern matching the official HeadlessX Dockerfile:
   1. **Source stage**: Clones the HeadlessX repository at the specified version
   2. **Website builder stage**: Builds the HeadlessX web interface for production
-  3. **Runtime stage**: Uses the official Playwright base image (`mcr.microsoft.com/playwright:v1.56.0-noble`) with all browser dependencies pre-installed
-* The CI workflow in `.github/workflows/image-build.yaml` automatically builds and pushes the image to `ghcr.io/theepicsaxguy/headlessx:1.2.0` when changes are made to the Dockerfile.
+  3. **Runtime stage**: Uses the official Playwright base image `mcr.microsoft.com/playwright:v1.56.1-noble`. That image already includes the browser dependencies.
+* The CI workflow in `.github/workflows/image-build.yaml` builds the image and publishes the `latest`, base image (`3.22`), app version (`1.2.0`), and Git commit suffix tags to `ghcr.io/theepicsaxguy/headlessx` whenever the Dockerfile changes.
 * The runtime image includes a `HEALTHCHECK` that probes `/api/health` every 30 seconds.
 
 ## Namespace
 
-* Namespace: `headlessx`. No extra quota or limit range is defined here—reuse the cluster defaults.
+* Namespace: `headlessx`. No extra quota or limit range lives here. Use the cluster defaults.
 
-## Configuration and Secrets
+## Configuration and secrets
 
 * Runtime knobs (`PORT`, `NODE_ENV`, `UV_THREADPOOL_SIZE`, `NODE_OPTIONS`) are set directly on the Deployment.
 * `AUTH_TOKEN` comes from `es-headlessx-auth-token`, which pulls `app-headlessx-auth-token` out of Bitwarden through External Secrets.
 
-## Storage Layout
+## Storage layout
 
-* Logs persist to `headlessx-logs`, a 10Gi Longhorn-backed PVC mounted at `/app/logs`.
+* A persistent volume claim (PVC) named `headlessx-logs` provides 10 Gi of storage backed by Longhorn at `/app/logs`.
 * `/tmp` uses an `emptyDir` to mimic the compose bind mount.
 
-## Deployment Highlights
+## Deployment highlights
 
 * Single replica Deployment with requests set to 1 CPU / 1Gi and limits to 4 CPU / 4Gi.
-* Probes hit `GET /api/health` on port 3000 with a 15s initial delay, 30s period, and 10s timeout.
-* Pod security: `runAsNonRoot`, `runAsUser`/`runAsGroup` 1000, default seccomp, no privilege escalation, and all capabilities dropped.
+* Probes hit `GET /api/health` on port 3000 with a 15 second initial delay, a 30 second period, and a 10 second timeout.
+* Pod security: `runAsNonRoot`, `runAsUser` and `runAsGroup` 1000, the runtime default seccomp profile, no privilege escalation, and all capabilities dropped.
 ## Networking
 
 * Service `headlessx` exposes port 3000 internally.
 * `HTTPRoute` binds `headlessx.pc-tips.se` to the `internal` Gateway and forwards all paths to the Service.
-* `NetworkPolicy` only permits ingress from namespaces labeled `name=gateway`, and limits egress to DNS plus outbound HTTP/HTTPS.
+* `NetworkPolicy` only permits ingress from namespaces labeled `name=gateway`, and limits egress to Domain Name System (DNS) plus outbound HTTP and HTTPS.
 * Publish `headlessx.pc-tips.se` inside the private DNS zone so the Gateway’s internal address resolves for callers.
 
-## Verification Checklist
+## Verification checklist
 
 1. Wait for the Deployment to become `Available` and confirm probes stay green.
-2. `kubectl port-forward` or exec into the pod and curl `http://localhost:3000/api/health` → HTTP 200.
-3. Resolve `headlessx.pc-tips.se` from an internal network and curl through the Gateway → HTTP 200.
-4. Inspect `/app/logs` to verify log files reach the PVC. Tune retention or ship to centralized logging before the volume fills.
+2. `kubectl port-forward` or exec into the pod and run `curl "http://localhost:3000/api/health"` → HTTP 200.
+3. Resolve `headlessx.pc-tips.se` from an internal network and call it through the Gateway with `curl "https://headlessx.pc-tips.se/api/health"` → HTTP 200.
+4. Inspect `/app/logs` to verify log files reach the persistent volume claim. Tune retention or ship to centralized logging before the volume fills.

--- a/website/utils/vale/styles/Project/brands.txt
+++ b/website/utils/vale/styles/Project/brands.txt
@@ -16,6 +16,7 @@ Goldmark
 Grammarly
 Graphviz
 HashiCorp
+HeadlessX
 instant.page
 Kubebuilder
 Kustomize

--- a/website/utils/vale/styles/Project/project-words.txt
+++ b/website/utils/vale/styles/Project/project-words.txt
@@ -50,6 +50,7 @@ Dependabot
 DeploymentRuntimeConfig
 DeploymentRuntimeConfigs
 Dockerfiles
+Dockerfile
 ECR
 ESO
 EnvironmentConfig
@@ -124,6 +125,7 @@ PDB
 PDBs
 PKI
 PVCs
+PVC
 Passthrough
 PatchSet
 PatchSets
@@ -151,6 +153,7 @@ SABnzbd
 SSD
 SSO
 ServiceMonitor
+seccomp
 Sigstore
 Sonarr
 Spilo


### PR DESCRIPTION
## Summary
- align the HeadlessX application notes with the Playwright v1.56.1 runtime image and current tagging behavior
- clarify namespace, storage, networking, and verification details using plain-language phrasing
- extend the Vale dictionary so brand and security terms in the doc no longer trigger false positives

## Testing
- vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/headlessx.md

------
https://chatgpt.com/codex/tasks/task_e_68fcf1ddf0908322a81f46d742ac32a0