### PR TITLE
fix(k8s/network): correct redis label selector in argocd egress policy

### DIFF
--- a/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
+++ b/k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml
@@ -30,7 +30,7 @@ spec:
   - toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: argocd
-        name: argocd-redis
+        app.kubernetes.io/name: argocd-redis
     toPorts:
     - ports:
       - port: "6379"


### PR DESCRIPTION
## Summary

- `argocd-server`'s egress rule to Redis in `k8s/infrastructure/network/policies/argocd/allow-argocd-access.yaml` selected the Redis pod with `name: argocd-redis`.
- The argo-helm chart (pinned at 9.5.15 in `k8s/infrastructure/controllers/argocd/kustomization.yaml`) only sets `app.kubernetes.io/name: argocd-redis` — no bare `name` label. The dedicated `argocd-redis-network-policy.yaml` already selects the pod correctly with `app.kubernetes.io/name`.
- With Cilium enforcing default-deny on `argocd-server`'s egress (`policyAuditMode: false`), the stale selector matched nothing, so egress to `argocd-redis:6379` was silently dropped.
- This reproduces the live `argocd-server` error: `redis: connection pool: failed to dial after 1 attempts: dial tcp 10.96.21.33:6379: i/o timeout` and the resulting `Failed to resync revoked tokens` warnings.
- Fixed by correcting the label key to `app.kubernetes.io/name: argocd-redis`.

## Test plan

- [ ] `kustomize build --enable-helm` on the changed path was not run — `kustomize`/`kubectl` binaries are not available in this session's environment. YAML syntax was validated with a Python YAML parser.
- [ ] After this policy syncs via Argo CD, confirm `argocd-server` logs no longer show Redis dial timeouts and that revoked-token resync succeeds.

## Note (separate, not fixed here)

`k8s/infrastructure/controllers/argocd/argocd-redis-network-policy.yaml` (the ingress-side policy for the Redis pod itself) isn't referenced by any `kustomization.yaml`, so it may not currently be applied at all. Worth checking separately — happy to open a follow-up PR if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP

---
_Generated by [Claude Code](https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP)_