### PR TITLE
feat(k8s): add sectionName to OpenClaw HTTPRoute

### DIFF
--- a/k8s/applications/ai/openclaw/http-route.yaml
+++ b/k8s/applications/ai/openclaw/http-route.yaml
@@ -10,6 +10,7 @@ spec:
   parentRefs:
     - name: external
       namespace: gateway
+      sectionName: https-gateway
     - name: internal
       namespace: gateway
   hostnames:


### PR DESCRIPTION
- Attach to external gateway HTTPS listener for openclaw.peekoff.com
- Ensures proper routing through gateway infrastructure