### PR TITLE
BedrockConnect persistent data

### DIFF
--- a/k8s/applications/media/minecraft-bedrock/bedrockconnect-deployment.yaml
+++ b/k8s/applications/media/minecraft-bedrock/bedrockconnect-deployment.yaml
@@ -23,6 +23,18 @@ spec:
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: init-data
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'mkdir -p /data/players && chown -R 1000:1000 /data']
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: data
+              mountPath: /data
       containers:
         - name: bedrockconnect
           image: pugmatt/bedrock-connect:1.63
@@ -56,7 +68,8 @@ spec:
               memory: "256Mi"
       volumes:
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: bedrockconnect-data
         - name: config
           configMap:
             name: bedrockconnect-config

--- a/k8s/applications/media/minecraft-bedrock/bedrockconnect-pvc.yaml
+++ b/k8s/applications/media/minecraft-bedrock/bedrockconnect-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bedrockconnect-data
+  labels:
+    app.kubernetes.io/name: bedrockconnect
+    app.kubernetes.io/part-of: media
+    backup.velero.io/backup-tier: Daily
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: proxmox-csi
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/applications/media/minecraft-bedrock/kustomization.yaml
+++ b/k8s/applications/media/minecraft-bedrock/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - admin-external-secret.yaml
   - statefulset.yaml
   - service.yaml
+  - bedrockconnect-pvc.yaml
   - bedrockconnect-deployment.yaml
   - bedrockconnect-service.yaml
 


### PR DESCRIPTION
Replace `emptyDir` with a PersistentVolumeClaim and add an init container to fix `IOException: No such file or directory` for BedrockConnect by ensuring `/data/players` exists with correct ownership, and to enable player data persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fc21042-c802-4c86-97b8-0b9348db17df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fc21042-c802-4c86-97b8-0b9348db17df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

