### PR TITLE
Authentik group to litellm role mapping

### DIFF
--- a/k8s/applications/ai/litellm/proxy_server_config.yaml
+++ b/k8s/applications/ai/litellm/proxy_server_config.yaml
@@ -305,6 +305,14 @@ general_settings:
   database_connection_pool_limit: 50
   database_connection_timeout: 60
   allow_requests_on_db_unavailable: false
+  litellm_jwtauth:
+    user_roles_jwt_field: "groups"
+    sync_user_role_and_teams: true
+    jwt_litellm_role_map:
+      - jwt_role: "Litellm Admins"
+        litellm_role: "proxy_admin"
+      - jwt_role: "Litellm Users"
+        litellm_role: "internal_user"
   user_header_mappings:
     - header_name: X-OpenWebUI-User-Id
       litellm_user_role: internal_user

--- a/k8s/infrastructure/auth/authentik/extra/blueprints-configmap.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints-configmap.yaml
@@ -21,6 +21,12 @@ data:
           name: Litellm Users
         attrs:
           name: Litellm Users
+      - id: litellm-admin-group
+        model: authentik_core.group
+        identifiers:
+          name: Litellm Admins
+        attrs:
+          name: Litellm Admins
       - id: litellm_provider
         model: authentik_providers_oauth2.oauth2provider
         identifiers:


### PR DESCRIPTION
Configure JWT role mapping to synchronize Authentik groups with LiteLLM user roles, enabling "Litellm Admins" to gain `proxy_admin` access.

This allows users assigned to the "Litellm Admins" group in Authentik to automatically receive `proxy_admin` privileges in LiteLLM, ensuring proper access control for the UI and platform features.

---
<a href="https://cursor.com/background-agent?bcId=bc-8968964f-e1b7-4c67-b301-b094fe0539ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8968964f-e1b7-4c67-b301-b094fe0539ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

