### PR TITLE
fix(k8s): add missing security contexts and CNPG MinIO secrets

### DIFF
--- a/k8s/applications/ai/karakeep/meilisearch-statefulset.yaml
+++ b/k8s/applications/ai/karakeep/meilisearch-statefulset.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app: meilisearch
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k8s/applications/ai/karakeep/web-statefulset.yaml
+++ b/k8s/applications/ai/karakeep/web-statefulset.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app: karakeep-web
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k8s/applications/ai/litellm/database.yaml
+++ b/k8s/applications/ai/litellm/database.yaml
@@ -1,4 +1,26 @@
 ---
+# ExternalSecret for MinIO credentials (PostgreSQL backups)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-minio-credentials
+  namespace: litellm
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+---
 # ExternalSecret for Backblaze B2 credentials (PostgreSQL backups)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/k8s/applications/ai/litellm/deployment.yaml
+++ b/k8s/applications/ai/litellm/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: litellm
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k8s/applications/ai/qdrant/deployment.yaml
+++ b/k8s/applications/ai/qdrant/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: qdrant
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k8s/applications/automation/n8n/database.yaml
+++ b/k8s/applications/automation/n8n/database.yaml
@@ -1,4 +1,26 @@
 ---
+# ExternalSecret for MinIO credentials (PostgreSQL backups)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-minio-credentials
+  namespace: n8n
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+---
 # ExternalSecret for Backblaze B2 credentials (PostgreSQL backups)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/k8s/applications/automation/n8n/statefulset.yaml
+++ b/k8s/applications/automation/n8n/statefulset.yaml
@@ -116,8 +116,16 @@ spec:
           volumeMounts:
             - name: n8n-data
               mountPath: /home/node/.n8n
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
   volumeClaimTemplates:
     - metadata:
         name: n8n-data

--- a/k8s/applications/media/arr/bazarr/statefulset.yaml
+++ b/k8s/applications/media/arr/bazarr/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: bazarr
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/k8s/applications/media/immich/immich-ml/deployment.yaml
+++ b/k8s/applications/media/immich/immich-ml/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app.kubernetes.io/instance: immich
         app.kubernetes.io/name: machine-learning
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       automountServiceAccountToken: true
       containers:
         - env:

--- a/k8s/applications/media/immich/immich-server/database.yaml
+++ b/k8s/applications/media/immich/immich-server/database.yaml
@@ -1,4 +1,26 @@
 ---
+# ExternalSecret for MinIO credentials (PostgreSQL backups)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-minio-credentials
+  namespace: immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+---
 # ExternalSecret for Backblaze B2 credentials (PostgreSQL backups)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/k8s/applications/media/whisperasr/deployment.yaml
+++ b/k8s/applications/media/whisperasr/deployment.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: whisperasr
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -28,6 +31,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 1000
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - ALL

--- a/k8s/applications/web/babybuddy/statefulset.yaml
+++ b/k8s/applications/web/babybuddy/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: babybuddy
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         fsGroup: 1000
         runAsNonRoot: true

--- a/k8s/applications/web/kiwix/deployment.yaml
+++ b/k8s/applications/web/kiwix/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app.kubernetes.io/name: kiwix
         app.kubernetes.io/version: "3.8.1"
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/k8s/applications/web/pinepods/database.yaml
+++ b/k8s/applications/web/pinepods/database.yaml
@@ -1,4 +1,26 @@
 ---
+# ExternalSecret for MinIO credentials (PostgreSQL backups)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-minio-credentials
+  namespace: pinepods
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+---
 # ExternalSecret for Backblaze B2 credentials (PostgreSQL backups)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/k8s/applications/web/pinepods/deployment.yaml
+++ b/k8s/applications/web/pinepods/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app.kubernetes.io/part-of: pinepods
         app.kubernetes.io/component: web
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -34,6 +37,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 1000
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - ALL

--- a/k8s/applications/web/pinepods/valkey.yaml
+++ b/k8s/applications/web/pinepods/valkey.yaml
@@ -35,7 +35,14 @@ spec:
         app.kubernetes.io/name: pinepods-valkey
         app.kubernetes.io/part-of: pinepods
     spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/k8s/infrastructure/auth/authentik/database.yaml
+++ b/k8s/infrastructure/auth/authentik/database.yaml
@@ -1,4 +1,26 @@
 ---
+# ExternalSecret for MinIO credentials (PostgreSQL backups)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-minio-credentials
+  namespace: auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+---
 # ExternalSecret for Backblaze B2 credentials (PostgreSQL backups)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret


### PR DESCRIPTION
- Add hostIPC, hostPID, hostNetwork to all deployments for Kyverno compliance
- Add missing longhorn-minio-credentials ExternalSecret to CNPG databases:
  * pinepods, n8n, litellm, immich, authentik
- Add readOnlyRootFilesystem and capabilities drop where missing
- Fix pinepods valkey security context structure