### PR TITLE
feat(k8s): add RustFS in-cluster S3, GitLab runner cache, and MLflow

### DIFF
--- a/k8s/applications/ai/kustomization.yaml
+++ b/k8s/applications/ai/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - gpt-researcher
 - openclaw
 - pocket-tts
+- mlflow

--- a/k8s/applications/ai/mlflow/database-scheduled-backup.yaml
+++ b/k8s/applications/ai/mlflow/database-scheduled-backup.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: mlflow-postgresql-b2-backup
+  namespace: mlflow
+spec:
+  schedule: "0 0 3 * * 0"
+  backupOwnerReference: self
+  cluster:
+    name: mlflow-postgresql
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+    parameters:
+      barmanObjectName: mlflow-b2-store

--- a/k8s/applications/ai/mlflow/database.yaml
+++ b/k8s/applications/ai/mlflow/database.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: b2-cnpg-credentials
+  namespace: mlflow
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: b2-cnpg-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: backblaze-b2-cnpg-access-key-id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: backblaze-b2-cnpg-secret-access-key
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: mlflow-minio-store
+  namespace: mlflow
+spec:
+  retentionPolicy: "14d"
+  configuration:
+    destinationPath: s3://homelab-postgres-backups/mlflow/mlflow-postgresql-2026-06
+    endpointURL: https://truenas.peekoff.com:9000
+    s3Credentials:
+      accessKeyId:
+        name: longhorn-minio-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: longhorn-minio-credentials
+        key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: mlflow-b2-store
+  namespace: mlflow
+spec:
+  retentionPolicy: "30d"
+  configuration:
+    destinationPath: s3://homelab-cnpg-b2/mlflow/mlflow-postgresql-2026-06
+    endpointURL: https://s3.us-west-002.backblazeb2.com
+    s3Credentials:
+      accessKeyId:
+        name: b2-cnpg-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: b2-cnpg-credentials
+        key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: mlflow-postgresql
+  namespace: mlflow
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  storage:
+    size: 10Gi
+    storageClass: proxmox-csi
+
+  walStorage:
+    size: 5Gi
+    storageClass: proxmox-csi
+    resizeInUseVolumes: true
+
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 50m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: "128MB"
+      effective_cache_size: "384MB"
+      maintenance_work_mem: "32MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "8MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: "1310kB"
+      huge_pages: "off"
+      min_wal_size: "256MB"
+      max_wal_size: "512MB"
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: mlflow-minio-store
+
+  externalClusters:
+    - name: mlflow-postgresql-b2-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: mlflow-b2-store
+    - name: mlflow-postgresql-minio-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: mlflow-minio-store
+
+  managed:
+    roles:
+      - name: app
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        inherit: true
+        replication: false
+        connectionLimit: -1
+
+  monitoring:
+    enablePodMonitor: false
+
+  affinity:
+    enablePodAntiAffinity: false

--- a/k8s/applications/ai/mlflow/gitlab-ci-template.yml
+++ b/k8s/applications/ai/mlflow/gitlab-ci-template.yml
@@ -21,11 +21,11 @@
 #   none — secrets are injected from the cluster via /run/secrets/mlflow/
 
 variables:
-  MLFLOW_TRACKING_URI: "http://mlflow.mlflow.svc.cluster.local"
-  MLFLOW_REGISTRY_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
+  MLFLOW_TRACKING_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow"
   GITLAB_PROJECT_API: "https://gitlab.peekoff.com/api/v4/projects/1"
   GITLAB_TRIGGER_URL: "https://gitlab.peekoff.com/api/v4/projects/1/trigger/pipeline"
   DEPLOYMENT_REF: "main"
+  MLFLOW_CI_SECRETS_PATH: "/run/secrets/mlflow"
 
 # Loads secrets from the cluster-mounted secret volume and exports them.
 # All subsequent script steps in the job inherit these exports.
@@ -79,14 +79,30 @@ variables:
       version    = os.environ["MODEL_VERSION"]
       run_id     = os.environ["RUN_ID"]
 
-      # Register to GitLab model registry via MLFLOW_REGISTRY_URI on the server.
+      # Register to GitLab model registry. GitLab ignores source/run_id args;
+      # set semver via gitlab.version tag. run_id is stored as a tag for traceability.
       mv = client.create_model_version(
           model_name,
-          source=f"runs:/{run_id}/model",
-          run_id=run_id,
-          tags={"gitlab.CI_JOB_ID": os.environ.get("CI_JOB_ID", "")},
+          source="",
+          tags={
+              "gitlab.version": version,
+              "gitlab.run_id": run_id,
+          },
       )
       print(f"Registered {model_name} v{version} (id={mv.version})")
+
+      # Link the model version's own run to this CI job (official GitLab pattern).
+      if os.getenv("GITLAB_CI"):
+          client.set_tag(mv.run_id, "gitlab.CI_JOB_ID", os.environ.get("CI_JOB_ID", ""))
+          client.set_tag(mv.run_id, "gitlab.CI_PIPELINE_ID", os.environ.get("CI_PIPELINE_ID", ""))
+
+      # Mirror training metrics onto the model version's run so they appear on the
+      # model version page in GitLab alongside the artifact.
+      training_run = client.get_run(run_id)
+      for key, value in training_run.data.metrics.items():
+          client.log_metric(mv.run_id, key, value)
+      for key, value in training_run.data.params.items():
+          client.log_param(mv.run_id, key, value)
       EOF
     # Post metric summary as MR note when running in an MR pipeline.
     - |
@@ -99,7 +115,7 @@ variables:
       for k, v in run.data.metrics.items():
           lines.append(f"- `{k}`: `{v}`")
       lines += ["", f"Model: `{os.environ['MODEL_NAME']}` v`{os.environ['MODEL_VERSION']}`",
-                f"Run: [{os.environ['RUN_ID']}]($MLFLOW_TRACKING_URI/#/experiments)"]
+                f"Run: [{os.environ['RUN_ID']}]({os.environ['MLFLOW_TRACKING_URI']}/#/experiments)"]
       print("\n".join(lines))
       EOF
       )

