### PR TITLE
Update Vale rule to forbid 'now'

### DIFF
--- a/website/utils/vale/styles/Project/NoTemporalLanguage.yml
+++ b/website/utils/vale/styles/Project/NoTemporalLanguage.yml
@@ -9,6 +9,7 @@ tokens:
   - '\bat the moment\b'
   - '\bright now\b'
   - '\bfor now\b'
+  - '\bnow\b'
   - '\btemporarily\b'
   - '\bas of [0-9]{4}'
   - '\bin [0-9]{4}\b'


### PR DESCRIPTION
## Summary
- extend the Project NoTemporalLanguage Vale rule to include the standalone word "now"

## Testing
- `vale --config=website/utils/vale/.vale.ini website/utils/vale/styles/Project/NoTemporalLanguage.yml` *(fails: `vale` binary is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a214374c832296201d0a40a80b14)