### PR TITLE
fix(k8s/network): allow arr app mesh and usenet SSL egress in media namespace

### DIFF
--- a/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
@@ -42,6 +42,12 @@ spec:
         protocol: TCP
       - port: "7878"
         protocol: TCP
+      - port: "9696"
+        protocol: TCP
+      - port: "6767"
+        protocol: TCP
+      - port: "8080"
+        protocol: TCP
   egress:
   - toEndpoints:
     - matchLabels:
@@ -73,4 +79,6 @@ spec:
     toPorts:
     - ports:
       - port: "443"
+        protocol: TCP
+      - port: "563"
         protocol: TCP


### PR DESCRIPTION
## Summary

The `media` namespace `CiliumNetworkPolicy` (`k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml`) was too restrictive for the arr stack and Usenet downloads to fully work:

- **Intra-namespace ingress**: only Sonarr (8989) and Radarr (7878) accepted pod-to-pod traffic from other apps in `media`. Prowlarr (9696), Bazarr (6767), and SABnzbd (8080) did not, so Sonarr/Radarr/Bazarr could not reach Prowlarr for indexer sync, or SABnzbd as a download client.
- **Egress to Usenet providers**: only port 443 was allowed to `0.0.0.0/0`. SABnzbd's configured provider (Newshosting, per `k8s/applications/media/sabnzbd/externalsecret.yaml`) uses `news.newshosting.com` with SSL on port 563 (default NNTPS) or 443 as a fallback — 563 was blocked.

## Changes

- Added ports `9696` (Prowlarr), `6767` (Bazarr), and `8080` (SABnzbd) to the same-namespace `fromEndpoints` ingress rule so arr apps can talk to each other and to the download client.
- Added port `563` (NNTP over SSL) to the `0.0.0.0/0` egress rule so SABnzbd can reach Usenet providers on their standard encrypted port.

## Test plan

- [x] Validated the manifest with `python3 -m yaml` (parses cleanly, single `CiliumNetworkPolicy` document).
- [ ] `kustomize build --enable-helm` on the changed path (not available in this sandbox — `kustomize`/`kubectl` are not installed; the referenced kustomization only includes this one file, so no other resources are affected).
- [ ] Argo CD sync and confirm Sonarr/Radarr can reach Prowlarr and SABnzbd, and SABnzbd can connect to the Usenet provider, in the live cluster.


---
_Generated by [Claude Code](https://claude.ai/code/session_013jJkRggdQmjSRWKeBUa4Vp)_