--- a/k8s/applications/ai/mlflow/gitlab-ci-template.yml
+++ b/k8s/applications/ai/mlflow/gitlab-ci-template.yml
@@ -1,0 +1,118 @@
+# MLflow + GitLab integration template for training pipelines.
+# Include in your project's .gitlab-ci.yml:
+#
+#   include:
+#     - project: 'theepicsaxguy/homelab'
+#       ref: main
+#       file: '/k8s/applications/ai/mlflow/gitlab-ci-template.yml'
+#
+# Then extend the hidden jobs:
+#
+#   train:
+#     extends: .mlflow-train
+#     script:
+#       - python train.py   # must set MODEL_NAME, MODEL_VERSION, RUN_ID as dotenv artifacts
+#
+#   register:
+#     extends: .mlflow-register
+#     needs: [train]
+#
+# Required CI/CD variables (set in project settings, masked):
+#   none — secrets are injected from the cluster via /run/secrets/mlflow/
+
+variables:
+  MLFLOW_TRACKING_URI: "http://mlflow.mlflow.svc.cluster.local"
+  MLFLOW_REGISTRY_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
+  GITLAB_PROJECT_API: "https://gitlab.peekoff.com/api/v4/projects/1"
+  GITLAB_TRIGGER_URL: "https://gitlab.peekoff.com/api/v4/projects/1/trigger/pipeline"
+  DEPLOYMENT_REF: "main"
+
+# Loads secrets from the cluster-mounted secret volume and exports them.
+# All subsequent script steps in the job inherit these exports.
+.mlflow-secrets:
+  before_script:
+    - export MLFLOW_TRACKING_TOKEN=$(cat "$MLFLOW_CI_SECRETS_PATH/MLFLOW_TRACKING_TOKEN")
+    - export GITLAB_TRIGGER_TOKEN=$(cat "$MLFLOW_CI_SECRETS_PATH/GITLAB_TRIGGER_TOKEN")
+
+# Base training job. Extend this and override `script` with your training code.
+# Your script must produce a dotenv artifact exporting MODEL_NAME, MODEL_VERSION,
+# and RUN_ID so downstream jobs can reference them.
+#
+# Example train.py tail:
+#   with open("mlflow.env", "w") as f:
+#       f.write(f"MODEL_NAME={model_name}\n")
+#       f.write(f"MODEL_VERSION={version}\n")
+#       f.write(f"RUN_ID={run.info.run_id}\n")
+.mlflow-train:
+  extends: .mlflow-secrets
+  artifacts:
+    reports:
+      dotenv: mlflow.env
+  script:
+    - echo "Override script in your job"
+  after_script:
+    # Link the MLflow run back to this CI job so GitLab UI shows the job/pipeline.
+    - |
+      if [ -n "$RUN_ID" ]; then
+        python3 - <<'EOF'
+      import os, mlflow
+      client = mlflow.MlflowClient(tracking_uri=os.environ["MLFLOW_TRACKING_URI"])
+      run_id = os.environ["RUN_ID"]
+      client.set_tag(run_id, "gitlab.CI_JOB_ID", os.environ.get("CI_JOB_ID", ""))
+      client.set_tag(run_id, "gitlab.CI_PIPELINE_ID", os.environ.get("CI_PIPELINE_ID", ""))
+      client.set_tag(run_id, "gitlab.CI_COMMIT_SHA", os.environ.get("CI_COMMIT_SHA", ""))
+      client.set_tag(run_id, "gitlab.CI_COMMIT_REF_NAME", os.environ.get("CI_COMMIT_REF_NAME", ""))
+      EOF
+      fi
+
+# Registers the model version (semver required by GitLab) and posts an MR note
+# if running in an MR pipeline. Triggers the deployment pipeline on success.
+# Needs the dotenv artifact from .mlflow-train.
+.mlflow-register:
+  extends: .mlflow-secrets
+  script:
+    - |
+      python3 - <<'EOF'
+      import os, mlflow
+      client = mlflow.MlflowClient(tracking_uri=os.environ["MLFLOW_TRACKING_URI"])
+      model_name = os.environ["MODEL_NAME"]
+      version    = os.environ["MODEL_VERSION"]
+      run_id     = os.environ["RUN_ID"]
+
+      # Register to GitLab model registry via MLFLOW_REGISTRY_URI on the server.
+      mv = client.create_model_version(
+          model_name,
+          source=f"runs:/{run_id}/model",
+          run_id=run_id,
+          tags={"gitlab.CI_JOB_ID": os.environ.get("CI_JOB_ID", "")},
+      )
+      print(f"Registered {model_name} v{version} (id={mv.version})")
+      EOF
+    # Post metric summary as MR note when running in an MR pipeline.
+    - |
+      if [ -n "$CI_MERGE_REQUEST_IID" ] && [ -n "$RUN_ID" ]; then
+        METRICS=$(python3 - <<'EOF'
+      import os, mlflow
+      client = mlflow.MlflowClient(tracking_uri=os.environ["MLFLOW_TRACKING_URI"])
+      run = client.get_run(os.environ["RUN_ID"])
+      lines = ["**MLflow run metrics for this MR:**", ""]
+      for k, v in run.data.metrics.items():
+          lines.append(f"- `{k}`: `{v}`")
+      lines += ["", f"Model: `{os.environ['MODEL_NAME']}` v`{os.environ['MODEL_VERSION']}`",
+                f"Run: [{os.environ['RUN_ID']}]($MLFLOW_TRACKING_URI/#/experiments)"]
+      print("\n".join(lines))
+      EOF
+      )
+        curl --silent --fail --request POST \
+          "${GITLAB_PROJECT_API}/merge_requests/${CI_MERGE_REQUEST_IID}/notes" \
+          --header "PRIVATE-TOKEN: ${MLFLOW_TRACKING_TOKEN}" \
+          --form "body=${METRICS}"
+      fi
+    # Trigger deployment pipeline with model coordinates as variables.
+    - |
+      curl --silent --fail --request POST "${GITLAB_TRIGGER_URL}" \
+        --form "token=${GITLAB_TRIGGER_TOKEN}" \
+        --form "ref=${DEPLOYMENT_REF}" \
+        --form "variables[MODEL_NAME]=${MODEL_NAME}" \
+        --form "variables[MODEL_VERSION]=${MODEL_VERSION}" \
+        --form "variables[RUN_ID]=${RUN_ID}"

--- a/k8s/applications/ai/mlflow/gitlab-tracking-externalsecret.yaml
+++ b/k8s/applications/ai/mlflow/gitlab-tracking-externalsecret.yaml
@@ -15,3 +15,21 @@ spec:
     - secretKey: MLFLOW_TRACKING_TOKEN
       remoteRef:
         key: app-mlflow-gitlab-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-trigger-secret
+  namespace: mlflow
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-gitlab-trigger
+    creationPolicy: Owner
+  data:
+    - secretKey: GITLAB_TRIGGER_TOKEN
+      remoteRef:
+        key: app-mlflow-gitlab-trigger-token

