### PR TITLE
feat(k8s): add audiobookshelf admins group and fix group claim casing

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-media.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-media.yaml
@@ -462,6 +462,14 @@ entries:
     model: authentik_policies.policybinding
     identifiers:
       target: !KeyOf application-audiobookshelf
-      group: !Find [authentik_core.group, [name, "Audiobookshelf Users"]]
+      group: !Find [authentik_core.group, [name, "audiobookshelf users"]]
     attrs:
       order: 1
+
+  - id: audiobookshelf_admins_policy_binding
+    model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf application-audiobookshelf
+      group: !Find [authentik_core.group, [name, "audiobookshelf admins"]]
+    attrs:
+      order: 2

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/groups.yaml
@@ -118,6 +118,12 @@ entries:
   - id: audiobookshelf-users
     model: authentik_core.group
     identifiers:
-      name: Audiobookshelf Users
+      name: audiobookshelf users
     attrs:
-      name: Audiobookshelf Users
+      name: audiobookshelf users
+  - id: audiobookshelf-admins
+    model: authentik_core.group
+    identifiers:
+      name: audiobookshelf admins
+    attrs:
+      name: audiobookshelf admins


### PR DESCRIPTION
## Summary
- Add audiobookshelf admins group for elevated access
- Fix group names to lowercase for audiobookshelf case-insensitive group matching

## Changes
- groups.yaml: Fix Audiobookshelf Users casing, add audiobookshelf admins
- apps-media.yaml: Update policy binding, add admins policy binding