### PR TITLE
feat(k8s): add tmail webmail client with authentik OIDC integration

### DIFF
--- a/k8s/applications/web/kustomization.yaml
+++ b/k8s/applications/web/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   #- headlessx
   - kiwix
   - pinepods
+  - tmail

--- a/k8s/applications/web/project.yaml
+++ b/k8s/applications/web/project.yaml
@@ -17,6 +17,8 @@ spec:
       server: '*'
     - namespace: 'pinepods'
       server: '*'
+    - namespace: 'tmail'
+      server: '*'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/k8s/applications/web/tmail/deployment.yaml
+++ b/k8s/applications/web/tmail/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tmail
+  namespace: tmail
+  labels:
+    app.kubernetes.io/name: tmail
+    app.kubernetes.io/part-of: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tmail
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tmail
+    spec:
+      containers:
+        - name: tmail
+          image: ghcr.io/linagora/tmail-web:v0.23.1
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: '100m'
+              memory: '256Mi'
+            limits:
+              cpu: '500m'
+              memory: '512Mi'
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: OIDC_SCOPES
+              value: 'openid,profile,email'
+            - name: DOMAIN_REDIRECT_URL
+              value: 'https://mail.peekoff.com'
+            - name: WEB_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: es-tmail-secrets
+                  key: WEB_OIDC_CLIENT_ID
+            - name: OIDC_ISSUER
+              value: 'https://auth.peekoff.com/application/o/tmail/'
+            - name: OIDC_AUTHORIZATION_ENDPOINT
+              value: 'https://auth.peekoff.com/application/o/authorize/'
+            - name: OIDC_TOKEN_ENDPOINT
+              value: 'https://auth.peekoff.com/application/o/token/'
+            - name: OIDC_USERINFO_ENDPOINT
+              value: 'https://auth.peekoff.com/application/o/userinfo/'
+            - name: OIDC_JWKS_ENDPOINT
+              value: 'https://auth.peekoff.com/application/o/jwks/'
+            - name: OIDC_END_SESSION_ENDPOINT
+              value: 'https://auth.peekoff.com/application/o/end-session/'
+            - name: JMAP_HOST
+              value: 'mail.peekoff.com'
+            - name: PLATFORM
+              value: 'other'
+            - name: WS_ECHO_PING
+              value: 'false'
+            - name: COZY_INTEGRATION
+              value: 'false'
+            - name: APP_GRID_AVAILABLE
+              value: 'unsupported'
+            - name: FCM_AVAILABLE
+              value: 'unsupported'
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5

--- a/k8s/applications/web/tmail/externalsecret.yaml
+++ b/k8s/applications/web/tmail/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: es-tmail-secrets
+  namespace: tmail
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: es-tmail-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: WEB_OIDC_CLIENT_ID
+      remoteRef:
+        key: app-tmail-web-oidc-client-id

--- a/k8s/applications/web/tmail/http-route.yaml
+++ b/k8s/applications/web/tmail/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: tmail
+  namespace: tmail
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+    - name: external
+      namespace: gateway
+  hostnames:
+    - "mail.peekoff.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: tmail
+          port: 80

--- a/k8s/applications/web/tmail/kustomization.yaml
+++ b/k8s/applications/web/tmail/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - http-route.yaml

--- a/k8s/applications/web/tmail/namespace.yaml
+++ b/k8s/applications/web/tmail/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tmail