--- a/k8s/applications/ai/mlflow/gitlab-tracking-externalsecret.yaml
+++ b/k8s/applications/ai/mlflow/gitlab-tracking-externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-tracking-secret
+  namespace: mlflow
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-gitlab-tracking
+    creationPolicy: Owner
+  data:
+    - secretKey: MLFLOW_TRACKING_TOKEN
+      remoteRef:
+        key: app-mlflow-gitlab-token

--- a/k8s/applications/ai/mlflow/http-route.yaml
+++ b/k8s/applications/ai/mlflow/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mlflow
+  namespace: mlflow
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - mlflow.peekoff.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mlflow
+          port: 80

--- a/k8s/applications/ai/mlflow/http-route.yaml
+++ b/k8s/applications/ai/mlflow/http-route.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: mlflow
 spec:
   parentRefs:
+    - name: external
+      namespace: gateway
     - name: internal
       namespace: gateway
   hostnames:

--- a/k8s/applications/ai/mlflow/kustomization.yaml
+++ b/k8s/applications/ai/mlflow/kustomization.yaml
@@ -1,0 +1,64 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mlflow
+
+helmCharts:
+  - name: mlflow
+    repo: https://community-charts.github.io/helm-charts
+    version: 1.11.2
+    releaseName: mlflow
+    namespace: mlflow
+    valuesFile: values.yaml
+    includeCRDs: false
+
+resources:
+  - namespace.yaml
+  - minio-externalsecret.yaml
+  - database.yaml
+  - database-scheduled-backup.yaml
+  - http-route.yaml
+  - network-policy.yaml
+
+patches:
+  - target:
+      kind: ServiceAccount
+      name: mlflow
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow
+  - target:
+      kind: ConfigMap
+      name: mlflow-env-configmap
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow
+  - target:
+      kind: Secret
+      name: mlflow-env-secret
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow
+  - target:
+      kind: Service
+      name: mlflow
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow
+  - target:
+      kind: Deployment
+      name: mlflow
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow
+  - target:
+      kind: ConfigMap
+      name: mlflow-migrations
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mlflow

--- a/k8s/applications/ai/mlflow/kustomization.yaml
+++ b/k8s/applications/ai/mlflow/kustomization.yaml
@@ -14,6 +14,7 @@ helmCharts:
 resources:
   - namespace.yaml
   - minio-externalsecret.yaml
+  - gitlab-tracking-externalsecret.yaml
   - database.yaml
   - database-scheduled-backup.yaml
   - http-route.yaml

--- a/k8s/applications/ai/mlflow/minio-externalsecret.yaml
+++ b/k8s/applications/ai/mlflow/minio-externalsecret.yaml
@@ -1,3 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rustfs-credentials
+  namespace: mlflow
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-rustfs-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: app-rustfs-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: app-rustfs-secret-key
+---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/k8s/applications/ai/mlflow/minio-externalsecret.yaml
+++ b/k8s/applications/ai/mlflow/minio-externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: mlflow
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url

--- a/k8s/applications/ai/mlflow/namespace.yaml
+++ b/k8s/applications/ai/mlflow/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mlflow

--- a/k8s/applications/ai/mlflow/network-policy.yaml
+++ b/k8s/applications/ai/mlflow/network-policy.yaml
@@ -17,14 +17,6 @@ spec:
         - ports:
             - port: "5000"
               protocol: TCP
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: gitlab-runner
-            app.kubernetes.io/name: gitlab-runner-job
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/k8s/applications/ai/mlflow/network-policy.yaml
+++ b/k8s/applications/ai/mlflow/network-policy.yaml
@@ -38,8 +38,10 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
-    - toFQDNs:
-        - matchName: "truenas.peekoff.com"
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+            app.kubernetes.io/name: rustfs
       toPorts:
         - ports:
             - port: "9000"

--- a/k8s/applications/ai/mlflow/network-policy.yaml
+++ b/k8s/applications/ai/mlflow/network-policy.yaml
@@ -17,6 +17,14 @@ spec:
         - ports:
             - port: "5000"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gitlab-runner
+            app.kubernetes.io/name: gitlab-runner-job
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/k8s/applications/ai/mlflow/network-policy.yaml
+++ b/k8s/applications/ai/mlflow/network-policy.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mlflow
+  namespace: mlflow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: mlflow-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "truenas.peekoff.com"
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mlflow-postgresql
+  namespace: mlflow
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:cnpg.io/cluster: mlflow-postgresql
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: mlflow
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: mlflow-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+            k8s:app.kubernetes.io/name: cloudnative-pg
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: mlflow-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "truenas.peekoff.com"
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "s3.us-west-002.backblazeb2.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/k8s/applications/ai/mlflow/network-policy.yaml
+++ b/k8s/applications/ai/mlflow/network-policy.yaml
@@ -44,6 +44,14 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gitlab
+            release: gitlab
+      toPorts:
+        - ports:
+            - port: "8181"
+              protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/k8s/applications/ai/mlflow/values.yaml
+++ b/k8s/applications/ai/mlflow/values.yaml
@@ -15,14 +15,14 @@ artifactRoot:
     enabled: true
     bucket: mlflow-artifacts
     existingSecret:
-      name: longhorn-minio-credentials
+      name: mlflow-rustfs-credentials
       keyOfAccessKeyId: AWS_ACCESS_KEY_ID
       keyOfSecretAccessKey: AWS_SECRET_ACCESS_KEY
 
 extraEnvVars:
-  MLFLOW_S3_ENDPOINT_URL: "https://truenas.peekoff.com:9000"
+  MLFLOW_S3_ENDPOINT_URL: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
   AWS_DEFAULT_REGION: "us-east-1"
-  MLFLOW_TRACKING_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
+  MLFLOW_REGISTRY_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
 
 extraSecretNamesForEnvFrom:
   - mlflow-gitlab-tracking

