### PR TITLE
fix(auth): change authentik proxy mode from forward_single to proxy for frigate and opencode

### DIFF
--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-frigate.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-frigate.yaml
@@ -34,7 +34,7 @@ entries:
 
       # Pass user info headers to Frigate
       basic_auth_enabled: false
-      mode: forward_single
+      mode: proxy
 
       # Session validity
       access_token_validity: hours=4
@@ -49,6 +49,7 @@ entries:
       group: Home Automation
       meta_description: AI-powered NVR with real-time object detection
       icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/frigate.png
+      meta_launch_url: https://frigate.peekoff.com
       provider: !KeyOf frigate_proxy_provider
       policy_engine_mode: any
 

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-opencode.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-opencode.yaml
@@ -33,7 +33,7 @@ entries:
 
       # Pass user info headers to OpenCode - no exclusions
       basic_auth_enabled: false
-      mode: forward_single
+      mode: proxy
 
       # Session validity
       access_token_validity: hours=4
@@ -48,6 +48,7 @@ entries:
       group: AI
       meta_description: AI-powered coding assistant
       icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/code.png
+      meta_launch_url: https://opencode.peekoff.com
       provider: !KeyOf opencode_proxy_provider
       policy_engine_mode: any
 


### PR DESCRIPTION
## Summary

Changed Authentik proxy provider mode from `forward_single` to `proxy` for both Frigate and OpenCode applications, and added explicit launch URLs.

## Changes

- **apps-frigate.yaml**: Changed `mode: forward_single` → `mode: proxy` and added `meta_launch_url: https://frigate.peekoff.com`
- **apps-opencode.yaml**: Changed `mode: forward_single` → `mode: proxy` and added `meta_launch_url: https://opencode.peekoff.com`

## Rationale

The `forward_single` mode is designed for reverse proxy integration (nginx auth_request, Traefik forwardAuth) and requires additional outpost deployment or reverse proxy configuration. For standalone authentication without reverse proxy integration, the `proxy` mode is more appropriate as it behaves like a transparent reverse-proxy that requires authentication.