--- a/k8s/applications/web/tmail/service.yaml
+++ b/k8s/applications/web/tmail/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tmail
+  namespace: tmail
+  labels:
+    app.kubernetes.io/name: tmail
+    app.kubernetes.io/part-of: web
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tmail
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/k8s/infrastructure/auth/authentik/extra/blueprints/apps-tmail.yaml
+++ b/k8s/infrastructure/auth/authentik/extra/blueprints/apps-tmail.yaml
@@ -1,0 +1,73 @@
+# k8s/infrastructure/auth/authentik/extra/blueprints/apps-tmail.yaml
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable-file
+# prettier-ignore-start
+# eslint-disable
+---
+version: 1
+metadata:
+  name: Apps - Tmail
+entries:
+  - id: tmail-user-group
+    model: authentik_core.group
+    identifiers:
+      name: Tmail Users
+    attrs:
+      name: Tmail Users
+  - id: tmail_provider
+    model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: k8s.peekoff.com/web/tmail
+    attrs:
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-authorization-implicit-consent"],
+        ]
+      signing_key:
+        !Find [
+          authentik_crypto.certificatekeypair,
+          [name, "authentik Self-signed Certificate"],
+        ]
+      invalidation_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-invalidation-flow"],
+        ]
+
+      client_type: confidential
+      client_id: !Env TMAIL_CLIENT_ID
+      client_secret: !Env TMAIL_CLIENT_SECRET
+      redirect_uris:
+        - url: https://mail.peekoff.com/auth/callback
+          matching_mode: strict
+
+      access_code_validity: minutes=1
+      access_token_validity: hours=1
+      refresh_token_validity: days=30
+
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, "email"]]
+
+  - id: tmail_application
+    model: authentik_core.application
+    identifiers:
+      slug: tmail
+    attrs:
+      name: Tmail
+      group: Web
+      meta_description: Webmail Client
+      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/thunderbird.png
+      provider: !KeyOf tmail_provider
+      policy_engine_mode: any
+
+  - id: tmail_policy_binding
+    model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf tmail_application
+      group: !Find [authentik_core.group, [name, "Tmail Users"]]
+    attrs:
+      order: 1

--- a/k8s/infrastructure/auth/authentik/extra/kustomization.yml
+++ b/k8s/infrastructure/auth/authentik/extra/kustomization.yml
@@ -25,6 +25,7 @@ configMapGenerator:
       - ./blueprints/apps-kubernetes.yaml
       - ./blueprints/apps-cloudflare.yaml
       - ./blueprints/apps-pinepods.yaml
+      - ./blueprints/apps-tmail.yaml
       - ./blueprints/groups.yaml
       - ./blueprints/users.yaml
       - ./blueprints/brands.yaml

--- a/k8s/infrastructure/auth/authentik/extra/secrets.yml
+++ b/k8s/infrastructure/auth/authentik/extra/secrets.yml
@@ -246,3 +246,11 @@ spec:
     - secretKey: PINEPODS_CLIENT_SECRET
       remoteRef:
         key: 'app-pinepods-oauth-client-secret'
+
+    # --- Tmail ---
+    - secretKey: TMAIL_CLIENT_ID
+      remoteRef:
+        key: 'app-tmail-oauth-client-id'
+    - secretKey: TMAIL_CLIENT_SECRET
+      remoteRef:
+        key: 'app-tmail-oauth-client-secret'


### PR DESCRIPTION
## Summary
Add Tmail webmail client deployment with Authentik OAuth2 authentication.

## Changes
- Deploy Tmail web client using `ghcr.io/linagora/tmail-web:v0.23.1`
- Configure OIDC authentication with Authentik
- Connect to JMAP server at `mail.peekoff.com`
- Expose at `https://mail.peekoff.com` via Gateway API
- Add Authentik blueprint for OAuth2 provider and application
- Required Bitwarden secrets for client credentials

## Components
- **Deployment**: Single replica with resource limits and health checks
- **ExternalSecret**: OAuth2 client ID from Bitwarden
- **HTTPRoute**: External access via `mail.peekoff.com`
- **Authentik Blueprint**: OAuth2 provider with Tmail Users group

## Required Bitwarden Entries
- `app-tmail-web-oidc-client-id` - OAuth2 client ID for Tmail web
- `app-tmail-oauth-client-id` - OAuth2 client ID for Authentik
- `app-tmail-oauth-client-secret` - OAuth2 client secret for Authentik