### PR TITLE
feat(k8s): migrate apps to proxmox-csi-2 storageclass

### DIFF
--- a/k8s/applications/ai/gpt-researcher/pvc.yaml
+++ b/k8s/applications/ai/gpt-researcher/pvc.yaml
@@ -9,7 +9,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: proxmox-csi
+  storageClassName: proxmox-csi-2
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -22,7 +22,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: proxmox-csi
+  storageClassName: proxmox-csi-2
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,4 +35,4 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: proxmox-csi
+  storageClassName: proxmox-csi-2

--- a/k8s/applications/ai/moltbot/statefulset.yaml
+++ b/k8s/applications/ai/moltbot/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         backup.velero.io/backup-tier: GFS
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "proxmox-csi"
+      storageClassName: "proxmox-csi-2"
       resources:
         requests:
           storage: 5Gi
@@ -31,7 +31,7 @@ spec:
         backup.velero.io/backup-tier: GFS
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "proxmox-csi"
+      storageClassName: "proxmox-csi-2"
       resources:
         requests:
           storage: 20Gi
@@ -42,7 +42,7 @@ spec:
         backup.velero.io/backup-tier: GFS
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "proxmox-csi"
+      storageClassName: "proxmox-csi-2"
       resources:
         requests:
           storage: 5Gi
@@ -53,7 +53,7 @@ spec:
         backup.velero.io/backup-tier: Daily
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "proxmox-csi"
+      storageClassName: "proxmox-csi-2"
       resources:
         requests:
           storage: 10Gi

--- a/k8s/applications/automation/frigate/values.yaml
+++ b/k8s/applications/automation/frigate/values.yaml
@@ -225,7 +225,7 @@ persistence:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: "proxmox-csi"
+    storageClass: "proxmox-csi-2"
     ##
     ## If you want to reuse an existing claim, you can pass the name of the PVC using
     ## the existingClaim variable
@@ -257,7 +257,7 @@ persistence:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: "proxmox-csi"
+    storageClass: "proxmox-csi-2"
     ##
     ## If you want to reuse an existing claim, you can pass the name of the PVC using
     ## the existingClaim variable

--- a/k8s/applications/automation/n8n/statefulset.yaml
+++ b/k8s/applications/automation/n8n/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        storageClassName: proxmox-csi
+        storageClassName: proxmox-csi-2
         resources:
           requests:
             storage: 10Gi

--- a/k8s/applications/automation/zigbee2mqtt/pvc.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: proxmox-csi
+  storageClassName: proxmox-csi-2
   resources:
     requests:
       storage: 400Mi

--- a/k8s/applications/media/sabnzbd/statefulset.yaml
+++ b/k8s/applications/media/sabnzbd/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
         name: config
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: proxmox-csi
+        storageClassName: proxmox-csi-2
         resources:
           requests:
             storage: 6Gi
@@ -22,7 +22,7 @@ spec:
         name: nzb-backup
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: proxmox-csi
+        storageClassName: proxmox-csi-2
         resources:
           requests:
             storage: 1Gi
@@ -32,7 +32,7 @@ spec:
           velero.io/exclude-from-backup: "true"
       spec:
         accessModes: ["ReadWriteOnce"]
-        storageClassName: proxmox-csi
+        storageClassName: proxmox-csi-2
         resources:
           requests:
             storage: 100Gi

--- a/k8s/applications/web/kiwix/pvc.yaml
+++ b/k8s/applications/web/kiwix/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 200Gi
-  storageClassName: proxmox-csi
+  storageClassName: proxmox-csi-2


### PR DESCRIPTION
- Update storageClassName from proxmox-csi to proxmox-csi-2
- Affects 15 PVCs across 7 applications:
  * moltbot (4 PVCs)
  * zigbee2mqtt (1 PVC)
  * n8n (1 PVC)
  * sabnzbd (3 PVCs)
  * kiwix (1 PVC)
  * gpt-researcher (3 PVCs)
  * frigate (2 PVCs)
- New storage class uses 'velocity' storage backend
- Existing PVCs remain unchanged, only new PVCs will use new class