### PR TITLE
feat(minecraft): update plugins and add renovate tracking

### DIFF
--- a/k8s/applications/games/minecraft/bedrockconnect/bedrockconnect-deployment.yaml
+++ b/k8s/applications/games/minecraft/bedrockconnect/bedrockconnect-deployment.yaml
@@ -28,7 +28,7 @@ spec:
 
       containers:
         - name: bedrockconnect
-          image: pugmatt/bedrock-connect:1.64
+          image: pugmatt/bedrock-connect:1.65
 
           imagePullPolicy: IfNotPresent
           securityContext:

--- a/k8s/applications/games/minecraft/plugins/kustomization.yaml
+++ b/k8s/applications/games/minecraft/plugins/kustomization.yaml
@@ -6,6 +6,7 @@ configMapGenerator:
     literals:
       - TYPE=PAPER
       - VERSION=1.21.11
+      - PAPER_BUILD=112 # renovate: datasource=github-releases depName=PaperMC/paper
       - EULA=true
       - SERVER_PORT=25565
       - ONLINE_MODE=true

--- a/k8s/applications/games/minecraft/plugins/plugins.txt
+++ b/k8s/applications/games/minecraft/plugins/plugins.txt
@@ -5,7 +5,7 @@ https://mediafilez.forgecdn.net/files/7479/274/worldedit-bukkit-7.4.0.jar
 https://github.com/EssentialsX/Essentials/releases/download/2.21.2/EssentialsX-2.21.2.jar
 https://github.com/EssentialsX/Essentials/releases/download/2.21.2/EssentialsXChat-2.21.2.jar
 https://github.com/EssentialsX/Essentials/releases/download/2.21.2/EssentialsXSpawn-2.21.2.jar
-https://github.com/Multiverse/Multiverse-Core/releases/download/5.5.0/multiverse-core-5.5.0.jar
+https://github.com/Multiverse/Multiverse-Core/releases/download/5.5.2/multiverse-core-5.5.2.jar
 https://github.com/Multiverse/Multiverse-SignPortals/releases/download/5.0.2/multiverse-signportals-5.0.2.jar
 https://download.luckperms.net/1614/bukkit/loader/LuckPerms-Bukkit-5.5.26.jar
 https://hub.bg-software.com/job/WildLoaders%20-%20Dev%20Builds/66/artifact/target/WildLoaders-2025.2-b66.jar

--- a/renovate.json
+++ b/renovate.json
@@ -27,9 +27,25 @@
         "/\\.sh$/"
       ],
       "matchStrings": [
-        "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*#\\s?renovate:\\s+(?<datasource>\\S+?)(?:=(?<depName>\\S+))?(?:\\s+registry=(?<registryUrl>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?",
+        "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*#\\s?renovate:\\s+(?<datasource>\\S+)(?:=(?<depName>\\S+))?(?:\\s+registry=(?<registryUrl>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?",
         "https://github.com/(?<depName>[^/]+/[^/]+)/releases/download/(?<currentValue>[^/]+)/",
         "https://raw.githubusercontent.com/(?<depName>[^/]+/[^/]+)/(?<currentValue>[^/]+)/"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/k8s/applications/games/minecraft/plugins/plugins\\.txt$"],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>EssentialsX/Essentials|EssentialsX/EssentialsX-GUI|Multiverse/Multiverse-Core|Multiverse/Multiverse-SignPortals|MilkBowl/Vault|SniperTVmc/EssentialsX-GUI|EssentialsX)/releases/download/(?<currentValue>[^/]+)/"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/k8s/applications/games/minecraft/plugins/kustomization\\.yaml$"],
+      "matchStrings": [
+        "PAPER_BUILD=(?<currentValue>\\d+) # renovate: datasource=github-releases depName=PaperMC/paper"
       ],
       "datasourceTemplate": "github-releases"
     },
@@ -98,6 +114,25 @@
       "description": "Handle descheduler image from registry.k8s.io",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["registry.k8s.io/descheduler/descheduler"]
+    },
+    {
+      "groupName": "Minecraft Plugins",
+      "description": "Track GitHub-based Minecraft plugin updates",
+      "matchFileNames": ["k8s/applications/games/minecraft/plugins/plugins.txt"],
+      "matchPackageNames": [
+        "EssentialsX/Essentials",
+        "EssentialsX/EssentialsX-GUI", 
+        "Multiverse/Multiverse-Core",
+        "Multiverse/Multiverse-SignPortals",
+        "MilkBowl/Vault",
+        "PaperMC/paper"
+      ]
+    },
+    {
+      "groupName": "BedrockConnect",
+      "description": "Track BedrockConnect Docker image updates",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["pugmatt/bedrock-connect"]
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
- Fix WorldEdit download URL (revert to working version)
- Add Paper build tracking with renovate comment
- Add BedrockConnect Docker image tracking
- Configure renovate for Minecraft plugin updates
- Pin BedrockConnect to specific version 1.65