### PR TITLE
Longhorn replica zone anti-affinity

### DIFF
--- a/k8s/infrastructure/storage/longhorn/values.yaml
+++ b/k8s/infrastructure/storage/longhorn/values.yaml
@@ -59,7 +59,7 @@ defaultSettings:
   defaultDataPath: /var/lib/longhorn/
   autoDeletePodWhenVolumeDetachedUnexpectedly: true
   autoSalvage: true
-  replicaZoneSoftAntiAffinity: false
+  replicaZoneSoftAntiAffinity: true
   concurrentReplicaRebuildPerNodeLimit: 1
   replicaReplenishmentWaitInterval: 600
   backupstorePollInterval: 300


### PR DESCRIPTION
Enable Longhorn's Replica Zone Level Soft Anti-Affinity to improve replica scheduling flexibility.

This change allows Longhorn to schedule volume replicas in the same zone if necessary (when there aren't enough nodes in different zones), preventing scheduling failures that could occur with strict zone-level anti-affinity in smaller or zone-limited clusters.

---
<a href="https://cursor.com/background-agent?bcId=bc-677b3e0a-33e3-49e7-b3f4-8586a3eb8113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-677b3e0a-33e3-49e7-b3f4-8586a3eb8113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

