### PR TITLE
fix: ensure jellyfin has writable tmp storage

### DIFF
--- a/k8s/applications/media/jellyfin/statefulset.yaml
+++ b/k8s/applications/media/jellyfin/statefulset.yaml
@@ -51,6 +51,8 @@ spec:
               mountPath: /app/data
             - name: cache
               mountPath: /cache
+            - name: tmp
+              mountPath: /tmp
           livenessProbe:
             httpGet:
               path: /
@@ -71,6 +73,8 @@ spec:
         - name: media
           persistentVolumeClaim:
             claimName: media-share
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: config


### PR DESCRIPTION
## Summary
- mount a writable emptyDir volume at /tmp for the Jellyfin statefulset to satisfy the application's startup checks

## Testing
- `kustomize build --enable-helm k8s/applications/media/jellyfin`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139ea734b883228d9b01df5998addf)