### PR TITLE
fix(bootstrap): remove triggers and destroy provisioners from bootstr…

### DIFF
--- a/tofu/bootstrap/kubernetes/cert-manager.tf
+++ b/tofu/bootstrap/kubernetes/cert-manager.tf
@@ -1,16 +1,6 @@
 resource "null_resource" "cert_manager_kustomize" {
-  triggers = {
-    manifests = sha256(join("", [for f in fileset("${path.module}/../../../k8s/infrastructure/controllers/cert-manager", "*.yaml") : filesha256("${path.module}/../../../k8s/infrastructure/controllers/cert-manager/${f}")]))
-  }
-
   provisioner "local-exec" {
-    command     = "kustomize build --enable-helm . | kubectl apply -f - --server-side --force-conflicts"
-    working_dir = "${path.module}/../../../k8s/infrastructure/controllers/cert-manager"
-  }
-
-  provisioner "local-exec" {
-    when        = destroy
-    command     = "kustomize build --enable-helm . | kubectl delete -f - --ignore-not-found=true"
+    command     = "kubectl delete job cert-manager-startupapicheck -n cert-manager --ignore-not-found=true && kustomize build --enable-helm . | kubectl apply -f - --server-side --force-conflicts"
     working_dir = "${path.module}/../../../k8s/infrastructure/controllers/cert-manager"
   }
 }

--- a/tofu/bootstrap/kubernetes/external-secrets.tf
+++ b/tofu/bootstrap/kubernetes/external-secrets.tf
@@ -1,16 +1,6 @@
 resource "null_resource" "external_secrets_kustomize" {
-  triggers = {
-    manifests = sha256(join("", [for f in fileset("${path.module}/../../../k8s/infrastructure/controllers/external-secrets", "*.yaml") : filesha256("${path.module}/../../../k8s/infrastructure/controllers/external-secrets/${f}")]))
-  }
-
   provisioner "local-exec" {
     command     = "kustomize build --enable-helm . | kubectl apply -f - --server-side --force-conflicts"
-    working_dir = "${path.module}/../../../k8s/infrastructure/controllers/external-secrets"
-  }
-
-  provisioner "local-exec" {
-    when        = destroy
-    command     = "kustomize build --enable-helm . | kubectl delete -f - --ignore-not-found=true"
     working_dir = "${path.module}/../../../k8s/infrastructure/controllers/external-secrets"
   }
 }


### PR DESCRIPTION
…ap resources

Bootstrap resources now run once on initial creation only. ArgoCD handles self-management via GitOps after bootstrap.

Changes:
- Removed triggers blocks from argocd_kustomize, cert_manager_kustomize, external_secrets_kustomize
- Removed destroy provisioners from all bootstrap null_resources
- Removed triggers and destroy provisioners from AppProject and ApplicationSet resources
- Added Job deletion workaround for cert-manager startupapicheck immutability

BREAKING CHANGE: Bootstrap is now one-shot. Use tofu taint to force re-bootstrap.