### PR TITLE
fix(unifi): pin controller image to v9.2.87

### DIFF
--- a/k8s/applications/network/unifi/statefulset.yaml
+++ b/k8s/applications/network/unifi/statefulset.yaml
@@ -10,14 +10,14 @@ spec:
     matchLabels:
       app: unifi-controller
   volumeClaimTemplates:
-  - metadata:
-      name: unifi-data
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "longhorn"
-      resources:
-        requests:
-          storage: 5Gi
+    - metadata:
+        name: unifi-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "longhorn"
+        resources:
+          requests:
+            storage: 5Gi
   template:
     metadata:
       labels:
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: unifi-controller
-          image: jacobalberty/unifi:v9.5.21 # renovate: docker=jacobalberty/unifi
+          image: jacobalberty/unifi:v9.2.87
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -42,11 +42,11 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: '100m'
-              memory: '512Mi'
+              cpu: "100m"
+              memory: "512Mi"
             limits:
-              cpu: '1000m'
-              memory: '2Gi'
+              cpu: "1000m"
+              memory: "2Gi"
           env:
             - name: TZ
               value: "Etc/UTC"


### PR DESCRIPTION
## Summary
- pin the UniFi controller deployment to jacobalberty/unifi:v9.2.87 to avoid ULP spam
- normalize resource request and limit quoting while matching the provided manifest formatting
- correct the `volumeClaimTemplates` indentation to match the expected layout

## Testing
- kustomize build --enable-helm k8s/applications/network/unifi

------
https://chatgpt.com/codex/tasks/task_e_690cd9c7a284832280b3a2f70583817b