--- a/k8s/applications/ai/mlflow/values.yaml
+++ b/k8s/applications/ai/mlflow/values.yaml
@@ -1,0 +1,59 @@
+backendStore:
+  databaseMigration: true
+  postgres:
+    enabled: true
+    host: mlflow-postgresql-rw.mlflow.svc.cluster.local
+    port: 5432
+    database: app
+  existingDatabaseSecret:
+    name: mlflow-postgresql-app
+    passwordKey: password
+    usernameKey: username
+
+artifactRoot:
+  s3:
+    enabled: true
+    bucket: mlflow-artifacts
+    existingSecret:
+      name: longhorn-minio-credentials
+      keyOfAccessKeyId: AWS_ACCESS_KEY_ID
+      keyOfSecretAccessKey: AWS_SECRET_ACCESS_KEY
+
+extraEnvVars:
+  MLFLOW_S3_ENDPOINT_URL: "https://truenas.peekoff.com:9000"
+  AWS_DEFAULT_REGION: "us-east-1"
+
+extraArgs:
+  workers: "1"
+
+serverAllowedHosts:
+  - "*"
+
+service:
+  type: ClusterIP
+  port: 80
+  containerPort: 5000
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 3Gi

--- a/k8s/applications/ai/mlflow/values.yaml
+++ b/k8s/applications/ai/mlflow/values.yaml
@@ -22,10 +22,6 @@ artifactRoot:
 extraEnvVars:
   MLFLOW_S3_ENDPOINT_URL: "http://rustfs-svc.rustfs.svc.cluster.local:9000"
   AWS_DEFAULT_REGION: "us-east-1"
-  MLFLOW_REGISTRY_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
-
-extraSecretNamesForEnvFrom:
-  - mlflow-gitlab-tracking
 
 extraArgs:
   workers: "1"
@@ -49,10 +45,19 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL
+
+extraVolumes:
+  - name: tmp
+    emptyDir:
+      sizeLimit: 500Mi
+
+extraVolumeMounts:
+  - name: tmp
+    mountPath: /tmp
 
 resources:
   requests:

--- a/k8s/applications/ai/mlflow/values.yaml
+++ b/k8s/applications/ai/mlflow/values.yaml
@@ -22,6 +22,10 @@ artifactRoot:
 extraEnvVars:
   MLFLOW_S3_ENDPOINT_URL: "https://truenas.peekoff.com:9000"
   AWS_DEFAULT_REGION: "us-east-1"
+  MLFLOW_TRACKING_URI: "https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/"
+
+extraSecretNamesForEnvFrom:
+  - mlflow-gitlab-tracking
 
 extraArgs:
   workers: "1"

--- a/k8s/applications/tools/gitlab-runner/externalsecret.yaml
+++ b/k8s/applications/tools/gitlab-runner/externalsecret.yaml
@@ -25,6 +25,27 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: mlflow-ci-secrets
+  namespace: gitlab-runner
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-ci-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: MLFLOW_TRACKING_TOKEN
+      remoteRef:
+        key: app-mlflow-gitlab-token
+    - secretKey: GITLAB_TRIGGER_TOKEN
+      remoteRef:
+        key: app-mlflow-gitlab-trigger-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: gitlab-runner-cache
   namespace: gitlab-runner
 spec:

--- a/k8s/applications/tools/gitlab-runner/externalsecret.yaml
+++ b/k8s/applications/tools/gitlab-runner/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-runner-token
+  namespace: gitlab-runner
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-runner-token
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        runner-token: "{{ .runnerToken }}"
+        runner-registration-token: ""
+  data:
+    - secretKey: runnerToken
+      remoteRef:
+        key: app-gitlab-runner-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-runner-cache
+  namespace: gitlab-runner
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-runner-cache
+    creationPolicy: Owner
+  data:
+    - secretKey: accesskey
+      remoteRef:
+        key: app-rustfs-access-key
+    - secretKey: secretkey
+      remoteRef:
+        key: app-rustfs-secret-key

--- a/k8s/applications/tools/gitlab-runner/kustomization.yaml
+++ b/k8s/applications/tools/gitlab-runner/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gitlab-runner
+
+helmCharts:
+  - name: gitlab-runner
+    repo: https://charts.gitlab.io
+    version: 0.89.1
+    releaseName: gitlab-runner
+    namespace: gitlab-runner
+    valuesFile: values.yaml
+    includeCRDs: false
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - network-policy.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: gitlab-runner
+    patch: |
+      - op: add
+        path: /spec/template/spec/hostNetwork
+        value: false
+      - op: add
+        path: /spec/template/spec/hostPID
+        value: false
+      - op: add
+        path: /spec/template/spec/hostIPC
+        value: false

--- a/k8s/applications/tools/gitlab-runner/namespace.yaml
+++ b/k8s/applications/tools/gitlab-runner/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitlab-runner

--- a/k8s/applications/tools/gitlab-runner/network-policy.yaml
+++ b/k8s/applications/tools/gitlab-runner/network-policy.yaml
@@ -87,6 +87,14 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: mlflow
+            app.kubernetes.io/name: mlflow
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
     - toEntities:
         - world
       toPorts:

--- a/k8s/applications/tools/gitlab-runner/network-policy.yaml
+++ b/k8s/applications/tools/gitlab-runner/network-policy.yaml
@@ -1,0 +1,97 @@
+---
+# Runner manager pod
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gitlab-runner-manager
+  namespace: gitlab-runner
+spec:
+  endpointSelector:
+    matchLabels:
+      app: gitlab-runner
+  ingress: []
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gitlab
+            release: gitlab
+      toPorts:
+        - ports:
+            - port: "8181"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+            app.kubernetes.io/name: rustfs
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+---
+# Job pods spawned by the Kubernetes executor
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gitlab-runner-jobs
+  namespace: gitlab-runner
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: gitlab-runner-job
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app: gitlab-runner
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gitlab
+            release: gitlab
+      toPorts:
+        - ports:
+            - port: "8181"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+            app.kubernetes.io/name: rustfs
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/k8s/applications/tools/gitlab-runner/network-policy.yaml
+++ b/k8s/applications/tools/gitlab-runner/network-policy.yaml
@@ -87,14 +87,6 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: mlflow
-            app.kubernetes.io/name: mlflow
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP
     - toEntities:
         - world
       toPorts:

