### PR TITLE
chore(deps): enhance renovate configuration and update Dockerfiles

### DIFF
--- a/images/headlessx/Dockerfile
+++ b/images/headlessx/Dockerfile
@@ -7,7 +7,7 @@
 ###############################################################################
 FROM alpine:3.23 AS source
 
-ARG IMAGE_VERSION=1.2.0
+ARG IMAGE_VERSION=1.2.0 # renovate: github-releases=saifyxpro/HeadlessX
 ARG HEADLESSX_REPO=https://github.com/saifyxpro/HeadlessX
 
 RUN apk add --no-cache git ca-certificates
@@ -45,9 +45,9 @@ WORKDIR /app
 # Install Node.js dependencies
 COPY --from=source /src/package*.json ./
 RUN if [ -f "package-lock.json" ]; then \
-        npm ci --omit=dev --prefer-offline --no-audit; \
+    npm ci --omit=dev --prefer-offline --no-audit; \
     else \
-        npm install --production --prefer-offline --no-audit; \
+    npm install --production --prefer-offline --no-audit; \
     fi && \
     npm cache clean --force
 

--- a/images/sabnzbd/Dockerfile
+++ b/images/sabnzbd/Dockerfile
@@ -5,7 +5,7 @@
 # Stage 0: build unrar from source (matches LSIO pattern)
 ###############################################################################
 FROM alpine:3.23 AS unrar-build
-ARG UNRAR_VER=6.2.12
+ARG UNRAR_VER=6.2.12 # renovate: github-releases=rarlab/unrar
 
 RUN apk add --no-cache build-base ca-certificates curl tar \
      && update-ca-certificates \
@@ -18,7 +18,7 @@ RUN apk add --no-cache build-base ca-certificates curl tar \
 # Stage 1: build SABnzbd from source + venv (includes native deps)
 ###############################################################################
 FROM alpine:3.23 AS sab-build
-ARG IMAGE_VERSION=4.5.3
+ARG IMAGE_VERSION=4.5.3 # renovate: github-releases=sabnzbd/sabnzbd
 
 RUN apk add --no-cache \
      git ca-certificates tzdata \
@@ -73,4 +73,4 @@ COPY entrypoint.py /entrypoint.py
 
 VOLUME ["/config", "/downloads"]
 EXPOSE 8080
-ENTRYPOINT ["/sbin/tini","-g","--","/venv/bin/python","/entrypoint.py"] 
+ENTRYPOINT ["/sbin/tini","-g","--","/venv/bin/python","/entrypoint.py"]

--- a/images/spilo17-vchord/Dockerfile
+++ b/images/spilo17-vchord/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/zalando/spilo-17:4.0-p2
 LABEL org.opencontainers.image.description="PostgreSQL 17 with VectorChord extension"
 
-ARG VCHORD_VERSION=0.3.0
+ARG VCHORD_VERSION=0.3.0 # renovate: github-releases=tensorchord/VectorChord
 ARG IMAGE_VERSION=0.1.0
 
 

--- a/images/vllm-cpu/Dockerfile
+++ b/images/vllm-cpu/Dockerfile
@@ -5,7 +5,7 @@
 #   VLLM_CPU_AVX512VNNI=false (default)|true
 #   VLLM_CPU_AMXBF16=false (default)|true
 #
-ARG IMAGE_VERSION=v0.11.0
+ARG IMAGE_VERSION=v0.11.0 # renovate: github-releases=vllm-project/vllm
 
 # This vLLM Dockerfile is used to build images that can run vLLM on both x86_64 and arm64 CPU platforms.
 #
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -y \
     && apt-get install -y --no-install-recommends sudo ccache git curl wget ca-certificates \
-        gcc-12 g++-12 libtcmalloc-minimal4 libnuma-dev ffmpeg libsm6 libxext6 libgl1 jq lsof \
+    gcc-12 g++-12 libtcmalloc-minimal4 libnuma-dev ffmpeg libsm6 libxext6 libgl1 jq lsof \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
     && curl -LsSf https://astral.sh/uv/install.sh | sh
 

--- a/renovate.json
+++ b/renovate.json
@@ -22,11 +22,22 @@
       "managerFilePatterns": [
         "/\\.tf$/",
         "/\\.tftpl$/",
+        "/\\.tfvars$/",
         "/\\.yaml$/",
         "/\\.sh$/"
       ],
       "matchStrings": [
         "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*#\\s?renovate: (?<datasource>\\S+)=(?<depName>\\S+)\\s?(registry=(?<registryUrl>\\S+))?\\s?(versioning=(?<versioning>\\S+))?"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/Dockerfile$/",
+        "/Dockerfile\\..*$/"
+      ],
+      "matchStrings": [
+        "ARG\\s+\\w+=(?<currentValue>[\\w+\\.\\-]*)['\"]?\\s*#\\s?renovate: (?<datasource>\\S+)=(?<depName>\\S+)\\s?(versioning=(?<versioning>\\S+))?"
       ]
     }
   ],
@@ -66,6 +77,14 @@
     {
       "groupName": "all dependencies",
       "matchPackageNames": ["*"]
+    },
+    {
+      "description": "Prevent automatic upgrades for Talos and Kubernetes versions in tofu/ - require manual review",
+      "matchFileNames": ["/tofu/.*\\.(tf|tfvars|tftpl)$/"],
+      "matchPackageNames": ["siderolabs/talos", "kubernetes/kubernetes"],
+      "automerge": false,
+      "automergeType": "pr",
+      "schedule": ["before 10am on monday"]
     }
   ],
   "kubernetes": {

--- a/tofu/config.auto.tfvars
+++ b/tofu/config.auto.tfvars
@@ -14,8 +14,8 @@ network = {
 proxmox_cluster = "host3"
 
 versions = {
-  talos      = "v1.10.3"
-  kubernetes = "1.33.2"
+  talos      = "v1.10.3" # renovate: github-releases=siderolabs/talos
+  kubernetes = "1.33.2" # renovate: github-releases=kubernetes/kubernetes versioning=loose
   #talos      = "v1.11.5"
   #kubernetes = "1.34.3"
 }


### PR DESCRIPTION
- Added support for .tfvars files in renovate.json.
- Introduced custom regex type for Dockerfile management in renovate.json.
- Added rules to prevent automatic upgrades for Talos and Kubernetes in tofu configuration.
- Updated ARG declarations in multiple Dockerfiles to include renovate comments for version tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Renovate to parse .tfvars and Dockerfile ARGs, adds safeguards for Talos/Kubernetes in tofu/, and annotates Dockerfiles/vars with renovate hints for automated version tracking.
> 
> - **Renovate configuration (`renovate.json`)**:
>   - Add `.tfvars` to regex manager and introduce a Dockerfile regex manager to detect `ARG` versions.
>   - New rule to prevent automatic upgrades of `siderolabs/talos` and `kubernetes/kubernetes` in `tofu/` (manual review, scheduled).
> - **Dockerfiles**:
>   - Annotate version `ARG`s with renovate hints in `images/headlessx/Dockerfile`, `images/sabnzbd/Dockerfile`, `images/spilo17-vchord/Dockerfile`, and `images/vllm-cpu/Dockerfile`.
> - **Tofu config (`tofu/config.auto.tfvars`)**:
>   - Add renovate annotations to `versions.talos` and `versions.kubernetes` for tracking (loose versioning for Kubernetes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63bce1e175691c5ca35264c1fe3153a773aa34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->