### PR TITLE
feat(affine): expose affine-mcp server to the internet

### DIFF
--- a/k8s/applications/web/affine/kustomization.yaml
+++ b/k8s/applications/web/affine/kustomization.yaml
@@ -12,4 +12,8 @@ resources:
   - deployment.yaml
   - service.yaml
   - http-route.yaml
+  - mcp-externalsecret.yaml
+  - mcp-deployment.yaml
+  - mcp-service.yaml
+  - mcp-http-route.yaml
   - network-policy.yaml

--- a/k8s/applications/web/affine/mcp-deployment.yaml
+++ b/k8s/applications/web/affine/mcp-deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: affine-mcp
+  namespace: affine
+  labels:
+    app.kubernetes.io/name: affine-mcp
+    app.kubernetes.io/part-of: affine
+    app.kubernetes.io/component: mcp
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: affine-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: affine-mcp
+        app.kubernetes.io/part-of: affine
+        app.kubernetes.io/component: mcp
+    spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: affine-mcp
+          image: ghcr.io/dawncr0w/affine-mcp-server:2.1.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: HOME
+              value: /tmp
+            - name: MCP_TRANSPORT
+              value: http
+            - name: PORT
+              value: "3000"
+            - name: AFFINE_MCP_HTTP_HOST
+              value: 0.0.0.0
+            - name: AFFINE_BASE_URL
+              value: http://affine.affine.svc.cluster.local:3010
+            - name: AFFINE_MCP_AUTH_MODE
+              value: bearer
+            - name: AFFINE_TOOL_PROFILE
+              value: full
+            - name: AFFINE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: affine-mcp-secrets
+                  key: AFFINE_API_TOKEN
+            - name: AFFINE_MCP_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: affine-mcp-secrets
+                  key: AFFINE_MCP_HTTP_TOKEN
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/k8s/applications/web/affine/mcp-externalsecret.yaml
+++ b/k8s/applications/web/affine/mcp-externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: affine-mcp
+  namespace: affine
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: affine-mcp-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: AFFINE_API_TOKEN
+      remoteRef:
+        key: app-affine-mcp-api-token
+    - secretKey: AFFINE_MCP_HTTP_TOKEN
+      remoteRef:
+        key: app-affine-mcp-http-token

--- a/k8s/applications/web/affine/mcp-http-route.yaml
+++ b/k8s/applications/web/affine/mcp-http-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: affine-mcp
+  namespace: affine
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "affine-mcp.peekoff.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: affine-mcp
+          port: 3000
+      timeouts:
+        request: 0s
+        backendRequest: 0s

--- a/k8s/applications/web/affine/mcp-service.yaml
+++ b/k8s/applications/web/affine/mcp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: affine-mcp
+  namespace: affine
+  labels:
+    app.kubernetes.io/name: affine-mcp
+    app.kubernetes.io/part-of: affine
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: affine-mcp
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP

--- a/k8s/applications/web/affine/network-policy.yaml
+++ b/k8s/applications/web/affine/network-policy.yaml
@@ -17,6 +17,13 @@ spec:
         - ports:
             - port: "3010"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: affine-mcp
+      toPorts:
+        - ports:
+            - port: "3010"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:
@@ -41,6 +48,43 @@ spec:
       toPorts:
         - ports:
             - port: "5432"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: affine-mcp
+  namespace: affine
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: affine-mcp
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: affine
+      toPorts:
+        - ports:
+            - port: "3010"
               protocol: TCP
 ---
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary

Adds the AFFiNE MCP server (`ghcr.io/dawncr0w/affine-mcp-server:2.1.0`) alongside the existing AFFiNE deployment and exposes it to the internet, following the established affine app patterns.

The MCP server runs in HTTP transport with bearer auth, reaches AFFiNE over the in-cluster service (`http://affine.affine.svc.cluster.local:3010`), and is published at `affine-mcp.peekoff.com` via the external and internal gateways. A Cloudflare DNS A record for `affine-mcp.peekoff.com` pointing to `10.25.150.222` must exist for public access (managed outside the repo, per convention).

## Changes
- `mcp-deployment.yaml` — affine-mcp Deployment, pinned to `2.1.0`, HTTP/bearer mode, full tool profile. Hardened: `runAsNonRoot`, `readOnlyRootFilesystem`, dropped caps, seccomp RuntimeDefault, CPU/memory requests+limits, writable `/tmp` emptyDir with size limit, `/healthz` + `/readyz` probes.
- `mcp-externalsecret.yaml` — `bitwarden-backend` ExternalSecret sourcing `AFFINE_API_TOKEN` (`app-affine-mcp-api-token`) and `AFFINE_MCP_HTTP_TOKEN` (`app-affine-mcp-http-token`), `refreshInterval: 1h`.
- `mcp-service.yaml` — ClusterIP service on port 3000.
- `mcp-http-route.yaml` — HTTPRoute on external + internal gateways for `affine-mcp.peekoff.com`.
- `network-policy.yaml` — new default-deny `affine-mcp` CiliumNetworkPolicy (DNS + egress to `affine:3010` only; ingress from gateway on 3000); allow `affine` ingress from `affine-mcp`.
- `kustomization.yaml` — register the new resources.

## Operator follow-up (required before it works)
1. Generate an AFFiNE API token in the self-hosted AFFiNE instance.
2. Create Bitwarden items `app-affine-mcp-api-token` and `app-affine-mcp-http-token` (the latter a strong shared bearer secret).
3. Ensure the Cloudflare A record for `affine-mcp.peekoff.com` → `10.25.150.222` exists.

Clients connect with:
```json
{ "mcpServers": { "affine": { "type": "http", "url": "https://affine-mcp.peekoff.com/mcp", "headers": { "Authorization": "Bearer <app-affine-mcp-http-token>" } } } }
```

## Validation
- `kustomize build --enable-helm k8s/applications/web/affine` succeeds.

https://claude.ai/code/session_01WSfsTcKAj4QfayrtLcPuJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSfsTcKAj4QfayrtLcPuJ7)_