--- a/k8s/applications/tools/gitlab-runner/values.yaml
+++ b/k8s/applications/tools/gitlab-runner/values.yaml
@@ -1,0 +1,71 @@
+gitlabUrl: https://gitlab.peekoff.com
+
+runners:
+  secret: gitlab-runner-token
+  config: |
+    [[runners]]
+      request_concurrency = 4
+      [runners.kubernetes]
+        namespace = "{{ default .Release.Namespace .Values.runners.jobNamespace }}"
+        image = "alpine:3.20"
+        privileged = false
+        [runners.kubernetes.pod_labels]
+          "app.kubernetes.io/name" = "gitlab-runner-job"
+      [runners.cache]
+        Type = "s3"
+        Path = "runner"
+        Shared = true
+        [runners.cache.s3]
+          ServerAddress = "rustfs-svc.rustfs.svc.cluster.local:9000"
+          BucketName = "gitlab-runner-cache"
+          BucketLocation = "us-east-1"
+          Insecure = true
+          AuthenticationType = "access-key"
+  cache:
+    secretName: gitlab-runner-cache
+
+concurrent: 4
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 65533
+  fsGroup: 65533
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop: ["ALL"]
+
+extraVolumes:
+  - name: runner-home
+    emptyDir:
+      sizeLimit: 500Mi
+  - name: runner-tmp
+    emptyDir:
+      sizeLimit: 200Mi
+
+extraVolumeMounts:
+  - name: runner-home
+    mountPath: /home/gitlab-runner
+  - name: runner-tmp
+    mountPath: /tmp
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/k8s/applications/tools/gitlab-runner/values.yaml
+++ b/k8s/applications/tools/gitlab-runner/values.yaml
@@ -5,12 +5,23 @@ runners:
   config: |
     [[runners]]
       request_concurrency = 4
+      environment = [
+        "MLFLOW_TRACKING_URI=http://mlflow.mlflow.svc.cluster.local",
+        "MLFLOW_REGISTRY_URI=https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/",
+        "GITLAB_PROJECT_API=https://gitlab.peekoff.com/api/v4/projects/1",
+        "GITLAB_TRIGGER_URL=https://gitlab.peekoff.com/api/v4/projects/1/trigger/pipeline",
+        "MLFLOW_CI_SECRETS_PATH=/run/secrets/mlflow"
+      ]
       [runners.kubernetes]
         namespace = "{{ default .Release.Namespace .Values.runners.jobNamespace }}"
         image = "alpine:3.20"
         privileged = false
         [runners.kubernetes.pod_labels]
           "app.kubernetes.io/name" = "gitlab-runner-job"
+        [[runners.kubernetes.volumes.secret]]
+          name = "mlflow-ci-secrets"
+          mount_path = "/run/secrets/mlflow"
+          read_only = true
       [runners.cache]
         Type = "s3"
         Path = "runner"

--- a/k8s/applications/tools/gitlab-runner/values.yaml
+++ b/k8s/applications/tools/gitlab-runner/values.yaml
@@ -6,15 +6,14 @@ runners:
     [[runners]]
       request_concurrency = 4
       environment = [
-        "MLFLOW_TRACKING_URI=http://mlflow.mlflow.svc.cluster.local",
-        "MLFLOW_REGISTRY_URI=https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow/",
+        "MLFLOW_TRACKING_URI=https://gitlab.peekoff.com/api/v4/projects/1/ml/mlflow",
         "GITLAB_PROJECT_API=https://gitlab.peekoff.com/api/v4/projects/1",
         "GITLAB_TRIGGER_URL=https://gitlab.peekoff.com/api/v4/projects/1/trigger/pipeline",
         "MLFLOW_CI_SECRETS_PATH=/run/secrets/mlflow"
       ]
       [runners.kubernetes]
         namespace = "{{ default .Release.Namespace .Values.runners.jobNamespace }}"
-        image = "alpine:3.20"
+        image = "alpine:3.21.3"
         privileged = false
         [runners.kubernetes.pod_labels]
           "app.kubernetes.io/name" = "gitlab-runner-job"

--- a/k8s/applications/tools/gitlab/database-scheduled-backup.yaml
+++ b/k8s/applications/tools/gitlab/database-scheduled-backup.yaml
@@ -1,0 +1,15 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: gitlab-postgresql-b2-backup
+  namespace: gitlab
+spec:
+  schedule: "0 0 3 * * 0"
+  backupOwnerReference: self
+  cluster:
+    name: gitlab-postgresql
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+    parameters:
+      barmanObjectName: gitlab-b2-store

--- a/k8s/applications/tools/gitlab/database.yaml
+++ b/k8s/applications/tools/gitlab/database.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: b2-cnpg-credentials
+  namespace: gitlab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: b2-cnpg-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: backblaze-b2-cnpg-access-key-id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: backblaze-b2-cnpg-secret-access-key
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: gitlab-minio-store
+  namespace: gitlab
+spec:
+  retentionPolicy: "14d"
+  configuration:
+    destinationPath: s3://homelab-postgres-backups/gitlab/gitlab-postgresql-2026-06
+    endpointURL: https://truenas.peekoff.com:9000
+    s3Credentials:
+      accessKeyId:
+        name: longhorn-minio-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: longhorn-minio-credentials
+        key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: gitlab-b2-store
+  namespace: gitlab
+spec:
+  retentionPolicy: "30d"
+  configuration:
+    destinationPath: s3://homelab-cnpg-b2/gitlab/gitlab-postgresql-2026-06
+    endpointURL: https://s3.us-west-002.backblazeb2.com
+    s3Credentials:
+      accessKeyId:
+        name: b2-cnpg-credentials
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: b2-cnpg-credentials
+        key: AWS_SECRET_ACCESS_KEY
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gitlab-postgresql
+  namespace: gitlab
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  storage:
+    size: 20Gi
+    storageClass: proxmox-csi
+
+  walStorage:
+    size: 10Gi
+    storageClass: proxmox-csi
+    resizeInUseVolumes: true
+
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 50m
+    limits:
+      memory: 1Gi
+      cpu: 1000m
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: "256MB"
+      effective_cache_size: "768MB"
+      maintenance_work_mem: "64MB"
+      checkpoint_completion_target: "0.9"
+      wal_buffers: "16MB"
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: "2621kB"
+      huge_pages: "off"
+      min_wal_size: "512MB"
+      max_wal_size: "1GB"
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: gitlab-minio-store
+
+  externalClusters:
+    - name: gitlab-postgresql-b2-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: gitlab-b2-store
+    - name: gitlab-postgresql-minio-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: gitlab-minio-store
+
+  managed:
+    roles:
+      - name: app
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        inherit: true
+        replication: false
+        connectionLimit: -1
+
+  monitoring:
+    enablePodMonitor: false
+
+  affinity:
+    enablePodAntiAffinity: false

--- a/k8s/applications/tools/gitlab/gitlab-secrets.yaml
+++ b/k8s/applications/tools/gitlab/gitlab-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-initial-secrets
+  namespace: gitlab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-initial-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: initial-root-password
+      remoteRef:
+        key: app-gitlab-initial-root-password

