### PR TITLE
feat(k8s): extend Cilium network policy for media access

### DIFF
--- a/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
@@ -62,3 +62,15 @@ spec:
         protocol: TCP
       - port: "2049"
         protocol: TCP
+  - toCIDR:
+    - 239.255.255.250/32
+    toPorts:
+    - ports:
+      - port: "1900"
+        protocol: UDP
+  - toCIDR:
+    - 0.0.0.0/0
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP


### PR DESCRIPTION
- add additional egress rules for multicast and general traffic