### PR TITLE
Refactor Mistral model configurations in proxy_server_config.yaml

### DIFF
--- a/k8s/applications/ai/litellm/proxy_server_config.yaml
+++ b/k8s/applications/ai/litellm/proxy_server_config.yaml
@@ -816,11 +816,6 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
       default_litellm_params:
         temperature: 0.6
         top_p: 0.95
@@ -837,15 +832,7 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
-      default_litellm_params:
-        temperature: 0.2
-        top_p: 1
-        max_tokens: 2048
+
     model_info:
       mode: chat
       max_input_tokens: 100000
@@ -858,11 +845,6 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
       default_litellm_params:
         temperature: 0.7
         top_p: 0.8
@@ -879,11 +861,6 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
       default_litellm_params:
         temperature: 0.6
         top_p: 0.95
@@ -900,11 +877,6 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
       default_litellm_params:
         temperature: 1
         top_p: 1
@@ -922,15 +894,7 @@ model_list:
       api_key: "os.environ/CEREBRAS_API_KEY"
       api_base: "https://api.cerebras.ai/v1"
       custom_llm_provider: "cerebras"
-      supports_streaming: false
-      drop_params: true
-      additional_drop_params: ["stream"]
-      extra_headers:
-        X-Cerebras-3rd-Party-Integration: litellm
-      default_litellm_params:
-        temperature: 0.2
-        top_p: 1
-        max_tokens: 2048
+
     model_info:
       mode: chat
       max_input_tokens: 100000
@@ -939,218 +903,493 @@ model_list:
 
 # Mistral models
   # Frontier Models - Generalist
-  - model_name: mistral/mistral-large-3
+  - model_name: mistral/mistral-medium-2505
+    litellm_params:
+      model: "mistral/mistral-medium-2505"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-medium-2508
+    litellm_params:
+      model: "mistral/mistral-medium-2508"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-medium-latest
+    litellm_params:
+      model: "mistral/mistral-medium-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-medium
+    litellm_params:
+      model: "mistral/mistral-medium"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/open-mistral-nemo
+    litellm_params:
+      model: "mistral/open-mistral-nemo"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/open-mistral-nemo-2407
+    litellm_params:
+      model: "mistral/open-mistral-nemo-2407"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-tiny-2407
+    litellm_params:
+      model: "mistral/mistral-tiny-2407"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-tiny-latest
+    litellm_params:
+      model: "mistral/mistral-tiny-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-large-2411
+    litellm_params:
+      model: "mistral/mistral-large-2411"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/pixtral-large-2411
+    litellm_params:
+      model: "mistral/pixtral-large-2411"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/pixtral-large-latest
+    litellm_params:
+      model: "mistral/pixtral-large-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-large-pixtral-2411
+    litellm_params:
+      model: "mistral/mistral-large-pixtral-2411"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-large-2512
+    litellm_params:
+      model: "mistral/mistral-large-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-large-latest
     litellm_params:
       model: "mistral/mistral-large-latest"
       api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-small-2506
+    litellm_params:
+      model: "mistral/mistral-small-2506"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-small-latest
+    litellm_params:
+      model: "mistral/mistral-small-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-3b-2512
+    litellm_params:
+      model: "mistral/ministral-3b-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-3b-latest
+    litellm_params:
+      model: "mistral/ministral-3b-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-8b-2512
+    litellm_params:
+      model: "mistral/ministral-8b-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-8b-latest
+    litellm_params:
+      model: "mistral/ministral-8b-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-14b-2512
+    litellm_params:
+      model: "mistral/ministral-14b-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/ministral-14b-latest
+    litellm_params:
+      model: "mistral/ministral-14b-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/magistral-medium-2509
+    litellm_params:
+      model: "mistral/magistral-medium-2509"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/magistral-medium-latest
+    litellm_params:
+      model: "mistral/magistral-medium-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/magistral-small-2509
+    litellm_params:
+      model: "mistral/magistral-small-2509"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/magistral-small-latest
+    litellm_params:
+      model: "mistral/magistral-small-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.7
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  # Specialist Models - Coding
+  - model_name: mistral/codestral-2508
+    litellm_params:
+      model: "mistral/codestral-2508"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
     model_info:
       mode: chat
       max_input_tokens: 256000
       max_output_tokens: 8192
 
