### PR TITLE
feat(minecraft): add Velero backup annotations for volume data

### DIFF
--- a/k8s/applications/games/minecraft/base/statefulset.yaml
+++ b/k8s/applications/games/minecraft/base/statefulset.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: minecraft-bedrock
         app.kubernetes.io/part-of: games
+      annotations:
+        backup.velero.io/backup-volumes: data
     spec:
       securityContext:
         runAsNonRoot: true

--- a/k8s/applications/games/minecraft/bedrockconnect/bedrockconnect-deployment.yaml
+++ b/k8s/applications/games/minecraft/bedrockconnect/bedrockconnect-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app.kubernetes.io/name: bedrockconnect
         app.kubernetes.io/part-of: games
+      annotations:
+        backup.velero.io/backup-volumes: data
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Add backup.velero.io/backup-volumes annotation to minecraft-bedrock StatefulSet and bedrockconnect Deployment to ensure scheduled Velero backups capture volume data using Kopia filesystem backup.