--- a/k8s/applications/tools/gitlab/http-route.yaml
+++ b/k8s/applications/tools/gitlab/http-route.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitlab
+  namespace: gitlab
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - gitlab.peekoff.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: gitlab-webservice-default
+          port: 8181
+      timeouts:
+        request: 0s
+        backendRequest: 0s
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitlab-registry
+  namespace: gitlab
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - registry.peekoff.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: gitlab-registry
+          port: 5000
+      timeouts:
+        request: 0s
+        backendRequest: 0s
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitlab-kas
+  namespace: gitlab
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - kas.peekoff.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: gitlab-kas
+          port: 8150
+      timeouts:
+        request: 0s
+        backendRequest: 0s

--- a/k8s/applications/tools/gitlab/kustomization.yaml
+++ b/k8s/applications/tools/gitlab/kustomization.yaml
@@ -1,0 +1,86 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gitlab
+
+helmCharts:
+  - name: gitlab
+    repo: https://charts.gitlab.io
+    version: 10.1.1
+    releaseName: gitlab
+    namespace: gitlab
+    valuesFile: values.yaml
+    includeCRDs: false
+
+resources:
+  - namespace.yaml
+  - minio-externalsecret.yaml
+  - gitlab-secrets.yaml
+  - database.yaml
+  - database-scheduled-backup.yaml
+  - redis.yaml
+  - network-policy.yaml
+  - registry-pvc.yaml
+
+patches:
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: HTTPRoute
+      name: gitlab-gitlab
+    patch: |
+      - op: remove
+        path: /spec/rules/0/name
+      - op: remove
+        path: /spec/rules/1/name
+      - op: add
+        path: /spec/parentRefs/-
+        value:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: internal
+          namespace: gateway
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: HTTPRoute
+      name: gitlab-registry
+    patch: |
+      - op: add
+        path: /spec/parentRefs/-
+        value:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: internal
+          namespace: gateway
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: HTTPRoute
+      name: gitlab-kas
+    patch: |
+      - op: add
+        path: /spec/parentRefs/-
+        value:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: internal
+          namespace: gateway
+  - target:
+      kind: Deployment
+      name: gitlab-registry
+    patch: |
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: registry-data
+          persistentVolumeClaim:
+            claimName: gitlab-registry-data
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: registry-data
+          mountPath: /var/lib/registry
+      - op: replace
+        path: /spec/strategy
+        value:
+          type: Recreate

--- a/k8s/applications/tools/gitlab/minio-externalsecret.yaml
+++ b/k8s/applications/tools/gitlab/minio-externalsecret.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-longhorn-backup-secret
+  namespace: gitlab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: longhorn-minio-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: infra-minio-s3-secret-key
+    - secretKey: AWS_ENDPOINTS
+      remoteRef:
+        key: infra-minio-s3-endpoint-url
+    - secretKey: LOGICAL_BACKUP_S3_ENDPOINT
+      remoteRef:
+        key: infra-minio-s3-endpoint-url
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-minio-connection-secret
+  namespace: gitlab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-minio-connection
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        connection: |
+          provider: AWS
+          region: us-east-1
+          aws_access_key_id: {{ .accessKey }}
+          aws_secret_access_key: {{ .secretKey }}
+          aws_signature_version: 4
+          host: rustfs.rustfs.svc.cluster.local
+          port: '9000'
+          endpoint: http://rustfs.rustfs.svc.cluster.local:9000
+          path_style: true
+  data:
+    - secretKey: accessKey
+      remoteRef:
+        key: app-rustfs-access-key
+    - secretKey: secretKey
+      remoteRef:
+        key: app-rustfs-secret-key
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-registry-storage-secret
+  namespace: gitlab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: bitwarden-backend
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-registry-storage
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        config: |
+          filesystem:
+            rootdirectory: /var/lib/registry
+          delete:
+            enabled: true
+  data:
+    - secretKey: accessKey
+      remoteRef:
+        key: infra-minio-s3-access-key
+    - secretKey: secretKey
+      remoteRef:
+        key: infra-minio-s3-secret-key

--- a/k8s/applications/tools/gitlab/minio-externalsecret.yaml
+++ b/k8s/applications/tools/gitlab/minio-externalsecret.yaml
@@ -48,9 +48,9 @@ spec:
           aws_access_key_id: {{ .accessKey }}
           aws_secret_access_key: {{ .secretKey }}
           aws_signature_version: 4
-          host: rustfs.rustfs.svc.cluster.local
+          host: rustfs-svc.rustfs.svc.cluster.local
           port: '9000'
-          endpoint: http://rustfs.rustfs.svc.cluster.local:9000
+          endpoint: http://rustfs-svc.rustfs.svc.cluster.local:9000
           path_style: true
   data:
     - secretKey: accessKey

--- a/k8s/applications/tools/gitlab/namespace.yaml
+++ b/k8s/applications/tools/gitlab/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitlab

--- a/k8s/applications/tools/gitlab/network-policy.yaml
+++ b/k8s/applications/tools/gitlab/network-policy.yaml
@@ -161,8 +161,10 @@ spec:
     - toEndpoints:
         - matchLabels:
             release: gitlab
-    - toFQDNs:
-        - matchName: "truenas.peekoff.com"
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+            app.kubernetes.io/name: rustfs
       toPorts:
         - ports:
             - port: "9000"

--- a/k8s/applications/tools/gitlab/network-policy.yaml
+++ b/k8s/applications/tools/gitlab/network-policy.yaml
@@ -1,0 +1,169 @@
+---
+# Policy for our custom Redis deployment
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gitlab-redis
+  namespace: gitlab
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: gitlab-redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            release: gitlab
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
+# Policy for CNPG PostgreSQL cluster
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gitlab-postgresql
+  namespace: gitlab
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:cnpg.io/cluster: gitlab-postgresql
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            release: gitlab
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: gitlab-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+            k8s:app.kubernetes.io/name: cloudnative-pg
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: gitlab-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "truenas.peekoff.com"
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "s3.us-west-002.backblazeb2.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# Policy for all Helm-managed GitLab components (release: gitlab)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gitlab-app
+  namespace: gitlab
+spec:
+  endpointSelector:
+    matchLabels:
+      release: gitlab
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8181"
+              protocol: TCP
+            - port: "5000"
+              protocol: TCP
+            - port: "8150"
+              protocol: TCP
+            - port: "8151"
+              protocol: TCP
+            - port: "8153"
+              protocol: TCP
+            - port: "9236"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            release: gitlab
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toEndpoints:
+        - matchLabels:
+            k8s:cnpg.io/cluster: gitlab-postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: gitlab-redis
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            release: gitlab
+    - toFQDNs:
+        - matchName: "truenas.peekoff.com"
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP

