### PR TITLE
Pip installation path

### DIFF
--- a/k8s/applications/ai/openwebui/pipelines-deployment.yaml
+++ b/k8s/applications/ai/openwebui/pipelines-deployment.yaml
@@ -63,6 +63,12 @@ spec:
               value: "production"
             - name: PIPELINES_REQUIREMENTS_PATH
               value: "/app/pipelines/requirements.txt"
+            - name: PIP_TARGET
+              value: "/app/pipelines/.venv"
+            - name: PYTHONPATH
+              value: "/app/pipelines/.venv:${PYTHONPATH}"
+            - name: PIP_CACHE_DIR
+              value: "/tmp/pipcache"
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/k8s/applications/ai/openwebui/pipelines/requirements.txt
+++ b/k8s/applications/ai/openwebui/pipelines/requirements.txt
@@ -5,3 +5,4 @@ llama-index-llms-ollama
 llama-index-vector-stores-qdrant
 aiohttp
 qdrant-client
+mem0ai==1.0.2


### PR DESCRIPTION
Configure pip to install dependencies to a writable path and add the missing `mem0ai` dependency to fix pipeline loading issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-58b9d040-1cf3-4ec9-a436-5456a73043dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58b9d040-1cf3-4ec9-a436-5456a73043dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

