### PR TITLE
fix(k8s): correct kyverno policy syntax and match logic

### DIFF
--- a/k8s/infrastructure/security/policies/kyverno-policies.yaml
+++ b/k8s/infrastructure/security/policies/kyverno-policies.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     description: "NSA/CISA hardening policies for all namespaces"
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: require-non-root-containers
     match:
@@ -39,9 +39,18 @@ spec:
       message: "Containers must drop all Linux capabilities (NSA/CISA 5.1.5)"
       pattern:
         spec:
-          securityContext:
-            capabilities:
-              drop: ["ALL"]
+          containers:
+          - securityContext:
+              capabilities:
+                drop: ["ALL"]
+          =(initContainers):
+          - securityContext:
+              capabilities:
+                drop: ["ALL"]
+          =(ephemeralContainers):
+          - securityContext:
+              capabilities:
+                drop: ["ALL"]
   - name: require-read-only-root-filesystem
     match:
       any:
@@ -57,8 +66,15 @@ spec:
       message: "Containers must have read-only root filesystem (NSA/CISA 4.2.1)"
       pattern:
         spec:
-          securityContext:
-            readOnlyRootFilesystem: true
+          containers:
+          - securityContext:
+              readOnlyRootFilesystem: true
+          =(initContainers):
+          - securityContext:
+              readOnlyRootFilesystem: true
+          =(ephemeralContainers):
+          - securityContext:
+              readOnlyRootFilesystem: true
   - name: disallow-host-namespace-sharing
     match:
       any:
@@ -74,7 +90,6 @@ spec:
       message: "Containers must not share host namespace (NSA/CISA 5.2.2)"
       pattern:
         spec:
-          securityContext:
-            hostPID: false
-            hostIPC: false
-            hostNetwork: false
+          =(hostPID): false
+          =(hostIPC): false
+          =(hostNetwork): false


### PR DESCRIPTION
Fix validationFailureAction capitalization (audit -> Audit).

Update security policy rules to properly match container-level securityContext instead of pod-level:
- Fix capabilities drop check to inspect containers, initContainers, and ephemeralContainers individually
- Fix readOnlyRootFilesystem check for container-level context
- Fix host namespace sharing validation syntax

These changes ensure policies correctly validate security settings at the container level as intended by NSA/CISA guidelines.