### PR TITLE
fix(k8s): resolve CiliumNetworkPolicy kube-apiserver access and probe issues

### DIFF
--- a/k8s/applications/ai/pocket-tts/deployment.yaml
+++ b/k8s/applications/ai/pocket-tts/deployment.yaml
@@ -73,11 +73,18 @@ spec:
             memory: "4Gi"
             cpu: "2000m"
             ephemeral-storage: "1Gi"
-        livenessProbe:
+        startupProbe:
           httpGet:
             path: /health
             port: 49112
           initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 49112
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
@@ -85,7 +92,6 @@ spec:
           httpGet:
             path: /health
             port: 49112
-          initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 3

--- a/k8s/infrastructure/network/policies/applications/automation/zigbee2mqtt/allow-zigbee2mqtt-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/automation/zigbee2mqtt/allow-zigbee2mqtt-access.yaml
@@ -11,6 +11,14 @@ spec:
       app: zigbee2mqtt
   description: "Allow Zigbee2MQTT access"
   ingress:
+  - fromEntities:
+    - host
+    - remote-node
+    - ingress
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
   - fromEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: home-assistant

--- a/k8s/infrastructure/network/policies/applications/external/truenas/allow-truenas-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/external/truenas/allow-truenas-access.yaml
@@ -30,7 +30,8 @@ spec:
         protocol: UDP
       - port: "53"
         protocol: TCP
-  - toCIDR: ["10.0.0.0/8"]
+  - toFQDNs:
+    - matchName: "truenas.peekoff.com"
     toPorts:
     - ports:
       - port: "443"

--- a/k8s/infrastructure/network/policies/applications/media/immich/allow-immich-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/media/immich/allow-immich-access.yaml
@@ -71,5 +71,9 @@ spec:
         protocol: TCP
       - port: "80"
         protocol: TCP
+  - toFQDNs:
+    - matchName: "truenas.peekoff.com"
+    toPorts:
+    - ports:
       - port: "9000"
         protocol: TCP

--- a/k8s/infrastructure/network/policies/applications/web/pinepods/allow-pinepods-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/web/pinepods/allow-pinepods-access.yaml
@@ -53,5 +53,9 @@ spec:
         protocol: TCP
       - port: "80"
         protocol: TCP
+  - toFQDNs:
+    - matchName: "truenas.peekoff.com"
+    toPorts:
+    - ports:
       - port: "9000"
         protocol: TCP

--- a/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
+++ b/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
@@ -18,6 +18,14 @@ spec:
     - ports:
       - port: "8080"
         protocol: TCP
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kubechecks
+        app.kubernetes.io/name: kubechecks
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
   egress:
   - toEndpoints:
     - matchLabels:

--- a/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
+++ b/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
@@ -46,7 +46,8 @@ spec:
         protocol: UDP
       - port: "53"
         protocol: TCP
-  - toCIDR: ["10.0.0.0/8"]
+  - toEntities:
+    - kube-apiserver
     toPorts:
     - ports:
       - port: "6443"

--- a/k8s/infrastructure/network/policies/clusterwide/allow-cluster-essentials.yaml
+++ b/k8s/infrastructure/network/policies/clusterwide/allow-cluster-essentials.yaml
@@ -24,4 +24,6 @@ spec:
       rules:
         dns:
           - matchPattern: "*"
+  - toEntities:
+    - kube-apiserver
   - toCIDR: ["10.0.0.0/8"]

--- a/k8s/infrastructure/network/policies/infrastructure/external-secrets/allow-external-secrets-access.yaml
+++ b/k8s/infrastructure/network/policies/infrastructure/external-secrets/allow-external-secrets-access.yaml
@@ -20,12 +20,11 @@ spec:
       - port: "8080"
         protocol: TCP
   egress:
-  - toCIDR: ["10.0.0.0/8"]
+  - toEntities:
+    - kube-apiserver
     toPorts:
     - ports:
       - port: "443"
-        protocol: TCP
-      - port: "80"
         protocol: TCP
   - toEntities:
     - world

--- a/k8s/infrastructure/network/policies/infrastructure/kubechecks/allow-kubechecks-access.yaml
+++ b/k8s/infrastructure/network/policies/infrastructure/kubechecks/allow-kubechecks-access.yaml
@@ -20,12 +20,29 @@ spec:
       - port: "8080"
         protocol: TCP
   egress:
-  - toCIDR: ["10.0.0.0/8"]
+  - toEntities:
+    - kube-apiserver
     toPorts:
     - ports:
       - port: "443"
         protocol: TCP
-      - port: "80"
+      - port: "6443"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: argocd
+        app.kubernetes.io/name: argocd-server
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      - port: "443"
+        protocol: TCP
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "443"
         protocol: TCP
   - toEndpoints:
     - matchLabels:

--- a/k8s/infrastructure/network/policies/infrastructure/velero/allow-velero-access.yaml
+++ b/k8s/infrastructure/network/policies/infrastructure/velero/allow-velero-access.yaml
@@ -20,12 +20,11 @@ spec:
       - port: "8085"
         protocol: TCP
   egress:
-  - toCIDR: ["10.0.0.0/8"]
+  - toEntities:
+    - kube-apiserver
     toPorts:
     - ports:
       - port: "443"
-        protocol: TCP
-      - port: "80"
         protocol: TCP
   - toEntities:
     - world


### PR DESCRIPTION
- Replace toCIDR 10.0.0.0/8 with toEntities kube-apiserver in external-secrets, velero, argocd-server, and kubechecks policies; toCIDR breaks with Cilium kubeProxyReplacement after recent Cilium upgrade
- Add toEndpoints argocd-server rule to kubechecks policy for ArgoCD API access
- Add toEntities ingress rule to zigbee2mqtt policy to allow gateway HTTP access
- Add startupProbe to pocket-tts deployment to allow model loading before liveness probe activates (model load takes >60s, previously killing container on startup)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>