--- a/k8s/applications/tools/gitlab/network-policy.yaml
+++ b/k8s/applications/tools/gitlab/network-policy.yaml
@@ -130,6 +130,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             release: gitlab
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: mlflow
+            app.kubernetes.io/name: mlflow
+      toPorts:
+        - ports:
+            - port: "8181"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/k8s/applications/tools/gitlab/redis.yaml
+++ b/k8s/applications/tools/gitlab/redis.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: gitlab
+  labels:
+    app.kubernetes.io/name: gitlab-redis
+    app.kubernetes.io/part-of: gitlab
+spec:
+  selector:
+    app.kubernetes.io/name: gitlab-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitlab-redis
+  namespace: gitlab
+  labels:
+    app.kubernetes.io/name: gitlab-redis
+    app.kubernetes.io/part-of: gitlab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gitlab-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gitlab-redis
+        app.kubernetes.io/part-of: gitlab
+    spec:
+      hostIPC: false
+      hostPID: false
+      hostNetwork: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: redis:8.8.0-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+              name: redis
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 999
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
+        - name: data
+          emptyDir:
+            sizeLimit: 1Gi

--- a/k8s/applications/tools/gitlab/registry-pvc.yaml
+++ b/k8s/applications/tools/gitlab/registry-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gitlab-registry-data
+  namespace: gitlab
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: proxmox-csi
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/applications/tools/gitlab/values.yaml
+++ b/k8s/applications/tools/gitlab/values.yaml
@@ -1,0 +1,206 @@
+global:
+  hosts:
+    domain: peekoff.com
+    https: true
+
+  gatewayApi:
+    enabled: true
+    gatewayRef:
+      name: external
+      namespace: gateway
+    installEnvoy: false
+    configureCertmanager: false
+    httpToHttpsRedirect: false
+
+  ingress:
+    enabled: false
+    configureCertmanager: false
+    provider: ""
+
+  psql:
+    host: gitlab-postgresql-rw.gitlab.svc.cluster.local
+    port: 5432
+    database: app
+    username: app
+    password:
+      useSecret: true
+      secret: gitlab-postgresql-app
+      key: password
+
+  redis:
+    host: redis.gitlab.svc.cluster.local
+    port: 6379
+    auth:
+      enabled: false
+
+  initialRootPassword:
+    secret: gitlab-initial-secrets
+    key: initial-root-password
+
+  smtp:
+    enabled: false
+
+  email:
+    from: ""
+    display_name: "GitLab"
+    reply_to: ""
+    subject_suffix: ""
+
+  appConfig:
+    object_store:
+      enabled: true
+      proxy_download: true
+      connection:
+        secret: gitlab-minio-connection
+        key: connection
+
+    uploads:
+      bucket: gitlab-uploads
+
+    artifacts:
+      bucket: gitlab-artifacts
+
+    lfs:
+      bucket: gitlab-lfs
+
+    packages:
+      bucket: gitlab-packages
+
+    terraformState:
+      bucket: gitlab-terraform-state
+
+    ciSecureFiles:
+      bucket: gitlab-ci-secure-files
+
+postgresql:
+  install: false
+
+redis:
+  install: false
+
+minio:
+  enabled: false
+
+nginx-ingress:
+  enabled: false
+
+certmanager-issuer:
+  email: "benjamin.sanden2@gmail.com"
+
+gitlab-runner:
+  install: false
+
+prometheus:
+  install: false
+
+grafana:
+  enabled: false
+
+registry:
+  enabled: true
+  gatewayRoute:
+    sectionName: ""
+  hpa:
+    behavior: {}
+  podDisruptionBudget:
+    enabled: false
+  storage:
+    secret: gitlab-registry-storage
+    key: config
+    extraKey: ""
+
+gitlab:
+  webservice:
+    minReplicas: 1
+    maxReplicas: 1
+    gatewayRoute:
+      sectionName: ""
+    hpa:
+      behavior: {}
+    podDisruptionBudget:
+      enabled: false
+    workerProcesses: 1
+    puma:
+      threads:
+        min: 2
+        max: 4
+      disableWorkerKiller: false
+      workerMaxMemory: 1200
+    resources:
+      requests:
+        cpu: 300m
+        memory: 1G
+      limits:
+        cpu: 2000m
+        memory: 2.5G
+    deployment:
+      strategy:
+        type: Recreate
+
+  sidekiq:
+    minReplicas: 1
+    maxReplicas: 1
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 2G
+
+  gitlab-shell:
+    minReplicas: 1
+    maxReplicas: 1
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 20Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+  kas:
+    enabled: true
+    gatewayRoute:
+      sectionName: ""
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  gitaly:
+    persistence:
+      storageClass: proxmox-csi
+      size: 50Gi
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
+      limits:
+        cpu: 1000m
+        memory: 1G
+
+  toolbox:
+    backups:
+      objectStorage:
+        config:
+          secret: gitlab-minio-connection
+          key: connection
+    resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/k8s/applications/tools/kustomization.yaml
+++ b/k8s/applications/tools/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
 - project.yaml
 - it-tools
+- gitlab
+- gitlab-runner
+- rustfs

--- a/k8s/applications/tools/rustfs/bucket-init.yaml
+++ b/k8s/applications/tools/rustfs/bucket-init.yaml
@@ -29,7 +29,7 @@ spec:
             - -c
             - |
               mc --config-dir /tmp alias set rustfs http://rustfs-svc.rustfs.svc.cluster.local:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY"
-              for bucket in gitlab-uploads gitlab-artifacts gitlab-lfs gitlab-packages gitlab-terraform-state gitlab-ci-secure-files gitlab-runner-cache; do
+              for bucket in gitlab-uploads gitlab-artifacts gitlab-lfs gitlab-packages gitlab-terraform-state gitlab-ci-secure-files gitlab-runner-cache mlflow-artifacts; do
                 mc --config-dir /tmp mb --ignore-existing rustfs/$bucket
               done
           envFrom:

--- a/k8s/applications/tools/rustfs/bucket-init.yaml
+++ b/k8s/applications/tools/rustfs/bucket-init.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rustfs-bucket-init
+  namespace: rustfs
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - sh
+            - -c
+            - |
+              mc --config-dir /tmp alias set rustfs http://rustfs-svc.rustfs.svc.cluster.local:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY"
+              for bucket in gitlab-uploads gitlab-artifacts gitlab-lfs gitlab-packages gitlab-terraform-state gitlab-ci-secure-files gitlab-runner-cache; do
+                mc --config-dir /tmp mb --ignore-existing rustfs/$bucket
+              done
+          envFrom:
+            - secretRef:
+                name: rustfs-credentials
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 10Mi

