### PR TITLE
feat(k8s): add minecraft-bedrock dedicated server

### DIFF
--- a/k8s/applications/media/kustomization.yaml
+++ b/k8s/applications/media/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - immich
 - audiobookshelf
 - audiobookrequest
+- minecraft-bedrock

--- a/k8s/applications/media/minecraft-bedrock/configmap.yaml
+++ b/k8s/applications/media/minecraft-bedrock/configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minecraft-bedrock
+  labels:
+    app.kubernetes.io/name: minecraft-bedrock
+    app.kubernetes.io/part-of: media
+    role: service-config
+data:
+  # Find more options at https://github.com/itzg/docker-minecraft-bedrock-server#server-properties
+  # Remove # from in front of line if changing from default values.
+  EULA: "TRUE" # Must accept EULA to use this minecraft server
+  #GAMEMODE: "survival" # Options: survival, creative, adventure
+  #DIFFICULTY: "easy" # Options: peaceful, easy, normal, hard
+  #DEFAULT_PLAYER_PERMISSION_LEVEL: "member" # Options: visitor, member, operator
+  #LEVEL_NAME: "my_minecraft_world"
+  #LEVEL_SEED: "33480944"
+  #SERVER_NAME: "my_minecraft_server"
+  #SERVER_PORT: "19132"
+  #LEVEL_TYPE: "DEFAULT" # Options: FLAT, LEGACY, DEFAULT
+  #ALLOW_CHEATS: "false" # Options: true, false
+  #MAX_PLAYERS: "10"
+  #PLAYER_IDLE_TIMEOUT: "30"
+  #TEXTUREPACK_REQUIRED: "false" # Options: true, false
+  #
+  ## Changing these will have a security impact
+  #ONLINE_MODE: "true" # Options: true, false (removes Xbox Live account requirements)
+  #WHITE_LIST: "false" # If enabled, need to provide a whitelist.json by your own means. 
+  #
+  ## Changing these will have a performance impact
+  #VIEW_DISTANCE: "10"
+  #TICK_DISTANCE: "4"
+  #MAX_THREADS: "8"

--- a/k8s/applications/media/minecraft-bedrock/kustomization.yaml
+++ b/k8s/applications/media/minecraft-bedrock/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - statefulset.yaml
+  - service.yaml

--- a/k8s/applications/media/minecraft-bedrock/service.yaml
+++ b/k8s/applications/media/minecraft-bedrock/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft-bedrock
+  labels:
+    app.kubernetes.io/name: minecraft-bedrock
+    app.kubernetes.io/part-of: media
+  annotations:
+    io.cilium/lb-ipam-ips: 10.25.150.254
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: minecraft-bedrock
+  ports:
+    - port: 19132
+      targetPort: minecraft
+      protocol: UDP
+      name: minecraft

--- a/k8s/applications/media/minecraft-bedrock/statefulset.yaml
+++ b/k8s/applications/media/minecraft-bedrock/statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/name: minecraft-bedrock
+    app.kubernetes.io/part-of: media
+  name: minecraft-bedrock
+spec:
+  replicas: 1
+  serviceName: minecraft-bedrock
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minecraft-bedrock
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minecraft-bedrock
+    spec:
+      containers:
+        - name: main
+          image: itzg/minecraft-bedrock-server:2024.12.0
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: minecraft-bedrock
+          volumeMounts:
+            - mountPath: /data
+              name: data
+          ports:
+            - containerPort: 19132
+              protocol: UDP
+              name: minecraft
+          readinessProbe: &probe
+            exec:
+              command:
+                - mc-monitor
+                - status-bedrock
+                - --host
+                - 127.0.0.1
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe: *probe
+          tty: true
+          stdin: true
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: minecraft-bedrock
+          app.kubernetes.io/part-of: media
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: proxmox-csi
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
## Summary
- Add Minecraft Bedrock Dedicated Server (BDS) deployment
- Use StatefulSet with volumeClaimTemplates for persistent storage
- Configure LoadBalancer with Cilium static IP annotation (10.25.150.254)
- Include ConfigMap with EULA acceptance and server properties
- Follow official itzg/docker-minecraft-bedrock-server patterns

## Changes
- New application under `k8s/applications/media/minecraft-bedrock/`
- StatefulSet with proxmox-csi storage class
- LoadBalancer service for LAN access at 10.25.150.254:19132 (UDP)

## Testing
- Kustomize builds successfully
- Follows repository patterns and conventions