### PR TITLE
chore(k8s): update deployment and policy exception configurations

### DIFF
--- a/k8s/applications/ai/opencode/deployment.yaml
+++ b/k8s/applications/ai/opencode/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         app: opencode-web  
     spec:
       securityContext:
+        runAsNonRoot: false
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault

--- a/k8s/applications/ai/opencode/policy-exception.yaml
+++ b/k8s/applications/ai/opencode/policy-exception.yaml
@@ -20,5 +20,6 @@ spec:
     - policyName: nsa-hardening-all-namespaces
       ruleNames:
         - require-non-root-containers
+        - require-read-only-root-filesystem
   podSecurity:
     - controlName: Running as Non-root

--- a/k8s/applications/automation/zigbee2mqtt/pvc.yaml
+++ b/k8s/applications/automation/zigbee2mqtt/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: proxmox-csi-2
+  storageClassName: proxmox-csi
   resources:
     requests:
       storage: 400Mi

--- a/k8s/infrastructure/database/cloudnative-pg/rules.yaml
+++ b/k8s/infrastructure/database/cloudnative-pg/rules.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: cnpg-default-alerts
+  namespace: cnpg-system
 spec:
   groups:
     - name: cnp-default.rules

--- a/k8s/infrastructure/network/gateway/kustomization.yaml
+++ b/k8s/infrastructure/network/gateway/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
-  - gwclass-cilium.yaml
   - cert-peekoff.yaml
   - gw-external.yaml
   - gw-internal.yaml


### PR DESCRIPTION
- Set runAsNonRoot to false in opencode deployment
- Add require-read-only-root-filesystem rule to policy exception
- Correct storageClassName in zigbee2mqtt PVC
- Remove unused gwclass-cilium resource from kustomization