### PR TITLE
Authentik argocd redirect issue

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-argocd.yaml
@@ -43,7 +43,7 @@ entries:
 
       client_type: confidential
       redirect_uris:
-        - url: https://argocd.pc-tips.se/auth/callback
+        - url: https://argocd.pc-tips.se/api/dex/callback
           matching_mode: strict
       client_id: !Env ARGOCD_CLIENT_ID
       client_secret: !Env ARGOCD_CLIENT_SECRET


### PR DESCRIPTION
Update Authentik blueprint's ArgoCD redirect URI to use Dex callback path to resolve "Redirect URI Error".

The previous configuration used `/auth/callback`, but ArgoCD's OIDC flow, when configured with Dex, expects the callback at `/api/dex/callback`. This change aligns the Authentik blueprint with ArgoCD's Dex-based authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-c584315b-ed1f-44d7-a851-6974413e2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c584315b-ed1f-44d7-a851-6974413e2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

