### PR TITLE
fix(k8s): add missing NSA/CISA security context to moltbot StatefulSet

### DIFF
--- a/k8s/applications/ai/moltbot/statefulset.yaml
+++ b/k8s/applications/ai/moltbot/statefulset.yaml
@@ -37,6 +37,12 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+        hostIPC: false
+        hostPID: false
+        hostNetwork: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
       volumes:
         - name: moltbot-workspace
           persistentVolumeClaim:
@@ -47,9 +53,7 @@ spec:
         - name: moltbot-logs
           persistentVolumeClaim:
             claimName: moltbot-logs-pvc
-        - name: moltbot-data
-          persistentVolumeClaim:
-            claimName: moltbot-data
+
         - name: tmp
           emptyDir: {}
         - name: config


### PR DESCRIPTION
- Add hostIPC, hostPID, hostNetwork: false for NSA/CISA 5.2.2 compliance
- Add readOnlyRootFilesystem: true for NSA/CISA 4.2.1 compliance
- Add capabilities.drop: ["ALL"] for NSA/CISA 5.1.5 compliance
- Remove incorrect moltbot-data PVC reference from volumes section
- Fixes Kyverno nsa-hardening-all-namespaces policy violations
- Resolves pod scheduling issue with volumeClaimTemplate

BREAKING CHANGE: Updates pod security context for NSA/CISA compliance