### PR TITLE
Add pipelines deployment for OpenWebUI

### DIFF
--- a/k8s/applications/ai/openwebui/kustomization.yaml
+++ b/k8s/applications/ai/openwebui/kustomization.yaml
@@ -9,3 +9,7 @@ resources:
 - openwebui-secrets-external.yaml
 - litellm-api-key.yaml
 - openwebui-qdrant-api-key.yaml
+- pipelines-pvc.yaml
+- pipelines-secret.yaml
+- pipelines-deployment.yaml
+- pipelines-service.yaml

--- a/k8s/applications/ai/openwebui/pipelines-deployment.yaml
+++ b/k8s/applications/ai/openwebui/pipelines-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openwebui-pipelines
+  namespace: open-webui
+  labels:
+    app: openwebui-pipelines
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openwebui-pipelines
+  template:
+    metadata:
+      labels:
+        app: openwebui-pipelines
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pipelines
+          image: ghcr.io/open-webui/pipelines:git-039f9c5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ['ALL']
+          ports:
+            - name: http
+              containerPort: 9099
+          env:
+            - name: PIPELINES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-openwebui-pipelines-api-key
+                  key: PIPELINES_API_KEY
+            - name: PIPELINES_DIR
+              value: "/app/pipelines"
+            - name: PIPELINES_ENV
+              value: "production"
+          volumeMounts:
+            - name: pipelines-data
+              mountPath: /app/pipelines
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: pipelines-data
+          persistentVolumeClaim:
+            claimName: openwebui-pipelines-storage

--- a/k8s/applications/ai/openwebui/pipelines-pvc.yaml
+++ b/k8s/applications/ai/openwebui/pipelines-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-pipelines-storage
+  namespace: open-webui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn

--- a/k8s/applications/ai/openwebui/pipelines-secret.yaml
+++ b/k8s/applications/ai/openwebui/pipelines-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-openwebui-pipelines-api-key
+  namespace: open-webui
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: app-openwebui-pipelines-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: PIPELINES_API_KEY
+      remoteRef:
+        key: app-openwebui-pipelines-api-key

--- a/k8s/applications/ai/openwebui/pipelines-service.yaml
+++ b/k8s/applications/ai/openwebui/pipelines-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipelines
+  namespace: open-webui
+  labels:
+    app: openwebui-pipelines
+spec:
+  type: ClusterIP
+  selector:
+    app: openwebui-pipelines
+  ports:
+    - name: http
+      port: 9099
+      targetPort: http
+      protocol: TCP

--- a/website/docs/k8s/applications/ai/openwebui.md
+++ b/website/docs/k8s/applications/ai/openwebui.md
@@ -1,0 +1,13 @@
+---
+title: 'OpenWebUI Pipelines'
+---
+
+Pipelines run alongside OpenWebUI to handle OpenAI-compatible traffic on port `9099`. The Deployment mounts a persistent volume at `/app/pipelines` so installed pipeline modules and dependencies survive pod restarts.
+
+## Configuration
+
+- **Storage**: `openwebui-pipelines-storage` is a `10Gi` Longhorn `PersistentVolumeClaim` mounted at `/app/pipelines` in the `openwebui-pipelines` Deployment.
+- **Secrets**: The ExternalSecret `app-openwebui-pipelines-api-key` sources `PIPELINES_API_KEY` from Bitwarden and injects it into the container.
+- **Service**: The `pipelines` `ClusterIP` Service exposes port `9099` inside the `open-webui` namespace.
+- **Access**: Add an OpenAI connection in the OpenWebUI admin panel with base URL `http://pipelines.open-webui.svc.cluster.local:9099` and the same API key stored in Bitwarden. Use that connection for models that should run through pipelines.
+- **Upstream provider**: Configure pipeline valves in the OpenWebUI UI to call LiteLLM at `http://litellm.litellm.svc.cluster.local:4000/v1` with the existing LiteLLM API key.


### PR DESCRIPTION
## Summary
- add a dedicated Pipelines deployment, PVC, service, and ExternalSecret for OpenWebUI
- register the new resources in the OpenWebUI kustomization
- document how to reach the Pipelines endpoint and configure connections

## Testing
- kustomize build --enable-helm k8s/applications/ai/openwebui *(fails: kustomize not installed in container)*
- vale --config=website/utils/vale/.vale.ini website/docs/k8s/applications/ai/openwebui.md *(fails: vale not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae140ee108322be27cef42f2a41ec)