### PR TITLE
chore(k8s): remove unused GitHub token from opencode

### DIFF
--- a/k8s/applications/ai/opencode/externalsecret.yaml
+++ b/k8s/applications/ai/opencode/externalsecret.yaml
@@ -1,21 +1,4 @@
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: app-opencode-github-token
-  namespace: opencode
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: bitwarden-backend
-    kind: ClusterSecretStore
-  target:
-    name: app-opencode-github-token
-    creationPolicy: Owner
-  data:
-    - secretKey: GITHUB_TOKEN
-      remoteRef:
-        key: app-opencode-github-token
----
+
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
This PR removes the unused app-opencode-github-token ExternalSecret from opencode configuration. The deployment uses AUTH_SECRET and no longer references the GitHub token.