### PR TITLE
chore(repo): gitignore the per-session scheduled_tasks.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ opencode.json
 !.agents/**
 !.claude/**
 .claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

- `.claude/scheduled_tasks.lock` is a runtime artifact (session id, pid, timestamp) written by the Claude Code scheduler to coordinate scheduled wakeups. It isn't repo content and shouldn't be tracked.
- The repo's `.gitignore` explicitly un-ignores `.claude/**`, so this file was showing up as untracked on every session that uses scheduled wakeups.
- Added `.claude/scheduled_tasks.lock` to `.gitignore`.

## Test plan

- N/A — pure `.gitignore` change, no application or infrastructure behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP

---
_Generated by [Claude Code](https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP)_