### PR TITLE
Kubernetes n8n deployment

### DIFF
--- a/k8s/applications/automation/kustomization.yaml
+++ b/k8s/applications/automation/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - mqtt
 - hassio
 - zigbee2mqtt
+- n8n

--- a/k8s/applications/automation/n8n/database-scheduled-backup.yaml
+++ b/k8s/applications/automation/n8n/database-scheduled-backup.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: n8n-db-backup
+  namespace: n8n
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: n8n-db
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/k8s/applications/automation/n8n/database.yaml
+++ b/k8s/applications/automation/n8n/database.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: n8n-minio-store
+  namespace: n8n
+spec:
+  configuration:
+    destinationPath: s3://homelab-postgres-backups/n8n/n8n-db
+    endpointURL: https://truenas.pc-tips.se:9000
+    s3Credentials:
+      accessKeyId:
+        name: longhorn-minio-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: longhorn-minio-credentials
+        key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: n8n-db
+  namespace: n8n
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job-group.longhorn.io/gfs: enabled
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
+  enablePDB: false
+  storage:
+    size: 20Gi
+    storageClass: longhorn
+  monitoring:
+    enablePodMonitor: false
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: "256MB"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: n8n-minio-store
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      memory: "1Gi"
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname

--- a/k8s/applications/automation/n8n/externalsecret.yaml
+++ b/k8s/applications/automation/n8n/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: n8n-secrets
+  namespace: n8n
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: n8n-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: N8N_ENCRYPTION_KEY
+      remoteRef:
+        key: app-n8n-encryption-key

--- a/k8s/applications/automation/n8n/http-route.yaml
+++ b/k8s/applications/automation/n8n/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+    - name: external
+      namespace: gateway
+  hostnames:
+    - n8n.pc-tips.se
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: n8n
+          port: 5678

--- a/k8s/applications/automation/n8n/kustomization.yaml
+++ b/k8s/applications/automation/n8n/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - database.yaml
+  - database-scheduled-backup.yaml
+  - statefulset.yaml
+  - service.yaml
+  - http-route.yaml

--- a/k8s/applications/automation/n8n/namespace.yaml
+++ b/k8s/applications/automation/n8n/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: n8n
+  labels:
+    name: n8n

--- a/k8s/applications/automation/n8n/service.yaml
+++ b/k8s/applications/automation/n8n/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: n8n
+  namespace: n8n
+  labels:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/instance: n8n
+spec:
+  selector:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/instance: n8n
+  ports:
+    - name: http
+      port: 5678
+      targetPort: http
+      protocol: TCP

--- a/k8s/applications/automation/n8n/statefulset.yaml
+++ b/k8s/applications/automation/n8n/statefulset.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: n8n
+  namespace: n8n
+  labels:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/instance: n8n
+    app.kubernetes.io/component: automation
+spec:
+  replicas: 1
+  serviceName: n8n
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: n8n
+      app.kubernetes.io/instance: n8n
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: n8n
+        app.kubernetes.io/instance: n8n
+        app.kubernetes.io/component: automation
+    spec:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown 1000:1000 /data"]
+          volumeMounts:
+            - name: n8n-data
+              mountPath: /data
+      containers:
+        - name: n8n
+          image: n8nio/n8n:1.71.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - sleep 5; n8n start
+          ports:
+            - containerPort: 5678
+              name: http
+              protocol: TCP
+          env:
+            - name: TZ
+              value: Europe/Stockholm
+            - name: N8N_PROTOCOL
+              value: https
+            - name: N8N_PORT
+              value: "5678"
+            - name: N8N_HOST
+              value: n8n.pc-tips.se
+            - name: WEBHOOK_URL
+              value: https://n8n.pc-tips.se/
+            - name: GENERIC_TIMEZONE
+              value: Europe/Stockholm
+            - name: DB_TYPE
+              value: postgresdb
+            - name: DB_POSTGRESDB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-db-app
+                  key: host
+            - name: DB_POSTGRESDB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-db-app
+                  key: port
+            - name: DB_POSTGRESDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-db-app
+                  key: dbname
+            - name: DB_POSTGRESDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-db-app
+                  key: username
+            - name: DB_POSTGRESDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-db-app
+                  key: password
+            - name: N8N_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-secrets
+                  key: N8N_ENCRYPTION_KEY
+          envFrom:
+            - secretRef:
+                name: n8n-secrets
+                optional: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: n8n-data
+              mountPath: /home/node/.n8n
+      securityContext:
+        fsGroup: 1000
+  volumeClaimTemplates:
+    - metadata:
+        name: n8n-data
+        labels:
+          recurring-job.longhorn.io/source: enabled
+          recurring-job-group.longhorn.io/daily: enabled
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/applications/automation/project.yaml
+++ b/k8s/applications/automation/project.yaml
@@ -15,6 +15,8 @@ spec:
       server: '*'
     - namespace: 'zigbee2mqtt'
       server: '*'
+    - namespace: 'n8n'
+      server: '*'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'


### PR DESCRIPTION
Add n8n deployment to Kubernetes, leveraging CloudNativePG for database management and External Secrets Operator for secure credential handling.

This deployment adheres to the existing application patterns, utilizing CloudNativePG for PostgreSQL and External Secrets Operator for fetching secrets from Bitwarden, as per the defined deployment guidelines.

---
<a href="https://cursor.com/background-agent?bcId=bc-d43c5730-a4cd-4e32-b38d-e874c4a292d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d43c5730-a4cd-4e32-b38d-e874c4a292d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces the n8n application with a CNPG-backed Postgres cluster, S3-based backups, External Secrets, and exposes it via Service and HTTPRoute; updates project/kustomization to include the new namespace/app.
> 
> - **n8n application**:
>   - Adds `namespace` `n8n` and includes `n8n` in `k8s/applications/automation/kustomization.yaml` and `AppProject` destinations.
>   - Deploys `StatefulSet` `n8n` with persistent storage (`n8n-data` PVC), resource limits, health probes, and initContainer for permissions.
>   - Creates `Service` `n8n` (port `5678`) and `HTTPRoute` for `n8n.pc-tips.se` via internal/external gateways.
> - **Database (CloudNativePG)**:
>   - Defines `Cluster` `n8n-db` (Postgres 18) with Longhorn storage and WAL archiving plugin.
>   - Configures `ObjectStore` `n8n-minio-store` for backups to S3 (MinIO) and a `ScheduledBackup` cron.
> - **Secrets**:
>   - Adds `ExternalSecret` `n8n-secrets` pulling `N8N_ENCRYPTION_KEY` from Bitwarden; app consumes DB creds from `n8n-db-app` secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00b9d576b1f83314ce0646e777da497f123b6d69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->