-  - model_name: mistral/mistral-medium-3.1
-    litellm_params:
-      model: "mistral/mistral-medium-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/mistral-small-3.2
-    litellm_params:
-      model: "mistral/mistral-small-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/ministral-3-14b
-    litellm_params:
-      model: "mistral/ministral-14b-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/ministral-3-8b
-    litellm_params:
-      model: "mistral/ministral-8b-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/ministral-3-3b
-    litellm_params:
-      model: "mistral/ministral-3b-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/magistral-medium-1.2
-    litellm_params:
-      model: "mistral/magistral-medium-2507"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/magistral-small-1.2
-    litellm_params:
-      model: "mistral/magistral-small-2507"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  # Specialist Models
-  - model_name: mistral/ocr-3
-    litellm_params:
-      model: "mistral/ocr-3"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: ocr
-
-  - model_name: mistral/voxtral-mini-transcribe
-    litellm_params:
-      model: "mistral/voxtral-mini-transcribe"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: audio_transcription
-
-  - model_name: mistral/codestral
+  - model_name: mistral/codestral-latest
     litellm_params:
       model: "mistral/codestral-latest"
       api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
     model_info:
       mode: chat
-      max_input_tokens: 32000
+      max_input_tokens: 256000
       max_output_tokens: 8192
 
-  - model_name: mistral/devstral-2
+  - model_name: mistral/devstral-small-2507
     litellm_params:
-      model: "mistral/devstral-2"
+      model: "mistral/devstral-small-2507"
       api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
     model_info:
       mode: chat
-      max_input_tokens: 128000
+      max_input_tokens: 131072
       max_output_tokens: 8192
 
-  - model_name: mistral/codestral-embed
+  - model_name: mistral/devstral-medium-2507
     litellm_params:
-      model: "mistral/codestral-embed"
+      model: "mistral/devstral-medium-2507"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
+    model_info:
+      mode: chat
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+
+  - model_name: mistral/devstral-2512
+    litellm_params:
+      model: "mistral/devstral-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/mistral-vibe-cli-latest
+    litellm_params:
+      model: "mistral/mistral-vibe-cli-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/devstral-medium-latest
+    litellm_params:
+      model: "mistral/devstral-medium-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/devstral-latest
+    litellm_params:
+      model: "mistral/devstral-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/labs-devstral-small-2512
+    litellm_params:
+      model: "mistral/labs-devstral-small-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  - model_name: mistral/devstral-small-latest
+    litellm_params:
+      model: "mistral/devstral-small-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: chat
+      max_input_tokens: 262144
+      max_output_tokens: 8192
+
+  # Specialist Models - Audio
+  - model_name: mistral/voxtral-mini-2507
+    litellm_params:
+      model: "mistral/voxtral-mini-2507"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: audio_transcription
+      max_input_tokens: 32768
+
+  - model_name: mistral/voxtral-mini-latest
+    litellm_params:
+      model: "mistral/voxtral-mini-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: audio_transcription
+      max_input_tokens: 32768
+
+  - model_name: mistral/voxtral-small-2507
+    litellm_params:
+      model: "mistral/voxtral-small-2507"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: audio_transcription
+      max_input_tokens: 32768
+
+  - model_name: mistral/voxtral-small-latest
+    litellm_params:
+      model: "mistral/voxtral-small-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.2
+    model_info:
+      mode: audio_transcription
+      max_input_tokens: 32768
+
+  - model_name: mistral/voxtral-mini-transcribe-2507
+    litellm_params:
+      model: "mistral/voxtral-mini-transcribe-2507"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
+    model_info:
+      mode: audio_transcription
+      max_input_tokens: 16384
+
+  # Specialist Models - Vision & OCR
+  - model_name: mistral/mistral-ocr-2512
+    litellm_params:
+      model: "mistral/mistral-ocr-2512"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
+    model_info:
+      mode: ocr
+      max_input_tokens: 16384
+
+  - model_name: mistral/mistral-ocr-latest
+    litellm_params:
+      model: "mistral/mistral-ocr-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
+    model_info:
+      mode: ocr
+      max_input_tokens: 16384
+
+  - model_name: mistral/mistral-ocr-2505
+    litellm_params:
+      model: "mistral/mistral-ocr-2505"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.0
+    model_info:
+      mode: ocr
+      max_input_tokens: 16384
+
+  # Specialist Models - Embeddings
+  - model_name: mistral/mistral-embed-2312
+    litellm_params:
+      model: "mistral/mistral-embed-2312"
       api_key: "os.environ/MISTRAL_API_KEY"
     model_info:
       mode: embedding
