### PR TITLE
fix(k8s/network): allow kubechecks egress to argocd-repo-server

### DIFF
--- a/k8s/infrastructure/network/policies/infrastructure/kubechecks/allow-kubechecks-access.yaml
+++ b/k8s/infrastructure/network/policies/infrastructure/kubechecks/allow-kubechecks-access.yaml
@@ -38,6 +38,14 @@ spec:
         protocol: TCP
       - port: "443"
         protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: argocd
+        app.kubernetes.io/name: argocd-repo-server
+    toPorts:
+    - ports:
+      - port: "8081"
+        protocol: TCP
   - toEntities:
     - world
     toPorts:


### PR DESCRIPTION
## Summary

- kubechecks calls `argocd-repo-server`'s GRPC API directly (`GetManifests`) to render manifest diffs on PRs.
- `k8s/infrastructure/network/policies/infrastructure/kubechecks/allow-kubechecks-access.yaml` only granted kubechecks egress to `argocd-server` on ports 8080/443 — nothing for `argocd-repo-server` on 8081.
- With Cilium enforcing default-deny on kubechecks' egress, this appears to break kubechecks for every PR: PR #2699 hit `failed to generate manifests: ... dial tcp 10.105.51.119:8081: i/o timeout` on the `infra-network` app, and PR #2698's kubechecks comment never got past "kubechecks running..." before merge.
- Added an egress rule allowing kubechecks → `argocd-repo-server` on port 8081.

## Test plan

- [ ] `kustomize build --enable-helm` on the changed path was not run — `kustomize`/`kubectl` binaries are not available in this session's environment. YAML syntax was validated with a Python YAML parser.
- [ ] After this policy syncs via Argo CD, confirm kubechecks produces a real manifest report (not a repo-server dial timeout) on the next PR it checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP

---
_Generated by [Claude Code](https://claude.ai/code/session_01D99gH79uYmPfbgJXHEdRtP)_