### PR TITLE
Enforce Qdrant auth for Open WebUI

### DIFF
--- a/k8s/applications/ai/openwebui/kustomization.yaml
+++ b/k8s/applications/ai/openwebui/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - http-route.yaml
 - openwebui-secrets-external.yaml
 - litellm-api-key.yaml
+- openwebui-qdrant-api-key.yaml

--- a/k8s/applications/ai/openwebui/openwebui-qdrant-api-key.yaml
+++ b/k8s/applications/ai/openwebui/openwebui-qdrant-api-key.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-openwebui-qdrant-api-key
+  namespace: open-webui
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: app-openwebui-qdrant-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: QDRANT_API_KEY
+      remoteRef:
+        key: app-qdrant-api-key
+        property: QDRANT__SERVICE__API_KEY

--- a/k8s/applications/ai/openwebui/webui-statefulset.yaml
+++ b/k8s/applications/ai/openwebui/webui-statefulset.yaml
@@ -107,7 +107,6 @@ spec:
                 secretKeyRef:
                   name: app-openwebui-qdrant-api-key
                   key: QDRANT_API_KEY
-                  optional: true
             - name: QDRANT_PREFER_GRPC
               value: 'false'
             - name: OPENAI_API_BASE_URL

--- a/website/docs/applications/open-webui.md
+++ b/website/docs/applications/open-webui.md
@@ -28,10 +28,15 @@ deployment:
 - `ENABLE_QDRANT_MULTITENANCY_MODE=true`
 - `QDRANT_PREFER_GRPC=false`
 
-Provide a Qdrant API key by creating a secret named
-`app-openwebui-qdrant-api-key` with a `QDRANT_API_KEY` field. The env var is
-optional, so the pod keeps running even if you leave the service unauthenticated
-for local testing.
+The `app-openwebui-qdrant-api-key` ExternalSecret now mirrors the
+`QDRANT__SERVICE__API_KEY` property from Bitwarden into a Kubernetes secret with
+a `QDRANT_API_KEY` field. Open WebUI will not start without this secret, which
+prevents it from silently falling back to the default Chroma store and ensures
+all traffic to Qdrant is authenticated.
+
+After switching stores or rotating the API key, re-index all documents from the
+Admin Panel → Settings → Documents page so the new Qdrant collection is
+populated.
 
 ## Embeddings
 


### PR DESCRIPTION
## Summary
- add an ExternalSecret for the Open WebUI Qdrant API key and include it in the kustomization
- require the API key in the StatefulSet so the pod refuses to start without Qdrant auth
- document the enforced secret usage and the need to re-index knowledge after switching vector stores

## Testing
- kustomize build --enable-helm k8s/applications/ai/openwebui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a00f5e488322a411bc49b713580b)