-
-  - model_name: mistral/voxtral-mini
-    litellm_params:
-      model: "mistral/voxtral-mini"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: audio_transcription
-
-  - model_name: mistral/voxtral-small
-    litellm_params:
-      model: "mistral/voxtral-small"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: audio_transcription
-
-  - model_name: mistral/mistral-moderation
-    litellm_params:
-      model: "mistral/mistral-moderation"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-
-  # Other Models
-  - model_name: mistral/mistral-small-creative
-    litellm_params:
-      model: "mistral/mistral-small-creative"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/devstral-small-2
-    litellm_params:
-      model: "mistral/devstral-small-2"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/devstral-medium-1.0
-    litellm_params:
-      model: "mistral/devstral-medium-1.0"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/devstral-small-1.1
-    litellm_params:
-      model: "mistral/devstral-small-2505"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/ocr-2
-    litellm_params:
-      model: "mistral/ocr-2"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: ocr
-
-  - model_name: mistral/mistral-medium-3
-    litellm_params:
-      model: "mistral/mistral-medium-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/mistral-large-2.1
-    litellm_params:
-      model: "mistral/mistral-large-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/pixtral-large
-    litellm_params:
-      model: "mistral/pixtral-large-latest"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
-
-  - model_name: mistral/mistral-nemo-12b
-    litellm_params:
-      model: "mistral/open-mistral-nemo"
-      api_key: "os.environ/MISTRAL_API_KEY"
-    model_info:
-      mode: chat
-      max_input_tokens: 128000
-      max_output_tokens: 8192
+      max_input_tokens: 8192
 
   - model_name: mistral/mistral-embed
     litellm_params:
@@ -1158,6 +1397,52 @@ model_list:
       api_key: "os.environ/MISTRAL_API_KEY"
     model_info:
       mode: embedding
+      max_input_tokens: 8192
+
+  - model_name: mistral/codestral-embed-2505
+    litellm_params:
+      model: "mistral/codestral-embed-2505"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    model_info:
+      mode: embedding
+      max_input_tokens: 8192
+
+  - model_name: mistral/codestral-embed
+    litellm_params:
+      model: "mistral/codestral-embed"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    model_info:
+      mode: embedding
+      max_input_tokens: 8192
+
+  # Specialist Models - Moderation
+  - model_name: mistral/mistral-moderation-2411
+    litellm_params:
+      model: "mistral/mistral-moderation-2411"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    model_info:
+      mode: chat
+      max_input_tokens: 8192
+
+  - model_name: mistral/mistral-moderation-latest
+    litellm_params:
+      model: "mistral/mistral-moderation-latest"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    model_info:
+      mode: chat
+      max_input_tokens: 8192
+
+  # Other Models
+  - model_name: mistral/labs-mistral-small-creative
+    litellm_params:
+      model: "mistral/labs-mistral-small-creative"
+      api_key: "os.environ/MISTRAL_API_KEY"
+    default_litellm_params:
+      temperature: 0.3
+    model_info:
+      mode: chat
+      max_input_tokens: 32768
+      max_output_tokens: 8192
 
 litellm_settings:
   callbacks: ["prometheus"]


### PR DESCRIPTION
- Removed deprecated parameters for Cerebras models to streamline configuration.
- Updated Mistral model names and added new models with specific parameters for chat, OCR, and audio transcription tasks.
- Enhanced default parameters and input/output token limits for improved performance.
- Introduced additional models for coding, audio, vision, and embedding tasks with appropriate settings.