### PR TITLE
fix(k8s/network): allow jellyseerr to reach jellyfin on port 8096

### DIFF
--- a/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
+++ b/k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml
@@ -48,6 +48,8 @@ spec:
         protocol: TCP
       - port: "8080"
         protocol: TCP
+      - port: "8096"
+        protocol: TCP
   egress:
   - toEndpoints:
     - matchLabels:


### PR DESCRIPTION
## Summary

- The `media` namespace's default-deny `CiliumNetworkPolicy` (`k8s/infrastructure/network/policies/applications/media/media/allow-media-access.yaml`) only allowed pod-to-pod ingress on the *arr ports (8989, 7878, 9696, 6767, 8080).
- Jellyfin's service port, 8096, was missing from that list, so Jellyseerr's calls to `jellyfin.media.svc.cluster.local:8096` (library sync, availability checks) were silently dropped by Cilium.
- Added port 8096 to the intra-namespace `fromEndpoints` ingress rule.

## Test plan

- [ ] `kustomize build --enable-helm` on the changed path was not run — `kustomize`/`kubectl` binaries are not available in this session's environment. YAML syntax was validated with a Python YAML parser.
- [ ] Confirm in-cluster with Cilium Hubble that Jellyseerr → Jellyfin traffic on port 8096 is no longer dropped after this policy is applied via Argo CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP

---
_Generated by [Claude Code](https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP)_