--- a/k8s/applications/tools/rustfs/externalsecret.yaml
+++ b/k8s/applications/tools/rustfs/externalsecret.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: rustfs-access-key-gen
+  namespace: rustfs
+spec:
+  length: 20
+  digits: 4
+  symbols: 0
+  symbolCharacters: ""
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: rustfs-secret-key-gen
+  namespace: rustfs
+spec:
+  length: 40
+  digits: 8
+  symbols: 0
+  symbolCharacters: ""
+  noUpper: false
+  allowRepeat: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rustfs-credentials
+  namespace: rustfs
+spec:
+  refreshInterval: "0"
+  target:
+    name: rustfs-credentials
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: rustfs-access-key-gen
+      rewrite:
+        - regexp:
+            source: "^password$"
+            target: "RUSTFS_ACCESS_KEY"
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: rustfs-secret-key-gen
+      rewrite:
+        - regexp:
+            source: "^password$"
+            target: "RUSTFS_SECRET_KEY"
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rustfs-credentials
+  namespace: rustfs
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: bitwarden-backend
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: rustfs-credentials
+  data:
+    - match:
+        secretKey: RUSTFS_ACCESS_KEY
+        remoteRef:
+          remoteKey: app-rustfs-access-key
+    - match:
+        secretKey: RUSTFS_SECRET_KEY
+        remoteRef:
+          remoteKey: app-rustfs-secret-key

--- a/k8s/applications/tools/rustfs/http-route.yaml
+++ b/k8s/applications/tools/rustfs/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rustfs-console
+  namespace: rustfs
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal
+      namespace: gateway
+  hostnames:
+    - rustfs.peekoff.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: rustfs
+          port: 9001

--- a/k8s/applications/tools/rustfs/kustomization.yaml
+++ b/k8s/applications/tools/rustfs/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rustfs
+
+helmCharts:
+  - name: rustfs
+    repo: https://charts.rustfs.com
+    version: 0.8.0
+    releaseName: rustfs
+    namespace: rustfs
+    valuesFile: values.yaml
+    includeCRDs: false
+
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - network-policy.yaml
+  - http-route.yaml
+  - bucket-init.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: rustfs
+    patch: |
+      - op: add
+        path: /spec/template/spec/hostNetwork
+        value: false
+      - op: add
+        path: /spec/template/spec/hostPID
+        value: false
+      - op: add
+        path: /spec/template/spec/hostIPC
+        value: false

--- a/k8s/applications/tools/rustfs/namespace.yaml
+++ b/k8s/applications/tools/rustfs/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rustfs

--- a/k8s/applications/tools/rustfs/network-policy.yaml
+++ b/k8s/applications/tools/rustfs/network-policy.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: rustfs
+  namespace: rustfs
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: rustfs
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gitlab
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "9001"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: rustfs-bucket-init
+  namespace: rustfs
+spec:
+  endpointSelector:
+    matchLabels:
+      job-name: rustfs-bucket-init
+  ingress: []
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: rustfs
+            app.kubernetes.io/name: rustfs
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP

--- a/k8s/applications/tools/rustfs/values.yaml
+++ b/k8s/applications/tools/rustfs/values.yaml
@@ -1,0 +1,72 @@
+mode:
+  standalone:
+    enabled: true
+    strategy:
+      type: Recreate
+  distributed:
+    enabled: false
+
+replicaCount: 1
+
+image:
+  rustfs:
+    repository: rustfs/rustfs
+    tag: "1.0.0-beta.8"
+    pullPolicy: IfNotPresent
+  initImage:
+    repository: busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+
+secret:
+  existingSecret: rustfs-credentials
+
+config:
+  rustfs:
+    volumes: "/data"
+    address: ":9000"
+    console_enable: "true"
+    console_address: ":9001"
+    log_level: "info"
+    region: "us-east-1"
+    obs_log_directory: ""
+    obs_environment: "production"
+
+storageclass:
+  name: proxmox-csi-2
+  dataStorageSize: 50Gi
+
+ingress:
+  enabled: false
+
+gatewayApi:
+  enabled: false
+
+affinity:
+  podAntiAffinity:
+    enabled: false
+  nodeAffinity: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop: ["ALL"]
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi

--- a/k8s/infrastructure/storage/proxmox-csi/deployment-patch.yaml
+++ b/k8s/infrastructure/storage/proxmox-csi/deployment-patch.yaml
@@ -25,3 +25,11 @@ spec:
       app.kubernetes.io/managed-by: argocd
       app.kubernetes.io/name: proxmox-csi-plugin
       dev.peekoff: storage
+  template:
+    spec:
+      containers:
+        - name: proxmox-csi-plugin-node
+          args:
+            - "-v=5"
+            - "--csi-address=unix:///csi/csi.sock"
+            - "--node-id=$(NODE_NAME)"


### PR DESCRIPTION
## Summary

- **RustFS**: standalone in-cluster S3-compatible object store on `proxmox-csi-2` (velocity pool), credentials auto-generated via ESO password generators and pushed to Bitwarden via PushSecret; PostSync job creates all 7 GitLab buckets idempotently
- **GitLab S3**: uploads, artifacts, LFS, packages, terraform-state, CI secure files wired to RustFS via ExternalSecret-rendered connection config; webservice deployment strategy set to `Recreate` to avoid rolling-update deadlock on resource-constrained nodes
- **GitLab runner cache**: switched from TrueNAS MinIO to in-cluster RustFS; network policies and ExternalSecret updated to use `app-rustfs-*` Bitwarden items
- **MLflow**: tracking server with CNPG database and MinIO artifact storage added to AI app set
- **proxmox-csi**: removed unsupported `--max-volumes-per-node` flag that caused node plugin CrashLoopBackOff

## Test plan

- [ ] ArgoCD syncs all apps without errors
- [ ] RustFS pod 1/1 Running, PVC bound on velocity pool
- [ ] bucket-init PostSync job completes — all 7 buckets present
- [ ] GitLab webservice and sidekiq healthy; S3 uploads/artifacts reachable
- [ ] GitLab runner completes a job and writes cache to RustFS bucket
- [ ] proxmox-csi-plugin-node DaemonSet all pods 3/3 Running (no crashloop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197bnGamNJKFxTQh9WHmnr9